### PR TITLE
MAKE-581: InfoHasMatchingID occasionally fails for Jasper process tests

### DIFF
--- a/jrpc/client_test.go
+++ b/jrpc/client_test.go
@@ -358,9 +358,10 @@ func TestJRPCProcess(t *testing.T) {
 				},
 				"InfoHasMatchingID": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
-					if assert.NoError(t, err) {
-						assert.Equal(t, proc.ID(), proc.Info(ctx).ID)
-					}
+					require.NoError(t, err)
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
+					assert.Equal(t, proc.ID(), proc.Info(ctx).ID)
 				},
 				"ResetTags": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)

--- a/process_test.go
+++ b/process_test.go
@@ -99,9 +99,10 @@ func TestProcessImplementations(t *testing.T) {
 				},
 				"InfoHasMatchingID": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)
-					if assert.NoError(t, err) {
-						assert.Equal(t, proc.ID(), proc.Info(ctx).ID)
-					}
+					require.NoError(t, err)
+					_, err = proc.Wait(ctx)
+					require.NoError(t, err)
+					assert.Equal(t, proc.ID(), proc.Info(ctx).ID)
 				},
 				"ResetTags": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					proc, err := makep(ctx, opts)

--- a/rest_client.go
+++ b/rest_client.go
@@ -325,7 +325,10 @@ func (p *restProcess) ID() string { return p.id }
 
 func (p *restProcess) Info(ctx context.Context) ProcessInfo {
 	info, err := p.client.getProcessInfo(ctx, p.id)
-	grip.Debug(message.WrapError(err, message.Fields{"process": p.id}))
+	if err != nil {
+		grip.Debug(message.WrapError(err, message.Fields{"process": p.id}))
+	}
+
 	return info
 }
 


### PR DESCRIPTION
We were calling `proc.Info()` without calling `proc.Wait()` and expecting consistent results. This is an incorrect use of Jasper. Took some time to realize that the bug was not in Jasper logic, but in the test logic. Oh well.

Also a slight fix to a debug statement that was calling `wrapError()` around potentially `nil` errors, which causes some ugly and misleading log output.