### PR TITLE
MAKE-584: Add missing documentation comments to Jasper

### DIFF
--- a/create.go
+++ b/create.go
@@ -14,11 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// TODO: "is a struct" is redundant.
-
-// CreateOptions is a struct containing options related to starting a process,
-// including, but not limited to things like its execution arguments,
-// environment variables and a timeout.
+// CreateOptions contains options related to starting a process, including, but
+// not limited to things like its execution arguments, environment variables
+// and a timeout.
 type CreateOptions struct {
 	Args             []string          `json:"args"`
 	Environment      map[string]string `json:"env,omitempty"`
@@ -59,13 +57,8 @@ func MakeCreationOptions(cmdStr string) (*CreateOptions, error) {
 	}, nil
 }
 
-// TODO: Follow format for substantial Validate() impls in output.go.
-
-// Validate checks the CreateOptions' values for basic correctness. This method
-// does not guarantee that the CreateOptions struct is completely valid, as
-// some issues can only be discovered once the process starts (and
-// subsequently fails).
-// e.g. This function will ensure that there are a non-zero number of arguments.
+// Validate ensures that the CreateOptions on which it is called has
+// reasonable options.
 func (opts *CreateOptions) Validate() error {
 	if len(opts.Args) == 0 {
 		return errors.New("invalid command, must specify at least one argument")

--- a/create.go
+++ b/create.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// TODO: "is a struct" is redundant.
+
 // CreateOptions is a struct containing options related to starting a process,
 // including, but not limited to things like its execution arguments,
 // environment variables and a timeout.
@@ -56,6 +58,8 @@ func MakeCreationOptions(cmdStr string) (*CreateOptions, error) {
 		},
 	}, nil
 }
+
+// TODO: Follow format for substantial Validate() impls in output.go.
 
 // Validate checks the CreateOptions' values for basic correctness. This method
 // does not guarantee that the CreateOptions struct is completely valid, as

