### PR TITLE
MAKE-639: add pre-signal trigger for basic and blocking processes

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -77,6 +77,10 @@ type Process interface {
 	// options and return the new, "respawned" process.
 	Respawn(context.Context) (Process, error)
 
+	// RegisterSignalTrigger associates triggers with a process,
+	// which execute before the process is about to be signaled.
+	RegisterSignalTrigger(context.Context, SignalTrigger) error
+
 	// RegisterTrigger associates triggers with a process,
 	// erroring when the context is canceled, the process is
 	// complete.

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -204,14 +204,15 @@ func (m *MockManager) Close(_ context.Context) error {
 }
 
 type MockProcess struct {
-	ProcID              string
-	ProcInfo            ProcessInfo
-	IsRunning           bool
-	IsComplete          bool
-	FailSignal          bool
-	FailWait            bool
-	FailRespawn         bool
-	FailRegisterTrigger bool
+	ProcID                    string
+	ProcInfo                  ProcessInfo
+	IsRunning                 bool
+	IsComplete                bool
+	FailSignal                bool
+	FailWait                  bool
+	FailRespawn               bool
+	FailRegisterTrigger       bool
+	FailRegisterSignalTrigger bool
 }
 
 func (p *MockProcess) ID() string                         { return p.ProcID }
@@ -247,6 +248,14 @@ func (p *MockProcess) Respawn(_ context.Context) (Process, error) {
 
 func (p *MockProcess) RegisterTrigger(_ context.Context, t ProcessTrigger) error {
 	if p.FailRegisterTrigger {
+		return errors.New("always fail")
+	}
+
+	return nil
+}
+
+func (p *MockProcess) RegisterSignalTrigger(_ context.Context, _ SignalTrigger) error {
+	if p.FailRegisterSignalTrigger {
 		return errors.New("always fail")
 	}
 

--- a/manager_test.go
+++ b/manager_test.go
@@ -90,7 +90,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.NoError(t, err)
 					assert.Len(t, output, 10)
 				},
-				"ListAllReturnsErrorWithCancledContext": func(ctx context.Context, t *testing.T, manager Manager) {
+				"ListAllReturnsErrorWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager) {
 					cctx, cancel := context.WithCancel(ctx)
 					created, err := createProcs(ctx, trueCreateOpts(), manager, 10)
 					assert.NoError(t, err)
@@ -254,7 +254,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), "not defined")
 				},
-				"RegisterProcessErrorsForCancledContext": func(ctx context.Context, t *testing.T, manager Manager) {
+				"RegisterProcessErrorsForCanceledContext": func(ctx context.Context, t *testing.T, manager Manager) {
 					if mname == "REST" {
 						t.Skip("not supported on rest interfaces")
 					}

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -22,10 +22,11 @@ type blockingProcess struct {
 	ops  chan func(*exec.Cmd)
 	err  error
 
-	mu       sync.RWMutex
-	tags     map[string]struct{}
-	triggers ProcessTriggerSequence
-	info     *ProcessInfo
+	mu             sync.RWMutex
+	tags           map[string]struct{}
+	triggers       ProcessTriggerSequence
+	signalTriggers SignalTriggerSequence
+	info           ProcessInfo
 }
 
 func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, error) {
@@ -58,6 +59,14 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 	p.opts.started = true
 	opts.started = true
 
+	p.info = ProcessInfo{
+		ID:        id,
+		PID:       cmd.Process.Pid,
+		Host:      opts.Hostname,
+		Options:   *opts,
+		IsRunning: true,
+	}
+
 	go p.reactor(ctx, cmd)
 
 	return p, nil
@@ -66,28 +75,20 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 func (p *blockingProcess) setInfo(info ProcessInfo) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.info = &info
+	p.info = info
 }
 
-func (p *blockingProcess) hasInfo() bool {
+func (p *blockingProcess) hasCompleteInfo() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	return p.info != nil
+	return p.info.Complete
 }
 
 func (p *blockingProcess) getInfo() ProcessInfo {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-
-	ret := ProcessInfo{}
-	if p.info == nil {
-		return ret
-	}
-
-	ret = *p.info
-
-	return ret
+	return p.info
 }
 
 func (p *blockingProcess) setErr(err error) {
@@ -120,17 +121,12 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 				p.mu.RLock()
 				defer p.mu.RUnlock()
 
-				info = ProcessInfo{
-					ID:        p.id,
-					Options:   p.opts,
-					Host:      p.opts.Hostname,
-					Complete:  true,
-					IsRunning: false,
-				}
+				info = p.info
+				info.Complete = true
+				info.IsRunning = false
 
 				if cmd.ProcessState != nil {
 					info.Successful = cmd.ProcessState.Success()
-					info.PID = cmd.ProcessState.Pid()
 					procWaitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
 					if procWaitStatus.Signaled() {
 						info.ExitCode = int(procWaitStatus.Signal())
@@ -149,8 +145,8 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 				}))
 			}()
 
