### PR TITLE
MAKE-520: Retrieve the exit code from calling Wait() in jasper

### DIFF
--- a/harness.go
+++ b/harness.go
@@ -41,7 +41,7 @@ func runIteration(ctx context.Context, makeProc func(context.Context, *CreateOpt
 	if err != nil {
 		return err
 	}
-	_ = proc.Wait(ctx)
+	_, _ = proc.Wait(ctx)
 	return nil
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -160,7 +160,7 @@ func TestMongod(t *testing.T) {
 					waitError := make(chan error, test.numProcs)
 					for _, proc := range procs {
 						go func(proc Process) {
-							err := proc.Wait(ctx)
+							_, err := proc.Wait(ctx)
 							waitError <- err
 						}(proc)
 					}

--- a/interface.go
+++ b/interface.go
@@ -68,6 +68,10 @@ type Process interface {
 	// exit code of the process. Returns nil if the process has
 	// completed successfully. If the process has not completed
 	// successfully, Wait will return a non-nil error.
+	//
+	// Note that death by signal does not return the signal code
+	// and instead falls under "some other error" and is returned
+	// as -1.
 	Wait(context.Context) (int, error)
 
 	// Respawn respawns a near-identical version of the process on

--- a/interface.go
+++ b/interface.go
@@ -62,9 +62,13 @@ type Process interface {
 	Signal(context.Context, syscall.Signal) error
 
 	// Wait blocks until the process exits or the context is
-	// canceled or is not properly defined. Returns nil if the
-	// process has completed.
-	Wait(context.Context) error
+	// canceled or is not properly defined. Wait will return the
+	// exit code as -1 if it was unable to return a true code due
+	// to some other error, but otherwise will return the actual
+	// exit code of the process. Returns nil if the process has
+	// completed successfully. If the process has not completed
+	// successfully, Wait will return a non-nil error.
+	Wait(context.Context) (int, error)
 
 	// Respawn respawns a near-identical version of the process on
 	// which it is called. It will spawn a new process with the same

--- a/interface.go
+++ b/interface.go
@@ -70,8 +70,7 @@ type Process interface {
 	// successfully, Wait will return a non-nil error.
 	//
 	// Note that death by signal does not return the signal code
-	// and instead falls under "some other error" and is returned
-	// as -1.
+	// and instead is returned as -1.
 	Wait(context.Context) (int, error)
 
 	// Respawn respawns a near-identical version of the process on

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -229,12 +229,12 @@ func (p *MockProcess) Signal(_ context.Context, s syscall.Signal) error {
 	return nil
 }
 
-func (p *MockProcess) Wait(_ context.Context) error {
+func (p *MockProcess) Wait(_ context.Context) (int, error) {
 	if p.FailWait {
-		return errors.New("always fail")
+		return -1, errors.New("always fail")
 	}
 
-	return nil
+	return 0, nil
 }
 
 func (p *MockProcess) Respawn(_ context.Context) (Process, error) {

--- a/jrpc/client.go
+++ b/jrpc/client.go
@@ -174,17 +174,20 @@ func (p *jrpcProcess) Signal(ctx context.Context, sig syscall.Signal) error {
 	return errors.New(resp.Text)
 }
 
-func (p *jrpcProcess) Wait(ctx context.Context) error {
+func (p *jrpcProcess) Wait(ctx context.Context) (int, error) {
 	resp, err := p.client.Wait(ctx, &internal.JasperProcessID{Value: p.info.Id})
 	if err != nil {
-		return errors.WithStack(err)
+		return -1, errors.WithStack(err)
 	}
 
 	if resp.Success {
-		return nil
+		if resp.ExitCode != 0 {
+			return int(resp.ExitCode), errors.New("operation failed")
+		}
+		return int(resp.ExitCode), nil
 	}
 
-	return errors.New(resp.Text)
+	return -1, errors.New(resp.Text)
 }
 
 func (p *jrpcProcess) Respawn(ctx context.Context) (jasper.Process, error) {

--- a/jrpc/client_test.go
+++ b/jrpc/client_test.go
@@ -220,7 +220,8 @@ func TestJRPCManager(t *testing.T) {
 					require.NoError(t, err)
 					sameProc, err := manager.Get(ctx, proc.ID())
 					require.Equal(t, proc.ID(), sameProc.ID())
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 					manager.Clear(ctx)
 					nilProc, err := manager.Get(ctx, proc.ID())
 					assert.Nil(t, nilProc)
@@ -243,7 +244,8 @@ func TestJRPCManager(t *testing.T) {
 					sleepProc, err := manager.Create(ctx, sleepOpts)
 					require.NoError(t, err)
 
-					require.NoError(t, lsProc.Wait(ctx))
+					_, err = lsProc.Wait(ctx)
+					require.NoError(t, err)
 
 					manager.Clear(ctx)
 

--- a/jrpc/client_test.go
+++ b/jrpc/client_test.go
@@ -3,6 +3,7 @@ package jrpc
 import (
 	"context"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
@@ -93,7 +94,8 @@ func TestJRPCManager(t *testing.T) {
 					proc, err := manager.Create(ctx, trueCreateOpts())
 					require.NoError(t, err)
 
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 
 					listOut, err := manager.List(ctx, jasper.Successful)
 					assert.NoError(t, err)
@@ -175,7 +177,8 @@ func TestJRPCManager(t *testing.T) {
 
 					procs, err := createProcs(ctx, trueCreateOpts(), manager, 10)
 					for _, p := range procs {
-						assert.NoError(t, p.Wait(ctx))
+						_, err := p.Wait(ctx)
+						assert.NoError(t, err)
 					}
 
 					assert.NoError(t, err)
@@ -381,7 +384,8 @@ func TestJRPCProcess(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					time.Sleep(10 * time.Millisecond) // give the process time to start background machinery
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 					assert.True(t, proc.Complete(ctx))
 				},
 				"WaitReturnsWithCancledContext": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
@@ -392,7 +396,8 @@ func TestJRPCProcess(t *testing.T) {
 					assert.True(t, proc.Running(ctx))
 					assert.NoError(t, err)
 					pcancel()
-					assert.Error(t, proc.Wait(pctx))
+					_, err = proc.Wait(pctx)
+					assert.Error(t, err)
 				},
 				"RegisterTriggerErrorsForNil": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
@@ -403,34 +408,40 @@ func TestJRPCProcess(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
-					assert.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					assert.NoError(t, err)
 				},
 				"RespawnedProcessGivesSameResult": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
 
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 					procExitCode := proc.Info(ctx).ExitCode
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.Equal(t, procExitCode, newProc.Info(ctx).ExitCode)
 				},
 				"RespawningFinishedProcessIsOK": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					assert.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)
 				},
 				"RespawningRunningProcessIsOK": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
@@ -441,7 +452,8 @@ func TestJRPCProcess(t *testing.T) {
 
 					newProc, err := proc.Respawn(ctx)
 					assert.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)
 				},
 				"RespawnShowsConsistentStateValues": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
@@ -449,14 +461,64 @@ func TestJRPCProcess(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
 					assert.True(t, newProc.Running(ctx))
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, proc.Complete(ctx))
 				},
+				"WaitGivesSuccessfulExitCode": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+					proc, err := makep(ctx, trueCreateOpts())
+					require.NoError(t, err)
+					require.NotNil(t, proc)
+					exitCode, err := proc.Wait(ctx)
+					assert.NoError(t, err)
+					assert.Equal(t, 0, exitCode)
+				},
+				"WaitGivesFailureExitCode": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+					proc, err := makep(ctx, falseCreateOpts())
+					require.NoError(t, err)
+					require.NotNil(t, proc)
+					exitCode, err := proc.Wait(ctx)
+					assert.Error(t, err)
+					assert.Equal(t, 1, exitCode)
+				},
+				"WaitGivesProperExitCodeOnSignalDeath": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+					proc, err := makep(ctx, sleepCreateOpts(100))
+					require.NoError(t, err)
+					require.NotNil(t, proc)
+					proc.Signal(ctx, syscall.SIGTERM)
+					exitCode, err := proc.Wait(ctx)
+					assert.Error(t, err)
+					assert.Equal(t, -1, exitCode)
+				},
+				"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+					cctx, cancel := context.WithCancel(ctx)
+					proc, err := makep(ctx, sleepCreateOpts(100))
+					require.NoError(t, err)
+					require.NotNil(t, proc)
+
+					var exitCode int
+					waitFinished := make(chan bool)
+					go func() {
+						exitCode, err = proc.Wait(cctx)
+						waitFinished <- true
+					}()
+					cancel()
+					select {
+					case <-waitFinished:
+						assert.Error(t, err)
+						assert.Equal(t, -1, exitCode)
+					case <-ctx.Done():
+						assert.Fail(t, "call to Wait() took too long to finish")
+					}
+					jasper.Terminate(ctx, proc) // Clean up.
+				},
+
 				// "": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {},
 				// "": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {},
 
@@ -470,7 +532,8 @@ func TestJRPCProcess(t *testing.T) {
 					require.NoError(t, err)
 
 					firstID := proc.ID()
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 					assert.True(t, proc.Complete(ctx))
 					proc.(*jrpcProcess).info.Id += "_foo"
 					proc.(*jrpcProcess).info.Complete = false
@@ -483,7 +546,8 @@ func TestJRPCProcess(t *testing.T) {
 					require.NoError(t, err)
 
 					firstID := proc.ID()
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 					proc.(*jrpcProcess).info.Id += "_foo"
 					proc.(*jrpcProcess).info.Complete = false
 					require.NotEqual(t, firstID, proc.ID())
@@ -494,7 +558,8 @@ func TestJRPCProcess(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 
 					assert.True(t, proc.Complete(ctx))
 

--- a/jrpc/internal/service.go
+++ b/jrpc/internal/service.go
@@ -171,7 +171,8 @@ func (s *jasperService) Wait(ctx context.Context, id *JasperProcessID) (*Operati
 		}, err
 	}
 
-	if err = proc.Wait(ctx); err != nil {
+	exitCode, err := proc.Wait(ctx)
+	if err != nil && exitCode == -1 {
 		err = errors.Wrap(err, "problem encountered while waiting")
 		return &OperationOutcome{
 			Success:  false,
@@ -183,7 +184,7 @@ func (s *jasperService) Wait(ctx context.Context, id *JasperProcessID) (*Operati
 	return &OperationOutcome{
 		Success:  true,
 		Text:     fmt.Sprintf("'%s' operation complete", id.Value),
-		ExitCode: int32(proc.Info(ctx).ExitCode),
+		ExitCode: int32(exitCode),
 	}, nil
 }
 

--- a/manager_self_clearing_test.go
+++ b/manager_self_clearing_test.go
@@ -67,7 +67,8 @@ func TestSelfClearingManager(t *testing.T) {
 					otherSleepProcs, err := manager.List(ctx, All)
 					require.NoError(t, err)
 					for _, otherSleepProc := range otherSleepProcs {
-						require.NoError(t, otherSleepProc.Wait(ctx))
+						_, err := otherSleepProc.Wait(ctx)
+						require.NoError(t, err)
 					}
 					sleepProc, err = createFunc(ctx, manager, t, sleepOpts)
 					assert.NoError(t, err)

--- a/manager_test.go
+++ b/manager_test.go
@@ -320,7 +320,8 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					sameProc, err := manager.Get(ctx, proc.ID())
 					require.Equal(t, proc.ID(), sameProc.ID())
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 					manager.Clear(ctx)
 					nilProc, err := manager.Get(ctx, proc.ID())
 					assert.Nil(t, nilProc)
@@ -343,7 +344,8 @@ func TestManagerInterface(t *testing.T) {
 					sleepProc, err := manager.Create(ctx, sleepOpts)
 					require.NoError(t, err)
 
-					require.NoError(t, lsProc.Wait(ctx))
+					_, err = lsProc.Wait(ctx)
+					require.NoError(t, err)
 
 					manager.Clear(ctx)
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -104,7 +104,8 @@ func TestManagerInterface(t *testing.T) {
 					proc, err := manager.Create(ctx, trueCreateOpts())
 					require.NoError(t, err)
 
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 
 					listOut, err := manager.List(ctx, Successful)
 					assert.NoError(t, err)
@@ -116,7 +117,8 @@ func TestManagerInterface(t *testing.T) {
 				"ListReturnsOneFailedCommand": func(ctx context.Context, t *testing.T, manager Manager) {
 					proc, err := manager.Create(ctx, falseCreateOpts())
 					require.NoError(t, err)
-					assert.Error(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.Error(t, err)
 
 					listOut, err := manager.List(ctx, Failed)
 					assert.NoError(t, err)
@@ -183,7 +185,8 @@ func TestManagerInterface(t *testing.T) {
 				"CloseErrorsWithTerminatedProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
 					procs, err := createProcs(ctx, trueCreateOpts(), manager, 10)
 					for _, p := range procs {
-						assert.NoError(t, p.Wait(ctx))
+						_, err := p.Wait(ctx)
+						assert.NoError(t, err)
 					}
 
 					assert.NoError(t, err)
@@ -302,7 +305,8 @@ func TestManagerInterface(t *testing.T) {
 					opts.closers = append(opts.closers, func() { closersDone <- true })
 					proc, err := manager.Create(ctx, opts)
 					assert.NoError(t, err)
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 					select {
 					case <-ctx.Done():
 						assert.Fail(t, "process took too long to run closers")

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -276,9 +276,9 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 	if p.hasInfo() {
 		// If the process did not end successfully, then there should be an error.
 		if !p.getInfo().Successful {
-			return p.info.ExitCode, errors.New("operation failed")
+			return p.getInfo().ExitCode, errors.New("operation failed")
 		}
-		return p.info.ExitCode, nil
+		return p.getInfo().ExitCode, nil
 	}
 
 	out := make(chan error)
@@ -307,13 +307,13 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 		case <-ctx.Done():
 			return -1, errors.New("wait operation canceled")
 		case err := <-out:
-			return p.info.ExitCode, errors.WithStack(err)
+			return p.getInfo().ExitCode, errors.WithStack(err)
 		default:
 			if p.hasInfo() {
 				if !p.getInfo().Successful {
-					return p.info.ExitCode, errors.New("operation failed")
+					return p.getInfo().ExitCode, errors.New("operation failed")
 				}
-				return p.info.ExitCode, nil
+				return p.getInfo().ExitCode, nil
 			}
 		}
 	}

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -198,7 +198,7 @@ func TestBlockingProcess(t *testing.T) {
 					assert.NoError(t, cmd.Start())
 					startAt := time.Now()
 					go proc.reactor(ctx, cmd)
-					err = proc.Wait(cctx)
+					_, err = proc.Wait(cctx)
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), "operation canceled")
 					assert.True(t, time.Since(startAt) >= 500*time.Millisecond)
@@ -214,7 +214,8 @@ func TestBlockingProcess(t *testing.T) {
 					go func() {
 						// this is the crucial
 						// assertion of this tests
-						assert.NoError(t, proc.Wait(ctx))
+						_, err := proc.Wait(ctx)
+						assert.NoError(t, err)
 						close(signal)
 					}()
 
@@ -244,7 +245,8 @@ func TestBlockingProcess(t *testing.T) {
 					go func() {
 						// this is the crucial
 						// assertion of this tests
-						assert.NoError(t, proc.Wait(ctx))
+						_, err := proc.Wait(ctx)
+						assert.NoError(t, err)
 						close(signal)
 					}()
 
@@ -275,7 +277,8 @@ func TestBlockingProcess(t *testing.T) {
 					go func() {
 						// this is the crucial assertion
 						// of this tests.
-						assert.Error(t, proc.Wait(ctx))
+						_, err := proc.Wait(ctx)
+						assert.Error(t, err)
 						close(signal)
 					}()
 

--- a/process_local.go
+++ b/process_local.go
@@ -76,11 +76,12 @@ func (p *localProcess) RegisterTrigger(ctx context.Context, trigger ProcessTrigg
 	return errors.WithStack(p.proc.RegisterTrigger(ctx, trigger))
 }
 
-func (p *localProcess) Wait(ctx context.Context) error {
+func (p *localProcess) Wait(ctx context.Context) (int, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	return errors.WithStack(p.proc.Wait(ctx))
+	exitCode, err := p.proc.Wait(ctx)
+	return exitCode, errors.WithStack(err)
 }
 
 func (p *localProcess) Respawn(ctx context.Context) (Process, error) {

--- a/process_test.go
+++ b/process_test.go
@@ -126,7 +126,8 @@ func TestProcessImplementations(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					time.Sleep(10 * time.Millisecond) // give the process time to start background machinery
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 					assert.True(t, proc.Complete(ctx))
 				},
 				"WaitReturnsWithCancledContext": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
@@ -137,7 +138,8 @@ func TestProcessImplementations(t *testing.T) {
 					assert.True(t, proc.Running(ctx))
 					assert.NoError(t, err)
 					pcancel()
-					assert.Error(t, proc.Wait(pctx))
+					_, err = proc.Wait(pctx)
+					assert.Error(t, err)
 				},
 				"RegisterTriggerErrorsForNil": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
@@ -191,7 +193,8 @@ func TestProcessImplementations(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					assert.NoError(t, err)
 
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 				},
 				"ProcessWritesToLog": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					if cname == "REST" {
@@ -211,7 +214,8 @@ func TestProcessImplementations(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					assert.NoError(t, err)
 
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 
 					// File is not guaranteed to be written once Wait() returns and closers begin executing,
 					// so wait for file to be non-empty.
@@ -258,7 +262,8 @@ func TestProcessImplementations(t *testing.T) {
 
 					proc, err := makep(ctx, opts)
 					assert.NoError(t, err)
-					assert.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					assert.NoError(t, err)
 
 					fileWrite := make(chan int64)
 					go func() {
@@ -282,34 +287,40 @@ func TestProcessImplementations(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
-					assert.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					assert.NoError(t, err)
 				},
 				"RespawnedProcessGivesSameResult": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
 
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 					procExitCode := proc.Info(ctx).ExitCode
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.Equal(t, procExitCode, proc.Info(ctx).ExitCode)
 				},
 				"RespawningFinishedProcessIsOK": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					assert.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)
 				},
 				"RespawningRunningProcessIsOK": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
@@ -320,7 +331,8 @@ func TestProcessImplementations(t *testing.T) {
 
 					newProc, err := proc.Respawn(ctx)
 					assert.NoError(t, err)
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)
 				},
 				"TriggersFireOnRespawnedProcessExit": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
@@ -366,12 +378,14 @@ func TestProcessImplementations(t *testing.T) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					require.NoError(t, proc.Wait(ctx))
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
 					require.NoError(t, err)
 					assert.True(t, newProc.Running(ctx))
-					require.NoError(t, newProc.Wait(ctx))
+					_, err = newProc.Wait(ctx)
+					require.NoError(t, err)
 					assert.True(t, newProc.Complete(ctx))
 				},
 				// "": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {},

--- a/rest_client.go
+++ b/rest_client.go
@@ -361,24 +361,25 @@ func (p *restProcess) Signal(ctx context.Context, sig syscall.Signal) error {
 	return nil
 }
 
-func (p *restProcess) Wait(ctx context.Context) error {
+func (p *restProcess) Wait(ctx context.Context) (int, error) {
 	req, err := http.NewRequest(http.MethodGet, p.client.getURL("/process/%s/wait", p.id), nil)
 	if err != nil {
-		return errors.Wrap(err, "problem building request")
+		return -1, errors.Wrap(err, "problem building request")
 	}
 
 	req = req.WithContext(ctx)
 
 	resp, err := p.client.client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "problem making request")
+		return -1, errors.Wrap(err, "problem making request")
 	}
 
 	if err = handleError(resp); err != nil {
-		return errors.WithStack(err)
+		return -1, errors.WithStack(err)
 	}
 
-	return nil
+	// TODO: We should try to just get the exit code from the resp.
+	return p.Info(ctx).ExitCode, nil
 }
 
 func (p *restProcess) Respawn(ctx context.Context) (Process, error) {

--- a/rest_client.go
+++ b/rest_client.go
@@ -379,7 +379,11 @@ func (p *restProcess) Wait(ctx context.Context) (int, error) {
 	}
 
 	// TODO: We should try to just get the exit code from the resp.
-	return p.Info(ctx).ExitCode, nil
+	procInfo := p.Info(ctx)
+	if !procInfo.Successful {
+		return procInfo.ExitCode, errors.New("operation failed")
+	}
+	return procInfo.ExitCode, nil
 }
 
 func (p *restProcess) Respawn(ctx context.Context) (Process, error) {

--- a/rest_client.go
+++ b/rest_client.go
@@ -378,12 +378,12 @@ func (p *restProcess) Wait(ctx context.Context) (int, error) {
 		return -1, errors.WithStack(err)
 	}
 
-	// TODO: We should try to just get the exit code from the resp.
-	procInfo := p.Info(ctx)
-	if !procInfo.Successful {
-		return procInfo.ExitCode, errors.New("operation failed")
+	var exitCode int
+	gimlet.GetJSON(resp.Body, &exitCode)
+	if exitCode != 0 {
+		return exitCode, errors.New("operation failed")
 	}
-	return procInfo.ExitCode, nil
+	return exitCode, nil
 }
 
 func (p *restProcess) Respawn(ctx context.Context) (Process, error) {

--- a/rest_service.go
+++ b/rest_service.go
@@ -369,7 +369,9 @@ func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := proc.Wait(ctx); err != nil {
+	// Somehow return exitCode?
+	_, err = proc.Wait(ctx)
+	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),

--- a/rest_service.go
+++ b/rest_service.go
@@ -370,8 +370,8 @@ func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	// Somehow return exitCode?
-	_, err = proc.Wait(ctx)
-	if err != nil {
+	exitCode, err := proc.Wait(ctx)
+	if err != nil && exitCode == -1 {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),

--- a/rest_service.go
+++ b/rest_service.go
@@ -369,7 +369,6 @@ func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Somehow return exitCode?
 	exitCode, err := proc.Wait(ctx)
 	if err != nil && exitCode == -1 {
 		writeError(rw, gimlet.ErrorResponse{
@@ -379,7 +378,7 @@ func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gimlet.WriteJSON(rw, struct{}{})
+	gimlet.WriteJSON(rw, exitCode)
 }
 
 func (s *Service) respawnProcess(rw http.ResponseWriter, r *http.Request) {

--- a/rest_test.go
+++ b/rest_test.go
@@ -181,7 +181,7 @@ func TestRestService(t *testing.T) {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "problem building request")
 
-			err = proc.Wait(ctx)
+			_, err = proc.Wait(ctx)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "problem building request")
 
@@ -205,7 +205,7 @@ func TestRestService(t *testing.T) {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "problem making request")
 
-			err = proc.Wait(ctx)
+			_, err = proc.Wait(ctx)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "problem making request")
 
@@ -284,7 +284,8 @@ func TestRestService(t *testing.T) {
 				id:     "foo",
 			}
 
-			assert.Error(t, proc.Wait(ctx))
+			_, err := proc.Wait(ctx)
+			assert.Error(t, err)
 		},
 		"SignalProcessThatDoesNotExistShouldError": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			proc := &restProcess{
@@ -534,7 +535,8 @@ func TestRestService(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, proc)
 
-			assert.NoError(t, proc.Wait(ctx))
+			_, err = proc.Wait(ctx)
+			assert.NoError(t, err)
 
 			logs, err := client.GetLogs(ctx, proc.ID())
 			assert.NoError(t, err)
@@ -551,7 +553,8 @@ func TestRestService(t *testing.T) {
 			proc, err := client.Create(ctx, opts)
 			assert.NoError(t, err)
 			assert.NotNil(t, proc)
-			assert.NoError(t, proc.Wait(ctx))
+			_, err = proc.Wait(ctx)
+			assert.NoError(t, err)
 			logs, err := client.GetLogs(ctx, proc.ID())
 			assert.Error(t, err)
 			assert.Empty(t, logs)
@@ -665,7 +668,8 @@ func TestRestService(t *testing.T) {
 			opts.Args = []string{"echo", "foobar"}
 			proc, err := client.Create(ctx, opts)
 			require.NoError(t, err)
-			require.NoError(t, proc.Wait(ctx))
+			_, err = proc.Wait(ctx)
+			require.NoError(t, err)
 
 			logs, err := client.GetLogs(ctx, proc.ID())
 			require.NoError(t, err)

--- a/signal.go
+++ b/signal.go
@@ -49,7 +49,7 @@ func TerminateAll(ctx context.Context, procs []Process) error {
 	}
 
 	for _, proc := range procs {
-		_ = proc.Wait(ctx)
+		proc.Wait(ctx)
 	}
 
 	return catcher.Resolve()
@@ -71,7 +71,7 @@ func KillAll(ctx context.Context, procs []Process) error {
 	}
 
 	for _, proc := range procs {
-		_ = proc.Wait(ctx)
+		proc.Wait(ctx)
 	}
 
 	return catcher.Resolve()

--- a/triggers_test.go
+++ b/triggers_test.go
@@ -32,7 +32,8 @@ func TestDefaultTrigger(t *testing.T) {
 			out, err := manager.List(ctx, All)
 			assert.NoError(t, err)
 			assert.Len(t, out, 1)
-			assert.NoError(t, out[0].Wait(ctx))
+			_, err = out[0].Wait(ctx)
+			assert.NoError(t, err)
 			assert.True(t, tcmd.started)
 		},
 		"OneOnSuccess": func(ctx context.Context, t *testing.T, manager Manager) {
@@ -99,7 +100,8 @@ func TestDefaultTrigger(t *testing.T) {
 			out, err := manager.List(ctx, All)
 			assert.NoError(t, err)
 			assert.Len(t, out, 1)
-			assert.NoError(t, out[0].Wait(ctx))
+			_, err = out[0].Wait(ctx)
+			assert.NoError(t, err)
 			assert.True(t, tcmd.started)
 		},
 		"TimeoutWithoutTimeout": func(ctx context.Context, t *testing.T, manager Manager) {
@@ -113,7 +115,8 @@ func TestDefaultTrigger(t *testing.T) {
 			out, err := manager.List(ctx, All)
 			assert.NoError(t, err)
 			assert.Len(t, out, 1)
-			assert.NoError(t, out[0].Wait(ctx))
+			_, err = out[0].Wait(ctx)
+			assert.NoError(t, err)
 			assert.True(t, tcmd.started)
 		},
 		"TimeoutWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager) {


### PR DESCRIPTION
Added a self-review comment to this patch because there is something in particular that bothers me about what we are doing here.