### PR TITLE
MAKE-569, MAKE-601: Fix TestManagerInterface/REST failures on RACE, Fix context deadline exceeded errors for JRPC process creation

### DIFF
--- a/jrpc/client_test.go
+++ b/jrpc/client_test.go
@@ -222,6 +222,7 @@ func TestJRPCManager(t *testing.T) {
 					proc, err := manager.Create(ctx, opts)
 					require.NoError(t, err)
 					sameProc, err := manager.Get(ctx, proc.ID())
+					require.NoError(t, err)
 					require.Equal(t, proc.ID(), sameProc.ID())
 					_, err = proc.Wait(ctx)
 					require.NoError(t, err)
@@ -235,6 +236,7 @@ func TestJRPCManager(t *testing.T) {
 					require.NoError(t, err)
 					manager.Clear(ctx)
 					sameProc, err := manager.Get(ctx, proc.ID())
+					require.NoError(t, err)
 					assert.Equal(t, proc.ID(), sameProc.ID())
 					require.NoError(t, jasper.Terminate(ctx, proc)) // Clean up
 				},

--- a/jrpc/internal/service.go
+++ b/jrpc/internal/service.go
@@ -83,6 +83,9 @@ func (s *jasperService) Status(ctx context.Context, _ *empty.Empty) (*StatusResp
 func (s *jasperService) Create(ctx context.Context, opts *CreateOptions) (*ProcessInfo, error) {
 	jopts := opts.Export()
 
+	// Spawn a new context so that the process' context is not potentially
+	// canceled by the request's. See how rest_service.go's createProcess() does
+	// this same thing.
 	var cctx context.Context
 	var cancel context.CancelFunc
 	if jopts.Timeout > 0 {

--- a/jrpc/internal/service.go
+++ b/jrpc/internal/service.go
@@ -59,7 +59,7 @@ func (s *jasperService) backgroundPrune() {
 }
 
 func getProcInfoNoHang(p jasper.Process) *ProcessInfo {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	return ConvertProcessInfo(p.Info(ctx))
 }

--- a/manager_basic.go
+++ b/manager_basic.go
@@ -65,7 +65,9 @@ func (m *basicProcessManager) List(ctx context.Context, f Filter) ([]Process, er
 			return nil, errors.New("operation canceled")
 		}
 
-		info := proc.Info(ctx)
+		cctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		info := proc.Info(cctx)
+		cancel()
 		switch {
 		case f == Running:
 			if info.IsRunning {

--- a/manager_test.go
+++ b/manager_test.go
@@ -319,6 +319,7 @@ func TestManagerInterface(t *testing.T) {
 					proc, err := manager.Create(ctx, opts)
 					require.NoError(t, err)
 					sameProc, err := manager.Get(ctx, proc.ID())
+					require.NoError(t, err)
 					require.Equal(t, proc.ID(), sameProc.ID())
 					_, err = proc.Wait(ctx)
 					require.NoError(t, err)
@@ -332,6 +333,7 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					manager.Clear(ctx)
 					sameProc, err := manager.Get(ctx, proc.ID())
+					require.NoError(t, err)
 					assert.Equal(t, proc.ID(), sameProc.ID())
 					require.NoError(t, Terminate(ctx, proc)) // Clean up
 				},

--- a/manager_test.go
+++ b/manager_test.go
@@ -88,7 +88,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.Nil(t, output)
 				},
 				"LongRunningOperationsAreListedAsRunning": func(ctx context.Context, t *testing.T, manager Manager) {
-					procs, err := createProcs(ctx, sleepCreateOpts(1), manager, 10)
+					procs, err := createProcs(ctx, sleepCreateOpts(10), manager, 10)
 					assert.NoError(t, err)
 					assert.Len(t, procs, 10)
 

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -184,10 +184,10 @@ func (p *blockingProcess) Info(ctx context.Context) ProcessInfo {
 		case res := <-out:
 			return res
 		case <-ctx.Done():
-			return ProcessInfo{}
+			return p.getInfo()
 		}
 	case <-ctx.Done():
-		return ProcessInfo{}
+		return p.getInfo()
 	}
 }
 

--- a/rest_service.go
+++ b/rest_service.go
@@ -106,7 +106,7 @@ func (s *Service) backgroundPrune() {
 }
 
 func getProcInfoNoHang(p Process) ProcessInfo {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 	return p.Info(ctx)
 }

--- a/rest_service.go
+++ b/rest_service.go
@@ -172,7 +172,11 @@ func (s *Service) createProcess(rw http.ResponseWriter, r *http.Request) {
 		cancel()
 	}
 
-	gimlet.WriteJSON(rw, proc.Info(ctx))
+	// Make sure that we don't hang for _too_ long if the process is just very
+	// long/infinite.
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	gimlet.WriteJSON(rw, proc.Info(cctx))
 }
 
 func (s *Service) getBuildloggerURLs(rw http.ResponseWriter, r *http.Request) {

--- a/rest_service.go
+++ b/rest_service.go
@@ -172,7 +172,7 @@ func (s *Service) createProcess(rw http.ResponseWriter, r *http.Request) {
 		cancel()
 	}
 
-	gimlet.WriteJSON(rw, proc.Info(r.Context()))
+	gimlet.WriteJSON(rw, proc.Info(ctx))
 }
 
 func (s *Service) getBuildloggerURLs(rw http.ResponseWriter, r *http.Request) {

--- a/rest_service.go
+++ b/rest_service.go
@@ -416,7 +416,7 @@ func (s *Service) respawnProcess(rw http.ResponseWriter, r *http.Request) {
 	if err := newProc.RegisterTrigger(ctx, func(_ ProcessInfo) {
 		cancel()
 	}); err != nil {
-		if !getProcInfoNoHang(proc).Complete {
+		if !getProcInfoNoHang(newProc).Complete {
 			writeError(rw, gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message: errors.Wrap(


### PR DESCRIPTION
Fundamentally, the problem here is twofold:

1. We were polluting context use by mixing up the request context with the context used by the process, which isn't a good thing especially when the process methods can hang.
2. We were calling `proc.Info()` in multiple parts of the codebase without calling `proc.Wait()`, which can lead to hangs, especially if the context used has no deadline.

It is possible that this may resolve [MAKE-523](https://jira.mongodb.org/browse/MAKE-523).