-			p.setInfo(info)
 			p.setErr(err)
+			p.setInfo(info)
 			p.mu.RLock()
 			p.triggers.Run(info)
 			p.mu.RUnlock()
@@ -158,15 +154,10 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 		case <-ctx.Done():
 			// note, the process might take a moment to
 			// die when it gets here.
-			info := ProcessInfo{
-				ID:         p.id,
-				Options:    p.opts,
-				Host:       p.opts.Hostname,
-				ExitCode:   -1,
-				Complete:   true,
-				IsRunning:  false,
-				Successful: false,
-			}
+			info := p.getInfo()
+			info.Complete = true
+			info.IsRunning = false
+			info.Successful = false
 
 			p.setInfo(info)
 			p.triggers.Run(info)
@@ -181,21 +172,13 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 
 func (p *blockingProcess) ID() string { return p.id }
 func (p *blockingProcess) Info(ctx context.Context) ProcessInfo {
-	if p.hasInfo() {
+	if p.hasCompleteInfo() {
 		return p.getInfo()
 	}
 
 	out := make(chan ProcessInfo)
 	operation := func(cmd *exec.Cmd) {
-		out <- ProcessInfo{
-			ID:        p.id,
-			Options:   p.opts,
-			Host:      p.opts.Hostname,
-			ExitCode:  -1,
-			Complete:  cmd.Process.Pid == -1,
-			IsRunning: cmd.Process.Pid > 0,
-			PID:       cmd.Process.Pid,
-		}
+		out <- p.getInfo()
 		close(out)
 	}
 
@@ -213,7 +196,7 @@ func (p *blockingProcess) Info(ctx context.Context) ProcessInfo {
 }
 
 func (p *blockingProcess) Running(ctx context.Context) bool {
-	if p.hasInfo() {
+	if p.hasCompleteInfo() {
 		return false
 	}
 
@@ -242,12 +225,12 @@ func (p *blockingProcess) Running(ctx context.Context) bool {
 	}
 }
 
-func (p *blockingProcess) Complete(ctx context.Context) bool {
-	return p.hasInfo()
+func (p *blockingProcess) Complete(_ context.Context) bool {
+	return p.hasCompleteInfo()
 }
 
 func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error {
-	if p.hasInfo() {
+	if p.hasCompleteInfo() {
 		return errors.New("cannot signal a process that has terminated")
 	}
 
@@ -259,6 +242,8 @@ func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error 
 			out <- errors.New("cannot signal nil process")
 			return
 		}
+
+		p.signalTriggers.Run(p.getInfo(), sig)
 
 		out <- errors.Wrapf(cmd.Process.Signal(sig), "problem sending signal '%s' to '%s'",
 			sig, p.id)
@@ -276,7 +261,7 @@ func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error 
 	}
 }
 
-func (p *blockingProcess) RegisterTrigger(ctx context.Context, trigger ProcessTrigger) error {
+func (p *blockingProcess) RegisterTrigger(_ context.Context, trigger ProcessTrigger) error {
 	if trigger == nil {
 		return errors.New("cannot register nil trigger")
 	}
@@ -284,7 +269,7 @@ func (p *blockingProcess) RegisterTrigger(ctx context.Context, trigger ProcessTr
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.info != nil {
+	if p.info.Complete {
 		return errors.New("cannot register trigger after process exits")
 	}
 
@@ -293,15 +278,31 @@ func (p *blockingProcess) RegisterTrigger(ctx context.Context, trigger ProcessTr
 	return nil
 }
 
+func (p *blockingProcess) RegisterSignalTrigger(_ context.Context, trigger SignalTrigger) error {
+	if trigger == nil {
+		return errors.New("cannot register nil trigger")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.info.Complete {
+		return errors.New("cannot register trigger after process exits")
+	}
+
+	p.signalTriggers = append(p.signalTriggers, trigger)
+
+	return nil
+}
+
 func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
-	if p.hasInfo() {
+	if p.hasCompleteInfo() {
 		return p.getInfo().ExitCode, p.getErr()
 	}
 
 	out := make(chan error)
 	waiter := func(cmd *exec.Cmd) {
-		info := p.getInfo()
-		if info.ID == "" {
+		if !p.hasCompleteInfo() {
 			return
 		}
 
@@ -321,7 +322,7 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 		case err := <-out:
 			return p.getInfo().ExitCode, errors.WithStack(err)
 		default:
-			if p.hasInfo() {
+			if p.hasCompleteInfo() {
 				return p.getInfo().ExitCode, p.getErr()
 			}
 		}

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -36,19 +36,9 @@ func TestBlockingProcess(t *testing.T) {
 						close(infoReturned)
 					}()
 
-					go func() {
-						op := <-proc.ops
-						op(nil)
-					}()
-
-					gracefulCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-					defer cancel()
-
-					select {
-					case <-infoReturned:
-					case <-gracefulCtx.Done():
-						t.Error("reached timeout")
-					}
+					op := <-proc.ops
+					op(nil)
+					<-infoReturned
 				},
 				"InfoReturnsNotCompleteForCanceledCase": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
 					signal := make(chan struct{})

--- a/process_local.go
+++ b/process_local.go
@@ -76,6 +76,13 @@ func (p *localProcess) RegisterTrigger(ctx context.Context, trigger ProcessTrigg
 	return errors.WithStack(p.proc.RegisterTrigger(ctx, trigger))
 }
 
+func (p *localProcess) RegisterSignalTrigger(ctx context.Context, trigger SignalTrigger) error {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	return errors.WithStack(p.proc.RegisterSignalTrigger(ctx, trigger))
+}
+
 func (p *localProcess) Wait(ctx context.Context) (int, error) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()

--- a/rest_client.go
+++ b/rest_client.go
@@ -417,9 +417,14 @@ func (p *restProcess) Respawn(ctx context.Context) (Process, error) {
 	}, nil
 }
 
-func (p *restProcess) RegisterTrigger(ctx context.Context, _ ProcessTrigger) error {
+func (p *restProcess) RegisterTrigger(_ context.Context, _ ProcessTrigger) error {
 	return errors.New("cannot register triggers on remote processes")
 }
+
+func (p *restProcess) RegisterSignalTrigger(_ context.Context, _ SignalTrigger) error {
+	return errors.New("cannot register signal trigger on remote processes")
+}
+
 func (p *restProcess) Tag(t string) {
 	req, err := http.NewRequest(http.MethodPost, p.client.getURL("/process/%s/tags?add=%s", p.id, t), nil)
 	if err != nil {

--- a/rest_test.go
+++ b/rest_test.go
@@ -250,7 +250,7 @@ func TestRestService(t *testing.T) {
 			srv.createProcess(rw, req)
 			assert.Equal(t, http.StatusBadRequest, rw.Code)
 		},
-		"CreateFailPropogatesErrors": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
+		"CreateFailPropagatesErrors": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			srv.manager = &MockManager{
 				FailCreate: true,
 			}

--- a/rest_test.go
+++ b/rest_test.go
@@ -382,6 +382,7 @@ func TestRestService(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEqual(t, 0, info.Size())
 		},
+		// TODO: fix this flaky test. It occasionally this receives 400 Bad Request instead of OK on Evergreen.
 		"DownloadFileCreatesResourceAndExtracts": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			if testing.Short() {
 				t.Skip("skipping download and extract test in short mode")

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -204,6 +204,10 @@ func (p *rpcProcess) RegisterTrigger(ctx context.Context, _ jasper.ProcessTrigge
 	return errors.New("cannot register remote triggers")
 }
 
+func (p *rpcProcess) RegisterSignalTrigger(ctx context.Context, _ jasper.SignalTrigger) error {
+	return errors.New("cannot register remote signal triggers")
+}
+
 func (p *rpcProcess) Tag(tag string) {
 	_, _ = p.client.TagProcess(context.TODO(), &internal.ProcessTags{
 		ProcessID: p.info.Id,

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -64,7 +64,7 @@ func TestRPCManager(t *testing.T) {
 					assert.Error(t, err)
 					assert.Nil(t, proc)
 				},
-				"ListAllReturnsErrorWithCancledContext": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
+				"ListAllReturnsErrorWithCanceledContext": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
 					cctx, cancel := context.WithCancel(ctx)
 					created, err := createProcs(ctx, trueCreateOpts(), manager, 10)
 					assert.NoError(t, err)
@@ -352,7 +352,7 @@ func TestRPCProcess(t *testing.T) {
 					assert.Error(t, err)
 					assert.Nil(t, proc)
 				},
-				"WithCancledContextProcessCreationFailes": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+				"WithCanceledContextProcessCreationFailes": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					pctx, pcancel := context.WithCancel(ctx)
 					pcancel()
 					proc, err := makep(pctx, opts)
@@ -424,7 +424,7 @@ func TestRPCProcess(t *testing.T) {
 					assert.NoError(t, err)
 					assert.True(t, proc.Complete(ctx))
 				},
-				"WaitReturnsWithCancledContext": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
+				"WaitReturnsWithCanceledContext": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 					opts.Args = []string{"sleep", "10"}
 					pctx, pcancel := context.WithCancel(ctx)
 					proc, err := makep(ctx, opts)
@@ -527,13 +527,14 @@ func TestRPCProcess(t *testing.T) {
 					proc, err := makep(ctx, sleepCreateOpts(100))
 					require.NoError(t, err)
 					require.NotNil(t, proc)
-					proc.Signal(ctx, syscall.SIGTERM)
+					sig := syscall.SIGTERM
+					proc.Signal(ctx, sig)
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
 					if runtime.GOOS == "windows" {
 						assert.Equal(t, -1, exitCode)
 					} else {
-						assert.Equal(t, 15, exitCode)
+						assert.Equal(t, int(sig), exitCode)
 					}
 				},
 				"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {

--- a/triggers.go
+++ b/triggers.go
@@ -2,6 +2,7 @@ package jasper
 
 import (
 	"context"
+	"syscall"
 	"time"
 
 	"github.com/mongodb/grip"
@@ -21,6 +22,15 @@ type ProcessTriggerSequence []ProcessTrigger
 func (s ProcessTriggerSequence) Run(info ProcessInfo) {
 	for _, trigger := range s {
 		trigger(info)
+	}
+}
+
+type SignalTrigger func(ProcessInfo, syscall.Signal)
+type SignalTriggerSequence []SignalTrigger
+
+func (s SignalTriggerSequence) Run(info ProcessInfo, sig syscall.Signal) {
+	for _, trigger := range s {
+		trigger(info, sig)
 	}
 }
 


### PR DESCRIPTION
* Added function to register triggers before signals
* Changed blocking process so that it doesn't wait until the process finishes to populate ProcessInfo. Instead of checking if `*ProcessInfo` exists (which only occurs when `Wait()` returns), blocking process now checks if `ProcessInfo.Complete` is set (this is also more consistent with basic process).
* Trivial spellcheck stuff