### PR TITLE
MAKE-537: Add some missing tests for basicProcess in JRPC & integration_test.go

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -107,6 +107,7 @@ func TestMongod(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for name, makeProc := range map[string]processConstructor{
+		"Basic": newBasicProcess,
 		"Blocking": newBlockingProcess,
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -107,7 +107,7 @@ func TestMongod(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for name, makeProc := range map[string]processConstructor{
-		"Basic": newBasicProcess,
+		"Basic":    newBasicProcess,
 		"Blocking": newBlockingProcess,
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -125,7 +125,7 @@ func TestMongod(t *testing.T) {
 					signal:      syscall.SIGKILL,
 					sleepMillis: 0,
 					expectError: true,
-					errorString: "operation failed",
+					errorString: "signal: killed",
 				},
 				{
 					id:          "With10MongodsAndSigkill",
@@ -133,7 +133,7 @@ func TestMongod(t *testing.T) {
 					signal:      syscall.SIGKILL,
 					sleepMillis: 2000,
 					expectError: true,
-					errorString: "operation failed",
+					errorString: "signal: killed",
 				},
 				{
 					id:          "With30MongodsAndSigkill",
@@ -141,7 +141,7 @@ func TestMongod(t *testing.T) {
 					signal:      syscall.SIGKILL,
 					sleepMillis: 4000,
 					expectError: true,
-					errorString: "operation failed",
+					errorString: "signal: killed",
 				},
 			} {
 				t.Run(test.id, func(t *testing.T) {

--- a/interface.go
+++ b/interface.go
@@ -66,8 +66,7 @@ type Process interface {
 	// exit code as -1 if it was unable to return a true code due
 	// to some other error, but otherwise will return the actual
 	// exit code of the process. Returns nil if the process has
-	// completed successfully. If the process has not completed
-	// successfully, Wait will return a non-nil error.
+	// completed successfully.
 	//
 	// Note that death by signal does not return the signal code
 	// and instead is returned as -1.

--- a/jrpc/service_test.go
+++ b/jrpc/service_test.go
@@ -16,7 +16,8 @@ import (
 
 func TestJRPCService(t *testing.T) {
 	for managerName, makeManager := range map[string]func() jasper.Manager{
-		"Blocking": jasper.NewLocalManager,
+		"Basic": jasper.NewLocalManager,
+		"Blocking": jasper.NewLocalManagerBlockingProcesses,
 	} {
 		t.Run(managerName, func(t *testing.T) {
 			for testName, testCase := range map[string]func(context.Context, *testing.T, jasper.CreateOptions, internal.JasperProcessManagerClient, string, string){

--- a/process_basic.go
+++ b/process_basic.go
@@ -161,9 +161,6 @@ func (p *basicProcess) Wait(ctx context.Context) (int, error) {
 	case <-p.waitProcessed:
 	}
 
-	if !p.info.Successful {
-		return p.info.ExitCode, errors.New("operation failed")
-	}
 	return p.info.ExitCode, p.err
 }
 

--- a/process_basic.go
+++ b/process_basic.go
@@ -162,7 +162,6 @@ func (p *basicProcess) Wait(ctx context.Context) (int, error) {
 	}
 
 	if !p.info.Successful {
-		// If the process was not successful, return an error indicating so.
 		return p.info.ExitCode, errors.New("operation failed")
 	}
 	return p.info.ExitCode, p.err

--- a/process_basic.go
+++ b/process_basic.go
@@ -161,6 +161,10 @@ func (p *basicProcess) Wait(ctx context.Context) (int, error) {
 	case <-p.waitProcessed:
 	}
 
+	if !p.info.Successful {
+		// If the process was not successful, return an error indicating so.
+		return p.info.ExitCode, errors.New("operation failed")
+	}
 	return p.info.ExitCode, p.err
 }
 

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -286,6 +287,7 @@ func TestBlockingProcess(t *testing.T) {
 						for {
 							select {
 							case op := <-proc.ops:
+								proc.err = errors.New("signal: killed")
 								proc.setInfo(ProcessInfo{
 									ID:         "foo",
 									Successful: false,


### PR DESCRIPTION
These are some tests elsewhere in the codebase where I forgot to add `basicProcess`.