### PR TITLE
MAKE-587: Failure to compile JRPC code does not lead to Evergreen task failure

### DIFF
--- a/jrpc/client.go
+++ b/jrpc/client.go
@@ -103,7 +103,7 @@ func (m *jrpcManager) Close(ctx context.Context) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if resp.Success {
+	if resp.Successful {
 		return nil
 	}
 

--- a/jrpc/client.go
+++ b/jrpc/client.go
@@ -103,7 +103,7 @@ func (m *jrpcManager) Close(ctx context.Context) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if resp.Successful {
+	if resp.Success {
 		return nil
 	}
 

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ race:
 test:
 	@mkdir -p $(buildDir)
 	go test $(testArgs) $(if $(DISABLE_COVERAGE),, -cover) $(_testPackages) | tee $(buildDir)/test.sink.out
-	@grep -s -q -e "^PASS" $(buildDir)/test.sink.out
+	@! grep -s -q -e "^FAIL" $(buildDir)/test.sink.out
 .PHONY: benchmark
 benchmark:
 	@mkdir -p $(buildDir)

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ compile:
 race:
 	@mkdir -p $(buildDir)
 	go test $(testArgs) -race $(_testPackages) | tee $(buildDir)/race.sink.out
-	@grep -s -q -e "^PASS" $(buildDir)/race.sink.out && ! grep -s -q "^WARNING: DATA RACE" $(buildDir)/race.sink.out
+	@! grep -s -q -e "^FAIL" $(buildDir)/race.sink.out && ! grep -s -q "^WARNING: DATA RACE" $(buildDir)/race.sink.out
 test:
 	@mkdir -p $(buildDir)
 	go test $(testArgs) $(if $(DISABLE_COVERAGE),, -cover) $(_testPackages) | tee $(buildDir)/test.sink.out


### PR DESCRIPTION
Pretty simple change should let us ensure we guarantee that _all_ our entries in `_testPackages` have passed.