### PR TITLE
MAKE-571: Increase timeout for Jasper benchmarks (also check that they pass)

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,7 +30,8 @@ test:
 .PHONY: benchmark
 benchmark:
 	@mkdir -p $(buildDir)
-	go test $(testArgs) -bench=$(benchPattern) $(if $(RUN_TEST),, -run=^^$$) | tee $(buildDir)/bench.sink.out
+	go test $(testArgs) -timeout 45m -bench=$(benchPattern) $(if $(RUN_TEST),, -run=^^$$) | tee $(buildDir)/bench.sink.out
+	@grep -s -q -e "^PASS" $(buildDir)/bench.sink.out
 coverage:$(buildDir)/cover.out
 	@go tool cover -func=$< | sed -E 's%github.com/.*/jasper/%%' | column -t
 coverage-html:$(buildDir)/cover.html


### PR DESCRIPTION
This also adds some logic that ensures that the benchmark actually passes.

We may want to prefer using "^FAIL" instead here, just to be consistent with MAKE-587.