--- a/create.go
+++ b/create.go
@@ -14,9 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CreateOptions contains options related to starting a process, including, but
-// not limited to things like its execution arguments, environment variables
-// and a timeout.
+// CreateOptions contains options related to starting a process. This includes
+// execution configuration, post-execution triggers, and output configuration.
 type CreateOptions struct {
 	Args             []string          `json:"args"`
 	Environment      map[string]string `json:"env,omitempty"`
@@ -35,9 +34,9 @@ type CreateOptions struct {
 	started bool
 }
 
-// MakeCreationOptions takes a command string and returns a pointer to an
-// equivalent CreateOptions struct that would spawn a process corresponding to
-// the given command string.
+// MakeCreationOptions takes a command string and returns an equivalent
+// CreateOptions struct that would spawn a process corresponding to the given
+// command string.
 func MakeCreationOptions(cmdStr string) (*CreateOptions, error) {
 	args, err := shlex.Split(cmdStr)
 	if err != nil {
@@ -57,8 +56,7 @@ func MakeCreationOptions(cmdStr string) (*CreateOptions, error) {
 	}, nil
 }
 
-// Validate ensures that the CreateOptions on which it is called has
-// reasonable options.
+// Validate ensures that CreateOptions is valid.
 func (opts *CreateOptions) Validate() error {
 	if len(opts.Args) == 0 {
 		return errors.New("invalid command, must specify at least one argument")
@@ -100,10 +98,7 @@ func (opts *CreateOptions) Validate() error {
 	return nil
 }
 
-// Resolve will create a corresponding *exec.Cmd object for the given
-// CreateOptions that can then be Start()'d or Run()'d. Executing the *exec.Cmd
-// will spawn a process corresponding to the values in the CreateOptions on
-// which this method is called.
+// Resolve creates the command object according to the create options.
 func (opts *CreateOptions) Resolve(ctx context.Context) (*exec.Cmd, error) {
 	var err error
 	if ctx.Err() != nil {

--- a/download.go
+++ b/download.go
@@ -76,11 +76,9 @@ type ArchiveFormat string
 const (
 	// ArchiveAuto is an ArchiveFormat that does not force any particular type of
 	// archive format.
-	ArchiveAuto ArchiveFormat = "auto"
-	// nolint
-	ArchiveTarGz = "targz"
-	// nolint
-	ArchiveZip = "zip"
+	ArchiveAuto  ArchiveFormat = "auto"
+	ArchiveTarGz               = "targz" // nolint
+	ArchiveZip                 = "zip"   // nolint
 )
 
 // Validate checks that the ArchiveFormat is a recognized format.

--- a/download.go
+++ b/download.go
@@ -38,9 +38,7 @@ func (info DownloadInfo) Validate() error {
 	return catcher.Resolve()
 }
 
-// Download will execute the download operation specified in the DownloadInfo
-// struct on which it is called. This function makes a hanging network call,
-// and may not return for a substantial period of time.
+// Download executes the download operation.
 func (info DownloadInfo) Download() error {
 	req, err := http.NewRequest(http.MethodGet, info.URL, nil)
 	if err != nil {
@@ -79,9 +77,9 @@ const (
 	// ArchiveAuto is an ArchiveFormat that does not force any particular type of
 	// archive format.
 	ArchiveAuto ArchiveFormat = "auto"
-	// ArchiveTarGz is a constant referring to the targz archive format.
+	// nolint
 	ArchiveTarGz = "targz"
-	// ArchiveZip is a constant referring to the zip archive format.
+	// nolint
 	ArchiveZip = "zip"
 )
 

--- a/download.go
+++ b/download.go
@@ -38,6 +38,8 @@ func (info DownloadInfo) Validate() error {
 	return catcher.Resolve()
 }
 
+// TODO: "on which this method" should be "on which it"
+
 // Download will execute the download operation specified in the DownloadInfo
 // struct on which this method is called. This function makes a hanging network
 // call, and may not return for a substantial period of time.

--- a/download.go
+++ b/download.go
@@ -38,11 +38,9 @@ func (info DownloadInfo) Validate() error {
 	return catcher.Resolve()
 }
 
-// TODO: "on which this method" should be "on which it"
-
 // Download will execute the download operation specified in the DownloadInfo
-// struct on which this method is called. This function makes a hanging network
-// call, and may not return for a substantial period of time.
+// struct on which it is called. This function makes a hanging network call,
+// and may not return for a substantial period of time.
 func (info DownloadInfo) Download() error {
 	req, err := http.NewRequest(http.MethodGet, info.URL, nil)
 	if err != nil {

--- a/download.go
+++ b/download.go
@@ -38,6 +38,9 @@ func (info DownloadInfo) Validate() error {
 	return catcher.Resolve()
 }
 
+// Download will execute the download operation specified in the DownloadInfo
+// struct on which this method is called. This function makes a hanging network
+// call, and may not return for a substantial period of time.
 func (info DownloadInfo) Download() error {
 	req, err := http.NewRequest(http.MethodGet, info.URL, nil)
 	if err != nil {
@@ -73,9 +76,13 @@ func (info DownloadInfo) Download() error {
 type ArchiveFormat string
 
 const (
-	ArchiveAuto  ArchiveFormat = "auto"
-	ArchiveTarGz               = "targz"
-	ArchiveZip                 = "zip"
+	// ArchiveAuto is an ArchiveFormat that does not force any particular type of
+	// archive format.
+	ArchiveAuto ArchiveFormat = "auto"
+	// ArchiveTarGz is a constant referring to the targz archive format.
+	ArchiveTarGz = "targz"
+	// ArchiveZip is a constant referring to the zip archive format.
+	ArchiveZip = "zip"
 )
 
 // Validate checks that the ArchiveFormat is a recognized format.

--- a/filter.go
+++ b/filter.go
@@ -20,8 +20,7 @@ const (
 	Successful = "successful"
 )
 
-// Validate ensures that the Filter on which it is called is a valid, supported
-// Filter value.
+// Validate ensures that Filter is valid.
 func (f Filter) Validate() error {
 	switch f {
 	case Running, Terminated, All, Failed, Successful:

--- a/filter.go
+++ b/filter.go
@@ -2,16 +2,27 @@ package jasper
 
 import "github.com/pkg/errors"
 
+// Filter is type for classifying and grouping types of processes in filter
+// operations, such as that found in List() on Managers.
 type Filter string
 
 const (
-	Running    Filter = "running"
-	Terminated        = "terminated"
-	All               = "all"
-	Failed            = "failed"
-	Successful        = "successful"
+	// Running is a filter for processes that have not yet completed and are
+	// still running.
+	Running Filter = "running"
+	// Terminated is the opposite of the Running filter.
+	Terminated = "terminated"
+	// All is a filter that is satisfied by any process.
+	All = "all"
+	// Failed refers to processes that have terminated unsuccessfully.
+	Failed = "failed"
+	// Successful refers to processes that have terminated successfully.
+	Successful = "successful"
 )
 
+// Validate ensures that the Filter on which it is called is a valid, supported
+// Filter value.
+// Valid filter types are all documented.
 func (f Filter) Validate() error {
 	switch f {
 	case Running, Terminated, All, Failed, Successful:

--- a/filter.go
+++ b/filter.go
@@ -20,12 +20,8 @@ const (
 	Successful = "successful"
 )
 
-// TODO: Comment about valid filter types being documented is probably not
-// necessary.
-
 // Validate ensures that the Filter on which it is called is a valid, supported
 // Filter value.
-// Valid filter types are all documented.
 func (f Filter) Validate() error {
 	switch f {
 	case Running, Terminated, All, Failed, Successful:

--- a/filter.go
+++ b/filter.go
@@ -20,6 +20,9 @@ const (
 	Successful = "successful"
 )
 
+// TODO: Comment about valid filter types being documented is probably not
+// necessary.
+
 // Validate ensures that the Filter on which it is called is a valid, supported
 // Filter value.
 // Valid filter types are all documented.

--- a/jrpc/client.go
+++ b/jrpc/client.go
@@ -18,6 +18,7 @@ type jrpcManager struct {
 
 // TODO provide some better way of constructing this object
 
+// NewJRPCManager is a constructor for a jrpcManager.
 func NewJRPCManager(cc *grpc.ClientConn) jasper.Manager {
 	return &jrpcManager{
 		client: internal.NewJasperProcessManagerClient(cc),

--- a/jrpc/internal/jasper.ext.go
+++ b/jrpc/internal/jasper.ext.go
@@ -9,6 +9,8 @@ import (
 	"github.com/tychoish/bond"
 )
 
+// Export takes a protobuf JRPC CreateOptions struct and returns the analogous
+// Jasper CreateOptions struct.
 func (opts *CreateOptions) Export() *jasper.CreateOptions {
 	out := &jasper.CreateOptions{
 		Args:             opts.Args,
@@ -37,6 +39,9 @@ func (opts *CreateOptions) Export() *jasper.CreateOptions {
 	return out
 }
 
+// ConvertCreateOptions takes a Jasper CreateOptions struct and returns an
+// equivalent protobuf JRPC *CreateOptions struct. ConvertCreateOptions is the
+// inverse of (*CreateOptions) Export().
 func ConvertCreateOptions(opts *jasper.CreateOptions) *CreateOptions {
 	if opts.TimeoutSecs == 0 && opts.Timeout != 0 {
 		opts.TimeoutSecs = int(opts.Timeout.Seconds())
@@ -66,6 +71,8 @@ func ConvertCreateOptions(opts *jasper.CreateOptions) *CreateOptions {
 	return co
 }
 
+// Export takes a protobuf JRPC ProcessInfo struct and returns the analogous
+// Jasper ProcessInfo struct.
 func (info *ProcessInfo) Export() jasper.ProcessInfo {
 	return jasper.ProcessInfo{
 		ID:         info.Id,
@@ -79,6 +86,9 @@ func (info *ProcessInfo) Export() jasper.ProcessInfo {
 	}
 }
 
+// ConvertProcessInfo takes a Jasper ProcessInfo struct and returns an
+// equivalent protobuf JRPC *ProcessInfo struct. ConvertProcessInfo is the
+// inverse of (*ProcessInfo) Export().
 func ConvertProcessInfo(info jasper.ProcessInfo) *ProcessInfo {
 	return &ProcessInfo{
 		Id:         info.ID,
@@ -92,6 +102,8 @@ func ConvertProcessInfo(info jasper.ProcessInfo) *ProcessInfo {
 	}
 }
 
+// Export takes a protobuf JRPC Signals struct and returns the analogous
+// syscall.Signal.
 func (s Signals) Export() syscall.Signal {
 	switch s {
 	case Signals_HANGUP:
@@ -107,6 +119,9 @@ func (s Signals) Export() syscall.Signal {
 	}
 }
 
+// ConvertSignal takes a syscall.Signal and returns an
+// equivalent protobuf JRPC Signals struct. ConvertSignals is the
+// inverse of (Signals) Export().
 func ConvertSignal(s syscall.Signal) Signals {
 	switch s {
 	case syscall.SIGHUP:
@@ -122,6 +137,8 @@ func ConvertSignal(s syscall.Signal) Signals {
 	}
 }
 
+// ConvertFilter takes a Jasper Filter struct and returns an
+// equivalent protobuf JRPC *Filter struct.
 func ConvertFilter(f jasper.Filter) *Filter {
 	switch f {
 	case jasper.All:
@@ -139,29 +156,8 @@ func ConvertFilter(f jasper.Filter) *Filter {
 	}
 }
 
-func ConvertLogType(lt jasper.LogType) LogType {
-	switch lt {
-	case jasper.LogBuildloggerV2:
-		return LogType_LOGBUILDLOGGERV2
-	case jasper.LogBuildloggerV3:
-		return LogType_LOGBUILDLOGGERV3
-	case jasper.LogDefault:
-		return LogType_LOGDEFAULT
-	case jasper.LogFile:
-		return LogType_LOGFILE
-	case jasper.LogInherit:
-		return LogType_LOGINHERIT
-	case jasper.LogSplunk:
-		return LogType_LOGSPLUNK
-	case jasper.LogSumologic:
-		return LogType_LOGSUMOLOGIC
-	case jasper.LogInMemory:
-		return LogType_LOGINMEMORY
-	default:
-		return LogType_LOGUNKNOWN
-	}
-}
-
+// Export takes a protobuf JRPC LogType struct and returns the analogous
+// Jasper LogType struct.
 func (lt LogType) Export() jasper.LogType {
 	switch lt {
 	case LogType_LOGBUILDLOGGERV2:
@@ -185,110 +181,34 @@ func (lt LogType) Export() jasper.LogType {
 	}
 }
 
-func ConvertOutputOptions(opts jasper.OutputOptions) OutputOptions {
-	loggers := []*Logger{}
-	for _, logger := range opts.Loggers {
-		loggers = append(loggers, ConvertLogger(logger))
-	}
-	return OutputOptions{
-		SuppressOutput:        opts.SuppressOutput,
-		SuppressError:         opts.SuppressError,
-		RedirectOutputToError: opts.SendOutputToError,
-		RedirectErrorToOutput: opts.SendErrorToOutput,
-		Loggers:               loggers,
-	}
-}
-
-func ConvertLogger(logger jasper.Logger) *Logger {
-	return &Logger{
-		LogType:    ConvertLogType(logger.Type),
-		LogOptions: ConvertLogOptions(logger.Options),
-	}
-}
-
-func ConvertLogOptions(opts jasper.LogOptions) *LogOptions {
-	return &LogOptions{
-		BufferOptions:      ConvertBufferOptions(opts.BufferOptions),
-		BuildloggerOptions: ConvertBuildloggerOptions(opts.BuildloggerOptions),
-		DefaultPrefix:      opts.DefaultPrefix,
-		FileName:           opts.FileName,
-		Format:             ConvertLogFormat(opts.Format),
-		InMemoryCap:        int64(opts.InMemoryCap),
-		SplunkOptions:      ConvertSplunkOptions(opts.SplunkOptions),
-		SumoEndpoint:       opts.SumoEndpoint,
-	}
-}
-
-func ConvertBufferOptions(opts jasper.BufferOptions) *BufferOptions {
-	return &BufferOptions{
-		Buffered: opts.Buffered,
-		Duration: int64(opts.Duration),
-		MaxSize:  int64(opts.MaxSize),
-	}
-}
-
-func ConvertBuildloggerOptions(opts send.BuildloggerConfig) *BuildloggerOptions {
-	return &BuildloggerOptions{
-		CreateTest: opts.CreateTest,
-		Url:        opts.URL,
-		Number:     int64(opts.Number),
-		Phase:      opts.Phase,
-		Builder:    opts.Builder,
-		Test:       opts.Test,
-		Command:    opts.Command,
-	}
-}
-
-func ConvertBuildloggerURLs(urls []string) *BuildloggerURLs {
-	u := &BuildloggerURLs{Urls: []string{}}
-	for _, url := range urls {
-		u.Urls = append(u.Urls, url)
-	}
-	return u
-}
-
-func (u *BuildloggerURLs) Export() []string {
-	urls := []string{}
-	for _, url := range u.Urls {
-		urls = append(urls, url)
-	}
-	return urls
-}
-
-func ConvertSplunkOptions(opts send.SplunkConnectionInfo) *SplunkOptions {
-	return &SplunkOptions{
-		Url:     opts.ServerURL,
-		Token:   opts.Token,
-		Channel: opts.Channel,
-	}
-}
-
-func ConvertLogFormat(f jasper.LogFormat) LogFormat {
-	switch f {
-	case jasper.LogFormatDefault:
-		return LogFormat_LOGFORMATDEFAULT
-	case jasper.LogFormatJSON:
-		return LogFormat_LOGFORMATJSON
-	case jasper.LogFormatPlain:
-		return LogFormat_LOGFORMATPLAIN
+// ConvertLogType takes a Jasper LogType struct and returns an
+// equivalent protobuf JRPC LogType struct. ConvertLogType is the
+// inverse of (LogType) Export().
+func ConvertLogType(lt jasper.LogType) LogType {
+	switch lt {
+	case jasper.LogBuildloggerV2:
+		return LogType_LOGBUILDLOGGERV2
+	case jasper.LogBuildloggerV3:
+		return LogType_LOGBUILDLOGGERV3
+	case jasper.LogDefault:
+		return LogType_LOGDEFAULT
+	case jasper.LogFile:
+		return LogType_LOGFILE
+	case jasper.LogInherit:
+		return LogType_LOGINHERIT
+	case jasper.LogSplunk:
+		return LogType_LOGSPLUNK
+	case jasper.LogSumologic:
+		return LogType_LOGSUMOLOGIC
+	case jasper.LogInMemory:
+		return LogType_LOGINMEMORY
 	default:
-		return LogFormat_LOGFORMATUNKNOWN
+		return LogType_LOGUNKNOWN
 	}
 }
 
-func (f LogFormat) Export() jasper.LogFormat {
-	switch f {
-	case LogFormat_LOGFORMATDEFAULT:
-		return jasper.LogFormatDefault
-	case LogFormat_LOGFORMATJSON:
-		return jasper.LogFormatJSON
-	case LogFormat_LOGFORMATPLAIN:
-		return jasper.LogFormatPlain
-	default:
-		return jasper.LogFormatInvalid
-	}
-}
-
+// Export takes a protobuf JRPC OutputOptions struct and returns the analogous
+// Jasper OutputOptions struct.
 func (opts OutputOptions) Export() jasper.OutputOptions {
 	loggers := []jasper.Logger{}
 	for _, logger := range opts.Loggers {
@@ -303,6 +223,25 @@ func (opts OutputOptions) Export() jasper.OutputOptions {
 	}
 }
 
+// ConvertOutputOptions takes a Jasper OutputOptions struct and returns an
+// equivalent protobuf JRPC OutputOptions struct. ConvertOutputOptions is the
+// inverse of (OutputOptions) Export().
+func ConvertOutputOptions(opts jasper.OutputOptions) OutputOptions {
+	loggers := []*Logger{}
+	for _, logger := range opts.Loggers {
+		loggers = append(loggers, ConvertLogger(logger))
+	}
+	return OutputOptions{
+		SuppressOutput:        opts.SuppressOutput,
+		SuppressError:         opts.SuppressError,
+		RedirectOutputToError: opts.SendOutputToError,
+		RedirectErrorToOutput: opts.SendErrorToOutput,
+		Loggers:               loggers,
+	}
+}
+
+// Export takes a protobuf JRPC Logger struct and returns the analogous
+// Jasper Logger struct.
 func (logger Logger) Export() jasper.Logger {
 	return jasper.Logger{
 		Type:    logger.LogType.Export(),
@@ -310,6 +249,18 @@ func (logger Logger) Export() jasper.Logger {
 	}
 }
 
+// ConvertLogger takes a Jasper Logger struct and returns an
+// equivalent protobuf JRPC Logger struct. ConvertLogger is the
+// inverse of (Logger) Export().
+func ConvertLogger(logger jasper.Logger) *Logger {
+	return &Logger{
+		LogType:    ConvertLogType(logger.Type),
+		LogOptions: ConvertLogOptions(logger.Options),
+	}
+}
+
+// Export takes a protobuf JRPC LogOptions struct and returns the analogous
+// Jasper LogOptions struct.
 func (opts LogOptions) Export() jasper.LogOptions {
 	out := jasper.LogOptions{
 		DefaultPrefix: opts.DefaultPrefix,
@@ -332,6 +283,24 @@ func (opts LogOptions) Export() jasper.LogOptions {
 	return out
 }
 
+// ConvertLogOptions takes a Jasper LogOptions struct and returns an
+// equivalent protobuf JRPC LogOptions struct. ConvertLogOptions is the
+// inverse of (LogOptions) Export().
+func ConvertLogOptions(opts jasper.LogOptions) *LogOptions {
+	return &LogOptions{
+		BufferOptions:      ConvertBufferOptions(opts.BufferOptions),
+		BuildloggerOptions: ConvertBuildloggerOptions(opts.BuildloggerOptions),
+		DefaultPrefix:      opts.DefaultPrefix,
+		FileName:           opts.FileName,
+		Format:             ConvertLogFormat(opts.Format),
+		InMemoryCap:        int64(opts.InMemoryCap),
+		SplunkOptions:      ConvertSplunkOptions(opts.SplunkOptions),
+		SumoEndpoint:       opts.SumoEndpoint,
+	}
+}
+
+// Export takes a protobuf JRPC BufferOptions struct and returns the analogous
+// Jasper BufferOptions struct.
 func (opts *BufferOptions) Export() jasper.BufferOptions {
 	return jasper.BufferOptions{
 		Buffered: opts.Buffered,
@@ -340,6 +309,19 @@ func (opts *BufferOptions) Export() jasper.BufferOptions {
 	}
 }
 
+// ConvertBufferOptions takes a Jasper BufferOptions struct and returns an
+// equivalent protobuf JRPC BufferOptions struct. ConvertBufferOptions is the
+// inverse of (*BufferOptions) Export().
+func ConvertBufferOptions(opts jasper.BufferOptions) *BufferOptions {
+	return &BufferOptions{
+		Buffered: opts.Buffered,
+		Duration: int64(opts.Duration),
+		MaxSize:  int64(opts.MaxSize),
+	}
+}
+
+// Export takes a protobuf JRPC BuildloggerOptions struct and returns the
+// analogous grip/send.BuildloggerConfig struct.
 func (opts BuildloggerOptions) Export() send.BuildloggerConfig {
 	return send.BuildloggerConfig{
 		CreateTest: opts.CreateTest,
@@ -352,6 +334,44 @@ func (opts BuildloggerOptions) Export() send.BuildloggerConfig {
 	}
 }
 
+// ConvertBuildloggerOptions takes a grip/send.BuildloggerConfig and returns an
+// equivalent protobuf JRPC BuildloggerOptions struct.
+// ConvertBuildloggerOptions is the inverse of (BuildloggerOptions) Export().
+func ConvertBuildloggerOptions(opts send.BuildloggerConfig) *BuildloggerOptions {
+	return &BuildloggerOptions{
+		CreateTest: opts.CreateTest,
+		Url:        opts.URL,
+		Number:     int64(opts.Number),
+		Phase:      opts.Phase,
+		Builder:    opts.Builder,
+		Test:       opts.Test,
+		Command:    opts.Command,
+	}
+}
+
+// Export takes a protobuf JRPC BuildloggerURLs struct and returns the analogous
+// []string.
+func (u *BuildloggerURLs) Export() []string {
+	urls := []string{}
+	for _, url := range u.Urls {
+		urls = append(urls, url)
+	}
+	return urls
+}
+
+// ConvertBuildloggerURLs takes a []string and returns the analogous protobuf
+// JRPC BuildloggerURLs struct. ConvertBuildloggerURLs is the
+// inverse of (*BuildloggerURLs) Export().
+func ConvertBuildloggerURLs(urls []string) *BuildloggerURLs {
+	u := &BuildloggerURLs{Urls: []string{}}
+	for _, url := range urls {
+		u.Urls = append(u.Urls, url)
+	}
+	return u
+}
+
+// Export takes a protobuf JRPC SplunkOptions struct and returns the
+// analogous grip/send.SplunkConnectionInfo struct.
 func (opts SplunkOptions) Export() send.SplunkConnectionInfo {
 	return send.SplunkConnectionInfo{
 		ServerURL: opts.Url,
@@ -360,6 +380,50 @@ func (opts SplunkOptions) Export() send.SplunkConnectionInfo {
 	}
 }
 
+// ConvertSplunkOptions takes a grip/send.SplunkConnectionInfo and returns the
+// analogous protobuf JRPC SplunkOptions struct. ConvertSplunkOptions is the
+// inverse of (SplunkOptions) Export().
+func ConvertSplunkOptions(opts send.SplunkConnectionInfo) *SplunkOptions {
+	return &SplunkOptions{
+		Url:     opts.ServerURL,
+		Token:   opts.Token,
+		Channel: opts.Channel,
+	}
+}
+
+// Export takes a protobuf JRPC LogFormat struct and returns the analogous
+// Jasper LogFormat struct.
+func (f LogFormat) Export() jasper.LogFormat {
+	switch f {
+	case LogFormat_LOGFORMATDEFAULT:
+		return jasper.LogFormatDefault
+	case LogFormat_LOGFORMATJSON:
+		return jasper.LogFormatJSON
+	case LogFormat_LOGFORMATPLAIN:
+		return jasper.LogFormatPlain
+	default:
+		return jasper.LogFormatInvalid
+	}
+}
+
+// ConvertLogFormat takes a Jasper LogFormat struct and returns an
+// equivalent protobuf JRPC LogFormat struct. ConvertLogFormat is the
+// inverse of (LogFormat) Export().
+func ConvertLogFormat(f jasper.LogFormat) LogFormat {
+	switch f {
+	case jasper.LogFormatDefault:
+		return LogFormat_LOGFORMATDEFAULT
+	case jasper.LogFormatJSON:
+		return LogFormat_LOGFORMATJSON
+	case jasper.LogFormatPlain:
+		return LogFormat_LOGFORMATPLAIN
+	default:
+		return LogFormat_LOGFORMATUNKNOWN
+	}
+}
+
+// Export takes a protobuf JRPC BuildOptions struct and returns the analogous
+// bond.BuildOptions struct.
 func (opts *BuildOptions) Export() bond.BuildOptions {
 	return bond.BuildOptions{
 		Target:  opts.Target,
@@ -369,6 +433,8 @@ func (opts *BuildOptions) Export() bond.BuildOptions {
 	}
 }
 
+// Export takes a protobuf JRPC MongoDBDownloadOptions struct and returns the
+// analogous Jasper MongoDBDownloadOptions struct.
 func (opts *MongoDBDownloadOptions) Export() jasper.MongoDBDownloadOptions {
 	jopts := jasper.MongoDBDownloadOptions{
 		BuildOpts: opts.BuildOptions.Export(),
@@ -382,6 +448,8 @@ func (opts *MongoDBDownloadOptions) Export() jasper.MongoDBDownloadOptions {
 	return jopts
 }
 
+// Export takes a protobuf JRPC CacheOptions struct and returns the analogous
+// Jasper CacheOptions struct.
 func (opts *CacheOptions) Export() jasper.CacheOptions {
 	return jasper.CacheOptions{
 		Disabled:   opts.Disabled,
@@ -390,14 +458,8 @@ func (opts *CacheOptions) Export() jasper.CacheOptions {
 	}
 }
 
-func ConvertDownloadInfo(info jasper.DownloadInfo) *DownloadInfo {
-	return &DownloadInfo{
-		Path:        info.Path,
-		Url:         info.URL,
-		ArchiveOpts: ConvertArchiveOptions(info.ArchiveOpts),
-	}
-}
-
+// Export takes a protobuf JRPC DownloadInfo struct and returns the analogous
+// Jasper DownloadInfo struct.
 func (info *DownloadInfo) Export() jasper.DownloadInfo {
 	return jasper.DownloadInfo{
 		Path:        info.Path,
@@ -406,19 +468,19 @@ func (info *DownloadInfo) Export() jasper.DownloadInfo {
 	}
 }
 
-func ConvertArchiveFormat(format jasper.ArchiveFormat) ArchiveFormat {
-	switch format {
-	case jasper.ArchiveAuto:
-		return ArchiveFormat_ARCHIVEAUTO
-	case jasper.ArchiveTarGz:
-		return ArchiveFormat_ARCHIVETARGZ
-	case jasper.ArchiveZip:
-		return ArchiveFormat_ARCHIVEZIP
-	default:
-		return ArchiveFormat_ARCHIVEUNKNOWN
+// ConvertDownloadInfo takes a Jasper DownloadInfo struct and returns an
+// equivalent protobuf JRPC DownloadInfo struct. ConvertDownloadInfo is the
+// inverse of (*DownloadInfo) Export().
+func ConvertDownloadInfo(info jasper.DownloadInfo) *DownloadInfo {
+	return &DownloadInfo{
+		Path:        info.Path,
+		Url:         info.URL,
+		ArchiveOpts: ConvertArchiveOptions(info.ArchiveOpts),
 	}
 }
 
+// Export takes a protobuf JRPC ArchiveFormat struct and returns the analogous
+// Jasper ArchiveFormat struct.
 func (format ArchiveFormat) Export() jasper.ArchiveFormat {
 	switch format {
 	case ArchiveFormat_ARCHIVEAUTO:
@@ -432,18 +494,39 @@ func (format ArchiveFormat) Export() jasper.ArchiveFormat {
 	}
 }
 
-func ConvertArchiveOptions(opts jasper.ArchiveOptions) *ArchiveOptions {
-	return &ArchiveOptions{
-		ShouldExtract: opts.ShouldExtract,
-		Format:        ConvertArchiveFormat(opts.Format),
-		TargetPath:    opts.TargetPath,
+// ConvertArchiveFormat takes a Jasper ArchiveFormat struct and returns an
+// equivalent protobuf JRPC ArchiveFormat struct. ConvertArchiveFormat is the
+// inverse of (ArchiveFormat) Export().
+func ConvertArchiveFormat(format jasper.ArchiveFormat) ArchiveFormat {
+	switch format {
+	case jasper.ArchiveAuto:
+		return ArchiveFormat_ARCHIVEAUTO
+	case jasper.ArchiveTarGz:
+		return ArchiveFormat_ARCHIVETARGZ
+	case jasper.ArchiveZip:
+		return ArchiveFormat_ARCHIVEZIP
+	default:
+		return ArchiveFormat_ARCHIVEUNKNOWN
 	}
 }
 
+// Export takes a protobuf JRPC ArchiveOptions struct and returns the analogous
+// Jasper ArchiveOptions struct.
 func (opts ArchiveOptions) Export() jasper.ArchiveOptions {
 	return jasper.ArchiveOptions{
 		ShouldExtract: opts.ShouldExtract,
 		Format:        opts.Format.Export(),
+		TargetPath:    opts.TargetPath,
+	}
+}
+
+// ConvertArchiveOptions takes a Jasper ArchiveOptions struct and returns an
+// equivalent protobuf JRPC ArchiveOptions struct. ConvertArchiveOptions is the
+// inverse of (ArchiveOptions) Export().
+func ConvertArchiveOptions(opts jasper.ArchiveOptions) *ArchiveOptions {
+	return &ArchiveOptions{
+		ShouldExtract: opts.ShouldExtract,
+		Format:        ConvertArchiveFormat(opts.Format),
 		TargetPath:    opts.TargetPath,
 	}
 }

--- a/jrpc/internal/service.go
+++ b/jrpc/internal/service.go
@@ -17,6 +17,9 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
+// AttachService attaches the given manager to the jasper GRPC server. This
+// function eventually calls generated Protobuf code for registering the the
+// GRPC Jasper server with the given Manager.
 func AttachService(manager jasper.Manager, s *grpc.Server) error {
 	hn, err := os.Hostname()
 	if err != nil {

--- a/jrpc/service.go
+++ b/jrpc/service.go
@@ -7,7 +7,7 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
-// AttachService attaches the given manager to the jasper GRPC server. After
+// AttachService attaches the jasper GRPC server to the given manager. After
 // this function successfully returns, calls to Manager functions will be sent
 // over GRPC to the Jasper GRPC server.
 func AttachService(manager jasper.Manager, s *grpc.Server) error {

--- a/jrpc/service.go
+++ b/jrpc/service.go
@@ -7,6 +7,9 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
+// AttachService attaches the given manager to the jasper GRPC server. After
+// this function successfully returns, calls to Manager functions will be sent
+// over GRPC to the Jasper GRPC server.
 func AttachService(manager jasper.Manager, s *grpc.Server) error {
 	return errors.WithStack(internal.AttachService(manager, s))
 }

--- a/manager_local.go
+++ b/manager_local.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewLocalManager is a constructor for a localProcessManager.
+// NewLocalManager is a constructor for a thread-safe Manager.
 func NewLocalManager() Manager {
 	return &localProcessManager{
 		manager: &basicProcessManager{

--- a/manager_local.go
+++ b/manager_local.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// NewLocalManager is a constructor for a localProcessManager.
 func NewLocalManager() Manager {
 	return &localProcessManager{
 		manager: &basicProcessManager{

--- a/output.go
+++ b/output.go
@@ -43,6 +43,8 @@ const (
 	LogFile = "file"
 	// LogInherit is a log option that will use the current grip/send.Journaler's
 	// sender instance.
+	// TODO: Maybe don't use grip/send. (dot notation) and just say grip/send
+	// like in colloquial English?
 	LogInherit = "inherit"
 	// LogSplunk refers to the Splunk logging option.
 	LogSplunk = "splunk"

--- a/output.go
+++ b/output.go
@@ -33,23 +33,14 @@ type OutputOptions struct {
 type LogType string
 
 const (
-	// LogBuildloggerV2 refers to the buildlogger logging option.
-	LogBuildloggerV2 = "buildloggerv2"
-	// LogBuildloggerV3 refers to the buildlogger logging option.
-	LogBuildloggerV3 = "buildloggerv3"
-	// LogDefault refers to the native logging option.
-	LogDefault = "default"
-	// LogFile refers to the plain file logging option.
-	LogFile = "file"
-	// LogInherit is a log option that will use the current grip/send.Journaler's
-	// sender instance.
-	LogInherit = "inherit"
-	// LogSplunk refers to the Splunk logging option.
-	LogSplunk = "splunk"
-	// LogSumologic refers to the Sumo Logic logging option.
-	LogSumologic = "sumologic"
-	// LogInMemory refers to grip/send's in-memory buffered sender logging option.
-	LogInMemory = "inmemory"
+	LogBuildloggerV2 = "buildloggerv2" // nolint
+	LogBuildloggerV3 = "buildloggerv3" // nolint
+	LogDefault       = "default"       // nolint
+	LogFile          = "file"          // nolint
+	LogInherit       = "inherit"       // nolint
+	LogSplunk        = "splunk"        // nolint
+	LogSumologic     = "sumologic"     // nolint
+	LogInMemory      = "inmemory"      // nolint
 )
 
 const (
@@ -75,7 +66,8 @@ const (
 )
 
 // LogOptions contains options related to the logging done by Jasper.
-// NOTE: By default, logger reads from both standard output and standard error.
+//
+// By default, logger reads from both standard output and standard error.
 type LogOptions struct {
 	BufferOptions      BufferOptions             `json:"buffer_options"`
 	BuildloggerOptions send.BuildloggerConfig    `json:"buildlogger_options"`
@@ -87,8 +79,7 @@ type LogOptions struct {
 	SumoEndpoint       string                    `json:"sumo_endpoint"`
 }
 
-// Validate ensures that the BufferOptions on which it is called has
-// reasonable options.
+// Validate ensures that BufferOptions is valid.
 func (opts BufferOptions) Validate() error {
 	if opts.Buffered && opts.Duration < 0 || opts.MaxSize < 0 {
 		return errors.New("cannot have negative buffer duration or size")
@@ -96,8 +87,7 @@ func (opts BufferOptions) Validate() error {
 	return nil
 }
 
-// Validate ensures that the LogOptions on which it is called has
-// reasonable BufferOptions set.
+// Validate ensures that LogOptions is valid.
 func (opts LogOptions) Validate() error {
 	return opts.BufferOptions.Validate()
 }
@@ -109,8 +99,7 @@ type Logger struct {
 	sender  send.Sender
 }
 
-// Validate ensures that the Logger on which it is called refers to valid
-// LogType and LogOptions.
+// Validate ensures that LogOptions is valid.
 func (l Logger) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Add(l.Type.Validate())
@@ -118,8 +107,7 @@ func (l Logger) Validate() error {
 	return catcher.Resolve()
 }
 
-// Validate ensures that the LogType on which it is called is a valid,
-// supported LogType value.
+// Validate ensures that the LogType is valid.
 func (l LogType) Validate() error {
 	switch l {
 	case LogBuildloggerV2, LogBuildloggerV3, LogDefault, LogFile, LogInherit, LogSplunk, LogSumologic, LogInMemory:
@@ -129,8 +117,7 @@ func (l LogType) Validate() error {
 	}
 }
 
-// Validate ensures that the LogFormat on which it is called is a valid,
-// supported LogFormat value.
+// Validate ensures that the LogFormat is valid.
 func (f LogFormat) Validate() error {
 	switch f {
 	case LogFormatDefault, LogFormatJSON, LogFormatPlain:
@@ -385,8 +372,8 @@ func (o *OutputOptions) GetOutput() (io.Writer, error) {
 	return o.outputMulti, nil
 }
 
-// GetError returns a Writer that has the stderr output from the process that
-// the OutputOptions that this method is called on is attached to.
+// GetError returns an io.Writer that can be used for standard error, depending on
+// the output configuration.
 func (o *OutputOptions) GetError() (io.Writer, error) {
 	if o.SendErrorToOutput {
 		return o.GetOutput()

--- a/output.go
+++ b/output.go
@@ -43,8 +43,6 @@ const (
 	LogFile = "file"
 	// LogInherit is a log option that will use the current grip/send.Journaler's
 	// sender instance.
-	// TODO: Maybe don't use grip/send. (dot notation) and just say grip/send
-	// like in colloquial English?
 	LogInherit = "inherit"
 	// LogSplunk refers to the Splunk logging option.
 	LogSplunk = "splunk"
@@ -104,7 +102,7 @@ func (opts LogOptions) Validate() error {
 	return opts.BufferOptions.Validate()
 }
 
-// Logger is a wrapper struct around a grip/send Sender.
+// Logger is a wrapper struct around a grip/send.Sender.
 type Logger struct {
 	Type    LogType    `json:"log_type"`
 	Options LogOptions `json:"log_options"`


### PR DESCRIPTION
Also some re-ordering of things in `jasper.ext.go` to be consistent.