### PR TITLE
MAKE-630: Improve exit code return from Jasper RPC Wait() calls

### DIFF
--- a/process_basic.go
+++ b/process_basic.go
@@ -92,7 +92,12 @@ func (p *basicProcess) transition(ctx context.Context, cmd *exec.Cmd) {
 		p.err = err
 		p.info.IsRunning = false
 		p.info.Complete = true
-		p.info.ExitCode = p.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+		procWaitStatus := p.cmd.ProcessState.Sys().(syscall.WaitStatus)
+		if procWaitStatus.Signaled() {
+			p.info.ExitCode = int(procWaitStatus.Signal())
+		} else {
+			p.info.ExitCode = procWaitStatus.ExitStatus()
+		}
 		p.info.Successful = p.cmd.ProcessState.Success()
 		p.triggers.Run(p.info)
 	}

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -132,7 +132,12 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 				if cmd.ProcessState != nil {
 					info.Successful = cmd.ProcessState.Success()
 					info.PID = cmd.ProcessState.Pid()
-					info.ExitCode = cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+					procWaitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+					if procWaitStatus.Signaled() {
+						info.ExitCode = int(procWaitStatus.Signal())
+					} else {
+						info.ExitCode = procWaitStatus.ExitStatus()
+					}
 				} else {
 					info.Successful = (err == nil)
 				}

--- a/process_test.go
+++ b/process_test.go
@@ -420,7 +420,7 @@ func TestProcessImplementations(t *testing.T) {
 					proc.Signal(ctx, syscall.SIGTERM)
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
-					assert.Equal(t, -1, exitCode)
+					assert.Equal(t, 15, exitCode)
 				},
 				"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					cctx, cancel := context.WithCancel(ctx)

--- a/process_test.go
+++ b/process_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
@@ -420,7 +421,11 @@ func TestProcessImplementations(t *testing.T) {
 					proc.Signal(ctx, syscall.SIGTERM)
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
-					assert.Equal(t, 15, exitCode)
+					if runtime.GOOS == "windows" {
+						assert.Equal(t, -1, exitCode)
+					} else {
+						assert.Equal(t, 15, exitCode)
+					}
 				},
 				"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep processConstructor) {
 					cctx, cancel := context.WithCancel(ctx)

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -282,7 +282,11 @@ func TestRPCManager(t *testing.T) {
 
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
-					assert.Equal(t, 9, exitCode)
+					if runtime.GOOS == "windows" {
+						assert.Equal(t, 1, exitCode)
+					} else {
+						assert.Equal(t, 9, exitCode)
+					}
 				},
 				// "": func(ctx context.Context, t *testing.T, manager jasper.Manager) {},
 			} {
@@ -526,7 +530,11 @@ func TestRPCProcess(t *testing.T) {
 					proc.Signal(ctx, syscall.SIGTERM)
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
-					assert.Equal(t, 15, exitCode)
+					if runtime.GOOS == "windows" {
+						assert.Equal(t, -1, exitCode)
+					} else {
+						assert.Equal(t, 15, exitCode)
+					}
 				},
 				"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					cctx, cancel := context.WithCancel(ctx)

--- a/rpc/internal/service.go
+++ b/rpc/internal/service.go
@@ -207,7 +207,7 @@ func (s *jasperService) Wait(ctx context.Context, id *JasperProcessID) (*Operati
 		return &OperationOutcome{
 			Success:  false,
 			Text:     err.Error(),
-			ExitCode: -3,
+			ExitCode: int32(exitCode),
 		}, nil
 	}
 


### PR DESCRIPTION
Had to do some Windows-specific rigging of the tests, since signal numbers like 9 and 15 for `SIGKILL` and `SIGTERM` don't exist on Windows.