### PR TITLE
MAKE-638, MAKE-659: add process tracking support and pre-signal mongod shutown trigger for Windows

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -137,7 +137,7 @@ func TestCreateOptions(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, cmd.Env)
 		},
-		"EnvironmentVariablesArePropogated": func(t *testing.T, opts *CreateOptions) {
+		"EnvironmentVariablesArePropagated": func(t *testing.T, opts *CreateOptions) {
 			opts.Environment = map[string]string{
 				"foo": "bar",
 			}
@@ -147,7 +147,7 @@ func TestCreateOptions(t *testing.T) {
 			assert.Contains(t, cmd.Env, "foo=bar")
 			assert.NotContains(t, cmd.Env, "bar=foo")
 		},
-		"MultipleArgsArePropogated": func(t *testing.T, opts *CreateOptions) {
+		"MultipleArgsArePropagated": func(t *testing.T, opts *CreateOptions) {
 			opts.Args = append(opts.Args, "-lha")
 			cmd, err := opts.Resolve(ctx)
 			assert.NoError(t, err)

--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
   - name: github.com/tychoish/bond
     version: a6a4ddb19d113c553f1ab0970d6292e0e95c7221
   - name: github.com/tychoish/lru
-    version: 91dacc0e8bc08fd2a2e8019a1ad2df86b8f5b292
+    version: f77a748d12a924cfbfcf396426dd58de5aa3a9e2
   - name: github.com/mholt/archiver
     version: de0d89e255e17c8d75a40122055763e743ab0593
   - name: github.com/montanaflynn/stats

--- a/integration_test.go
+++ b/integration_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Returns path to release and to mongod
-func downloadMongodb(t *testing.T) (string, string) {
+func downloadMongoDB(t *testing.T) (string, string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -39,6 +39,7 @@ func downloadMongodb(t *testing.T) (string, string) {
 	arch := bond.MongoDBArch("x86_64")
 	release := "4.0-stable"
 
+	require.NoError(t, makeEnclosingDirectories("build"))
 	dir, err := ioutil.TempDir("build", "mongodb")
 	require.NoError(t, err)
 
@@ -103,7 +104,7 @@ func TestMongod(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, mongodPath := downloadMongodb(t)
+	dir, mongodPath := downloadMongoDB(t)
 	defer os.RemoveAll(dir)
 
 	for name, makeProc := range map[string]processConstructor{

--- a/interface.go
+++ b/interface.go
@@ -58,7 +58,7 @@ type Process interface {
 
 	// Signal sends the specified signals to the underlying
 	// process. Its error response reflects the outcome of sending
-	// the signal, not the state of process signaled.
+	// the signal, not the state of the process signaled.
 	Signal(context.Context, syscall.Signal) error
 
 	// Wait blocks until the process exits or the context is

--- a/jasper.proto
+++ b/jasper.proto
@@ -191,7 +191,7 @@ message BuildloggerURLs {
 }
 
 service JasperProcessManager {
-  rpc Status(google.protobuf.Empty) returns  (StatusResponse);
+  rpc Status(google.protobuf.Empty) returns (StatusResponse);
   rpc Create(CreateOptions) returns (ProcessInfo);
   rpc List(Filter) returns (stream ProcessInfo);
   rpc Group(TagName) returns (stream ProcessInfo);

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -85,7 +85,8 @@ outerRetry:
 			return nil, -1
 		default:
 			port := getPortNumber()
-			srv := NewManagerService(NewLocalManager())
+			localManager, _ := NewLocalManager(false)
+			srv := NewManagerService(localManager)
 			app := srv.App()
 			app.SetPrefix("jasper")
 			if err := app.SetPort(port); err != nil {

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -85,7 +85,10 @@ outerRetry:
 			return nil, -1
 		default:
 			port := getPortNumber()
-			localManager, _ := NewLocalManager(false)
+			localManager, err := NewLocalManager(false)
+			if err != nil {
+				return nil, -1
+			}
 			srv := NewManagerService(localManager)
 			app := srv.App()
 			app.SetPrefix("jasper")

--- a/manager_local.go
+++ b/manager_local.go
@@ -8,24 +8,26 @@ import (
 )
 
 // NewLocalManager is a constructor for a thread-safe Manager.
-func NewLocalManager() Manager {
-	return &localProcessManager{
-		manager: &basicProcessManager{
-			procs:    map[string]Process{},
-			blocking: false,
-		},
+func NewLocalManager(trackProcs bool) (Manager, error) {
+	basicManager, err := newBasicProcessManager(map[string]Process{}, false, false, trackProcs)
+	if err != nil {
+		return nil, err
 	}
+	return &localProcessManager{
+		manager: basicManager.(*basicProcessManager),
+	}, nil
 }
 
 // NewLocalManagerBlockingProcesses is a constructor for localProcessManager,
 // that uses blockingProcess instead of the default basicProcess.
-func NewLocalManagerBlockingProcesses() Manager {
-	return &localProcessManager{
-		manager: &basicProcessManager{
-			procs:    map[string]Process{},
-			blocking: true,
-		},
+func NewLocalManagerBlockingProcesses(trackProcs bool) (Manager, error) {
+	basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, false, true, trackProcs)
+	if err != nil {
+		return nil, err
 	}
+	return &localProcessManager{
+		manager: basicBlockingManager.(*basicProcessManager),
+	}, nil
 }
 
 type localProcessManager struct {

--- a/manager_self_clearing.go
+++ b/manager_self_clearing.go
@@ -12,21 +12,29 @@ import (
 // the need for calling Clear() from the user. Clear() can, however, be called
 // proactively. This manager therefore gives no guarantees on the persistence
 // of a process in its memory that has already completed.
-func NewSelfClearingProcessManager(maxProcs int) Manager {
-	return &selfClearingProcessManager{
-		local:    NewLocalManager().(*localProcessManager),
-		maxProcs: maxProcs,
+func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, error) {
+	localManager, err := NewLocalManager(trackProcs)
+	if err != nil {
+		return nil, err
 	}
+	return &selfClearingProcessManager{
+		local:    localManager.(*localProcessManager),
+		maxProcs: maxProcs,
+	}, nil
 }
 
 // NewSelfClearingProcessManagerBlockingProcesses creates and returns a process
 // manager that uses blockingProcesses rather than the default basicProcess.
 // See the NewSelfClearingProcessManager() constructor for more information.
-func NewSelfClearingProcessManagerBlockingProcesses(maxProcs int) Manager {
-	return &selfClearingProcessManager{
-		local:    NewLocalManagerBlockingProcesses().(*localProcessManager),
-		maxProcs: maxProcs,
+func NewSelfClearingProcessManagerBlockingProcesses(maxProcs int, trackProcs bool) (Manager, error) {
+	localBlockingManager, err := NewLocalManagerBlockingProcesses(trackProcs)
+	if err != nil {
+		return nil, err
 	}
+	return &selfClearingProcessManager{
+		local:    localBlockingManager.(*localProcessManager),
+		maxProcs: maxProcs,
+	}, nil
 }
 
 type selfClearingProcessManager struct {

--- a/manager_self_clearing_test.go
+++ b/manager_self_clearing_test.go
@@ -80,8 +80,9 @@ func TestSelfClearingManager(t *testing.T) {
 					tctx, cancel := context.WithTimeout(context.Background(), managerTestTimeout)
 					defer cancel()
 
-					selfClearingManager := NewSelfClearingProcessManager(5).(*selfClearingProcessManager)
-					test(tctx, t, selfClearingManager)
+					selfClearingManager, err := NewSelfClearingProcessManager(5, false)
+					require.NoError(t, err)
+					test(tctx, t, selfClearingManager.(*selfClearingProcessManager))
 					selfClearingManager.Close(tctx)
 				})
 			}

--- a/manager_test.go
+++ b/manager_test.go
@@ -32,16 +32,24 @@ func TestManagerInterface(t *testing.T) {
 			}
 		},
 		"Basic/Lock/BasicProcs": func(ctx context.Context, t *testing.T) Manager {
-			return NewLocalManager()
+			localManager, err := NewLocalManager(false)
+			require.NoError(t, err)
+			return localManager
 		},
 		"Basic/Lock/BlockingProcs": func(ctx context.Context, t *testing.T) Manager {
-			return NewLocalManagerBlockingProcesses()
+			localBlockingManager, err := NewLocalManagerBlockingProcesses(false)
+			require.NoError(t, err)
+			return localBlockingManager
 		},
 		"SelfClearing/BasicProcs": func(ctx context.Context, t *testing.T) Manager {
-			return NewSelfClearingProcessManager(10)
+			selfClearingManager, err := NewSelfClearingProcessManager(10, false)
+			require.NoError(t, err)
+			return selfClearingManager
 		},
 		"SelfClearing/BlockingProcs": func(ctx context.Context, t *testing.T) Manager {
-			return NewSelfClearingProcessManagerBlockingProcesses(10)
+			selfClearingBlockingManager, err := NewSelfClearingProcessManagerBlockingProcesses(10, false)
+			require.NoError(t, err)
+			return selfClearingBlockingManager
 		},
 		"REST": func(ctx context.Context, t *testing.T) Manager {
 			srv, port := makeAndStartService(ctx, httpClient)
@@ -170,7 +178,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.Len(t, procs, 0)
 					assert.Contains(t, err.Error(), "canceled")
 				},
-				"GroupPropgatesMatching": func(ctx context.Context, t *testing.T, manager Manager) {
+				"GroupPropagatesMatching": func(ctx context.Context, t *testing.T, manager Manager) {
 					proc, err := manager.Create(ctx, trueCreateOpts())
 					require.NoError(t, err)
 
@@ -214,7 +222,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.NoError(t, err)
 					assert.NoError(t, manager.Close(ctx))
 				},
-				"CloseExcutesClosersForProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
+				"CloseExecutesClosersForProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
 					if mname == "REST" {
 						t.Skip("not supported on rest interfaces")
 					}
@@ -348,7 +356,7 @@ func TestManagerInterface(t *testing.T) {
 					nilProc, err := manager.Get(ctx, proc.ID())
 					assert.Nil(t, nilProc)
 				},
-				"ClearIsANoOpForActiveProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
+				"ClearIsANoopForActiveProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
 					opts := sleepCreateOpts(20)
 					proc, err := manager.Create(ctx, opts)
 					require.NoError(t, err)

--- a/manager_test.go
+++ b/manager_test.go
@@ -354,6 +354,7 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					manager.Clear(ctx)
 					nilProc, err := manager.Get(ctx, proc.ID())
+					assert.Error(t, err)
 					assert.Nil(t, nilProc)
 				},
 				"ClearIsANoopForActiveProcesses": func(ctx context.Context, t *testing.T, manager Manager) {
@@ -385,6 +386,7 @@ func TestManagerInterface(t *testing.T) {
 					assert.Equal(t, sleepProc.ID(), sameSleepProc.ID())
 
 					nilProc, err := manager.Get(ctx, lsProc.ID())
+					assert.Error(t, err)
 					assert.Nil(t, nilProc)
 					require.NoError(t, Terminate(ctx, sleepProc)) // Clean up
 				},

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -1,0 +1,105 @@
+// +build windows
+
+package jasper
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicManagerWithTrackedProcesses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for managerName, makeManager := range map[string]func(ctx context.Context, t *testing.T) *basicProcessManager{
+		"Basic/NoLock/BasicProcs": func(ctx context.Context, t *testing.T) *basicProcessManager {
+			basicManager, err := newBasicProcessManager(map[string]Process{}, false, false, true)
+			require.NoError(t, err)
+			return basicManager.(*basicProcessManager)
+		},
+		"Basic/NoLock/BlockingProcs": func(ctx context.Context, t *testing.T) *basicProcessManager {
+			basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, false, true, true)
+			require.NoError(t, err)
+			return basicBlockingManager.(*basicProcessManager)
+		},
+	} {
+		t.Run(managerName, func(t *testing.T) {
+			for testName, testCase := range map[string]func(context.Context, *testing.T, *basicProcessManager, *windowsProcessTracker, *CreateOptions){
+				"ProcessTrackerCreatedEmpty": func(_ context.Context, t *testing.T, m *basicProcessManager, tracker *windowsProcessTracker, _ *CreateOptions) {
+					require.NotNil(t, tracker.job)
+
+					info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+					assert.NoError(t, err)
+					assert.Zero(t, info.NumberOfAssignedProcesses)
+				},
+				"CreateAddsProcess": func(ctx context.Context, t *testing.T, m *basicProcessManager, tracker *windowsProcessTracker, opts *CreateOptions) {
+					proc, err := m.Create(ctx, opts)
+					require.NoError(t, err)
+
+					info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+					assert.NoError(t, err)
+					assert.Equal(t, 1, int(info.NumberOfAssignedProcesses))
+					assert.Equal(t, proc.Info(ctx).PID, int(info.ProcessIdList[0]))
+					assert.NoError(t, m.Close(ctx))
+				},
+				"RegisterAddsProcess": func(ctx context.Context, t *testing.T, m *basicProcessManager, tracker *windowsProcessTracker, opts *CreateOptions) {
+					proc, err := newBasicProcess(ctx, opts)
+					require.NoError(t, err)
+					assert.NoError(t, m.Register(ctx, proc))
+
+					info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+					assert.NoError(t, err)
+					assert.Equal(t, 1, int(info.NumberOfAssignedProcesses))
+					assert.Equal(t, proc.Info(ctx).PID, int(info.ProcessIdList[0]))
+					assert.NoError(t, m.Close(ctx))
+				},
+				"ClosePerformsProcessTrackingCleanup": func(ctx context.Context, t *testing.T, m *basicProcessManager, tracker *windowsProcessTracker, opts *CreateOptions) {
+					proc, err := m.Create(ctx, opts)
+					require.NoError(t, err)
+
+					info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+					assert.NoError(t, err)
+					assert.Equal(t, 1, int(info.NumberOfAssignedProcesses))
+					assert.Equal(t, proc.Info(ctx).PID, int(info.ProcessIdList[0]))
+					assert.NoError(t, m.Close(ctx))
+
+					exitCode, err := proc.Wait(ctx)
+					assert.NoError(t, err)
+					assert.Zero(t, exitCode)
+					assert.False(t, proc.Running(ctx))
+					assert.True(t, proc.Complete(ctx))
+				},
+				"CloseOnTerminatedProcessSucceeds": func(ctx context.Context, t *testing.T, m *basicProcessManager, tracker *windowsProcessTracker, opts *CreateOptions) {
+					proc, err := m.Create(ctx, opts)
+					require.NoError(t, err)
+
+					info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+					assert.NoError(t, err)
+					assert.Equal(t, 1, int(info.NumberOfAssignedProcesses))
+					assert.Equal(t, proc.Info(ctx).PID, int(info.ProcessIdList[0]))
+
+					assert.NoError(t, proc.Signal(ctx, syscall.SIGKILL))
+					assert.NoError(t, m.Close(ctx))
+				},
+			} {
+				t.Run(testName, func(t *testing.T) {
+					// TODO: since processes can only be associated with 1 job, support Windows process and create them
+					// with the CREATE_BREAKAWAY_FROM_JOB flag.
+					t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
+						"(although they will pass if locally run).")
+					tctx, cancel := context.WithTimeout(ctx, longTaskTimeout)
+					defer cancel()
+					manager := makeManager(tctx, t)
+					tracker, ok := manager.tracker.(*windowsProcessTracker)
+					require.True(t, ok)
+					opts := yesCreateOpts(0)
+					testCase(tctx, t, manager, tracker, &opts)
+				})
+			}
+		})
+	}
+}

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -4,6 +4,7 @@ package jasper
 
 import (
 	"context"
+	"os"
 	"syscall"
 	"testing"
 
@@ -87,10 +88,12 @@ func TestBasicManagerWithTrackedProcesses(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					// TODO: since processes can only be associated with 1 job, support Windows process and create them
-					// with the CREATE_BREAKAWAY_FROM_JOB flag.
-					t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
-						"(although they will pass if locally run).")
+					if _, runningInEvgAgent := os.LookupEnv("EVR_TASK_ID"); runningInEvgAgent {
+						// TODO: since processes can only be associated with 1 job, support Windows process and create them
+						// with the CREATE_BREAKAWAY_FROM_JOB flag.
+						t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
+							"(although they will pass if locally run).")
+					}
 					tctx, cancel := context.WithTimeout(ctx, longTaskTimeout)
 					defer cancel()
 					manager := makeManager(tctx, t)

--- a/process_basic.go
+++ b/process_basic.go
@@ -48,7 +48,9 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 		p.Tag(t)
 	}
 
-	_ = p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
+	if err = p.RegisterTrigger(ctx, makeOptionsCloseTrigger()); err != nil {
+		return nil, errors.Wrap(err, "problem registering options closer trigger")
+	}
 
 	err = cmd.Start()
 	if err != nil {

--- a/process_basic.go
+++ b/process_basic.go
@@ -48,7 +48,7 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 		p.Tag(t)
 	}
 
-	p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
+	_ = p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
 
 	err = cmd.Start()
 	if err != nil {
@@ -135,8 +135,10 @@ func (p *basicProcess) Signal(_ context.Context, sig syscall.Signal) error {
 	defer p.RUnlock()
 
 	if p.Running(nil) {
-		p.signalTriggers.Run(p.Info(nil), sig)
-		return errors.Wrapf(p.cmd.Process.Signal(sig), "problem sending signal '%s' to '%s'", sig, p.id)
+		if skipSignal := p.signalTriggers.Run(p.Info(nil), sig); !skipSignal {
+			return errors.Wrapf(p.cmd.Process.Signal(sig), "problem sending signal '%s' to '%s'", sig, p.id)
+		}
+		return nil
 	}
 
 	return errors.New("cannot signal a process that has terminated")

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -50,7 +50,7 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 		p.Tag(t)
 	}
 
-	p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
+	_ = p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
 
 	if err = cmd.Start(); err != nil {
 		return nil, errors.Wrap(err, "problem starting command")
@@ -243,10 +243,13 @@ func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error 
 			return
 		}
 
-		p.signalTriggers.Run(p.getInfo(), sig)
+		if skipSignal := p.signalTriggers.Run(p.getInfo(), sig); !skipSignal {
+			out <- errors.Wrapf(cmd.Process.Signal(sig), "problem sending signal '%s' to '%s'",
+				sig, p.id)
+		} else {
+			out <- nil
+		}
 
-		out <- errors.Wrapf(cmd.Process.Signal(sig), "problem sending signal '%s' to '%s'",
-			sig, p.id)
 	}
 	select {
 	case p.ops <- operation:

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -50,7 +50,9 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 		p.Tag(t)
 	}
 
-	_ = p.RegisterTrigger(ctx, makeOptionsCloseTrigger())
+	if err = p.RegisterTrigger(ctx, makeOptionsCloseTrigger()); err != nil {
+		return nil, errors.Wrap(err, "problem registering options closer trigger")
+	}
 
 	if err = cmd.Start(); err != nil {
 		return nil, errors.Wrap(err, "problem starting command")

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -27,7 +27,8 @@ func TestRPCManager(t *testing.T) {
 
 	for mname, factory := range map[string]func(ctx context.Context, t *testing.T) jasper.Manager{
 		"Basic": func(ctx context.Context, t *testing.T) jasper.Manager {
-			mngr := jasper.NewLocalManager()
+			mngr, err := jasper.NewLocalManager(false)
+			require.NoError(t, err)
 			addr, err := startRPC(ctx, mngr)
 			require.NoError(t, err)
 
@@ -37,7 +38,8 @@ func TestRPCManager(t *testing.T) {
 			return client
 		},
 		"Blocking": func(ctx context.Context, t *testing.T) jasper.Manager {
-			mngr := jasper.NewLocalManagerBlockingProcesses()
+			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
+			require.NoError(t, err)
 			addr, err := startRPC(ctx, mngr)
 			require.NoError(t, err)
 
@@ -137,7 +139,7 @@ func TestRPCManager(t *testing.T) {
 					assert.Len(t, procs, 0)
 					assert.Contains(t, err.Error(), "canceled")
 				},
-				"GroupPropgatesMatching": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
+				"GroupPropagatesMatching": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
 					proc, err := manager.Create(ctx, trueCreateOpts())
 					require.NoError(t, err)
 
@@ -210,7 +212,7 @@ func TestRPCManager(t *testing.T) {
 					nilProc, err := manager.Get(ctx, proc.ID())
 					assert.Nil(t, nilProc)
 				},
-				"ClearIsANoOpForActiveProcesses": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
+				"ClearIsANoopForActiveProcesses": func(ctx context.Context, t *testing.T, manager jasper.Manager) {
 					opts := sleepCreateOpts(20)
 					proc, err := manager.Create(ctx, opts)
 					require.NoError(t, err)
@@ -308,7 +310,8 @@ func TestRPCProcess(t *testing.T) {
 
 	for cname, makeProc := range map[string]processConstructor{
 		"Basic": func(ctx context.Context, opts *jasper.CreateOptions) (jasper.Process, error) {
-			mngr := jasper.NewLocalManager()
+			mngr, err := jasper.NewLocalManager(false)
+			require.NoError(t, err)
 			addr, err := startRPC(ctx, mngr)
 			if err != nil {
 				return nil, errors.WithStack(err)
@@ -323,7 +326,8 @@ func TestRPCProcess(t *testing.T) {
 
 		},
 		"Blocking": func(ctx context.Context, opts *jasper.CreateOptions) (jasper.Process, error) {
-			mngr := jasper.NewLocalManagerBlockingProcesses()
+			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
+			require.NoError(t, err)
 			addr, err := startRPC(ctx, mngr)
 			if err != nil {
 				return nil, errors.WithStack(err)

--- a/rpc/internal/service.go
+++ b/rpc/internal/service.go
@@ -18,7 +18,7 @@ import (
 )
 
 // AttachService attaches the given manager to the jasper GRPC server. This
-// function eventually calls generated Protobuf code for registering the the
+// function eventually calls generated Protobuf code for registering the
 // GRPC Jasper server with the given Manager.
 func AttachService(manager jasper.Manager, s *grpc.Server) error {
 	hn, err := os.Hostname()

--- a/rpc/service_test.go
+++ b/rpc/service_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestRPCService(t *testing.T) {
-	for managerName, makeManager := range map[string]func() jasper.Manager{
-		"Basic": jasper.NewLocalManager,
+	for managerName, makeManager := range map[string]func(trackProcs bool) (jasper.Manager, error){
+		"Basic":    jasper.NewLocalManager,
 		"Blocking": jasper.NewLocalManagerBlockingProcesses,
 	} {
 		t.Run(managerName, func(t *testing.T) {
@@ -125,7 +125,8 @@ func TestRPCService(t *testing.T) {
 					output := "foobar"
 					opts := jasper.CreateOptions{Args: []string{"echo", output}}
 
-					manager := makeManager()
+					manager, err := makeManager(false)
+					require.NoError(t, err)
 					addr, err := startRPC(ctx, manager)
 					require.NoError(t, err)
 

--- a/signal.go
+++ b/signal.go
@@ -56,7 +56,7 @@ func TerminateAll(ctx context.Context, procs []Process) error {
 }
 
 // KillAll sends a SIGKILL signal to each of the given processes under the
-// given context. This guarantees that each process will actually die.  This
+// given context. This guarantees that each process will actually die. This
 // function calls Wait() on each process after sending them SIGKILL signals. On
 // Windows, this function does not send a SIGKILL signal, but will Wait() on
 // each process until it exits. Use Kill() in a loop if you do not wish to

--- a/subprocess_windows.go
+++ b/subprocess_windows.go
@@ -61,10 +61,10 @@ const (
 	EVENT_MODIFY_STATE = 0x0002
 
 	// Constants representing the wait return value
-	WAIT_OBJECT_0  = 0x00000000
-	WAIT_ABANDONED = 0x00000080
-	WAIT_FAILED    = 0xFFFFFFFF
-	WAIT_TIMEOUT   = 0x00000102
+	WAIT_OBJECT_0  uint32 = 0x00000000
+	WAIT_ABANDONED        = 0x00000080
+	WAIT_FAILED           = 0xFFFFFFFF
+	WAIT_TIMEOUT          = 0x00000102
 
 	// Max allowed length of process ID list
 	MAX_PROCESS_ID_LIST_LENGTH = 1000

--- a/subprocess_windows.go
+++ b/subprocess_windows.go
@@ -272,20 +272,21 @@ func SetInformationJobObjectExtended(job syscall.Handle, info JobObjectExtendedL
 	return nil
 }
 
-func WaitForSingleObject(object syscall.Handle, timeout time.Duration) (uintptr, error) {
+func WaitForSingleObject(object syscall.Handle, timeout time.Duration) (uint32, error) {
 	timeoutMillis := int64(timeout * time.Millisecond)
 	r1, _, e1 := procWaitForSingleObject.Call(
 		uintptr(object),
 		uintptr(uint32(timeoutMillis)),
 	)
-	if r1 == WAIT_FAILED {
+	waitEvent := uint32(r1)
+	if waitEvent == WAIT_FAILED {
 		if e1 != ERROR_SUCCESS {
-			return r1, e1
+			return waitEvent, e1
 		} else {
-			return r1, syscall.EINVAL
+			return waitEvent, syscall.EINVAL
 		}
 	}
-	return r1, nil
+	return waitEvent, nil
 }
 
 func OpenEvent(name string) (syscall.Handle, error) {

--- a/subprocess_windows.go
+++ b/subprocess_windows.go
@@ -1,0 +1,363 @@
+package jasper
+
+import (
+	"fmt"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// TODO: needs some documentation.
+
+const (
+	ERROR_SUCCESS syscall.Errno = 0
+
+	DELETE                   = 0x00010000
+	READ_CONTROL             = 0x00020000
+	WRITE_DAC                = 0x00040000
+	WRITE_OWNER              = 0x00080000
+	SYNCHRONIZE              = 0x00100000
+	STANDARD_RIGHTS_REQUIRED = 0x000F0000
+	STANDARD_RIGHTS_READ     = READ_CONTROL
+	STANDARD_RIGHTS_WRITE    = READ_CONTROL
+	STANDARD_RIGHTS_EXECUTE  = READ_CONTROL
+	STANDARD_RIGHTS_ALL      = 0x001F0000
+	SPECIFIC_RIGHTS_ALL      = 0x0000FFFF
+	ACCESS_SYSTEM_SECURITY   = 0x01000000
+	MAXIMUM_ALLOWED          = 0x02000000
+
+	// Constants for process permissions
+	PROCESS_TERMINATE                 = 0x0001
+	PROCESS_CREATE_THREAD             = 0x0002
+	PROCESS_SET_SESSIONID             = 0x0004
+	PROCESS_VM_OPERATION              = 0x0008
+	PROCESS_VM_READ                   = 0x0010
+	PROCESS_VM_WRITE                  = 0x0020
+	PROCESS_DUP_HANDLE                = 0x0040
+	PROCESS_CREATE_PROCESS            = 0x0080
+	PROCESS_SET_QUOTA                 = 0x0100
+	PROCESS_SET_INFORMATION           = 0x0200
+	PROCESS_QUERY_INFORMATION         = 0x0400
+	PROCESS_SUSPEND_RESUME            = 0x0800
+	PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+	PROCESS_ALL_ACCESS                = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFFF
+
+	// Constants for job object limits
+	JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE          = 0x2000
+	JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION = 0x400
+	JOB_OBJECT_LIMIT_ACTIVE_PROCESS             = 8
+	JOB_OBJECT_LIMIT_JOB_MEMORY                 = 0x200
+	JOB_OBJECT_LIMIT_JOB_TIME                   = 4
+	JOB_OBJECT_LIMIT_PROCESS_MEMORY             = 0x100
+	JOB_OBJECT_LIMIT_PROCESS_TIME               = 2
+	JOB_OBJECT_LIMIT_WORKINGSET                 = 1
+	JOB_OBJECT_LIMIT_AFFINITY                   = 0x00000010
+
+	JobObjectInfoClassNameBasicProcessIdList       = 3
+	JobObjectInfoClassNameExtendedLimitInformation = 9
+
+	// Constants for access rights for event objects
+	EVENT_ALL_ACCESS   = 0x1F0003
+	EVENT_MODIFY_STATE = 0x0002
+
+	// Constants representing the wait return value
+	WAIT_OBJECT_0  = 0x00000000
+	WAIT_ABANDONED = 0x00000080
+	WAIT_FAILED    = 0xFFFFFFFF
+	WAIT_TIMEOUT   = 0x00000102
+
+	// Max allowed length of process ID list
+	MAX_PROCESS_ID_LIST_LENGTH = 1000
+)
+
+var (
+	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+	modadvapi32 = syscall.NewLazyDLL("advapi32.dll")
+
+	procAssignProcessToJobObject  = modkernel32.NewProc("AssignProcessToJobObject")
+	procCloseHandle               = modkernel32.NewProc("CloseHandle")
+	procCreateJobObjectW          = modkernel32.NewProc("CreateJobObjectW")
+	procOpenEvent                 = modkernel32.NewProc("OpenEventW")
+	procSetEvent                  = modkernel32.NewProc("SetEvent")
+	procOpenProcess               = modkernel32.NewProc("OpenProcess")
+	procQueryInformationJobObject = modkernel32.NewProc("QueryInformationJobObject")
+	procTerminateJobObject        = modkernel32.NewProc("TerminateJobObject")
+	procSetInformationJobObject   = modkernel32.NewProc("SetInformationJobObject")
+	procWaitForSingleObject       = modkernel32.NewProc("WaitForSingleObject")
+)
+
+type Job struct {
+	handle syscall.Handle
+}
+
+func NewJob(name string) (*Job, error) {
+	hJob, err := CreateJobObject(syscall.StringToUTF16Ptr(name))
+	if err != nil {
+		return nil, NewWindowsError("CreateJobObject", err)
+	}
+
+	if err := SetInformationJobObjectExtended(hJob, JobObjectExtendedLimitInformation{
+		BasicLimitInformation: JobObjectBasicLimitInformation{
+			LimitFlags: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}); err != nil {
+		return nil, NewWindowsError("SetInformationJobObject", err)
+	}
+
+	return &Job{handle: hJob}, nil
+}
+
+func (j *Job) AssignProcess(pid uint) error {
+	hProcess, err := OpenProcess(PROCESS_ALL_ACCESS, false, uint32(pid))
+	if err != nil {
+		return NewWindowsError("OpenProcess", err)
+	}
+	defer CloseHandle(hProcess)
+	if err := AssignProcessToJobObject(j.handle, hProcess); err != nil {
+		return NewWindowsError("AssignProcessToJobObject", err)
+	}
+	return nil
+}
+
+func (j *Job) Terminate(exitCode uint) error {
+	if err := TerminateJobObject(j.handle, uint32(exitCode)); err != nil {
+		return NewWindowsError("TerminateJobObject", err)
+	}
+	return nil
+}
+
+func (j *Job) Close() error {
+	if j.handle != 0 {
+		if err := CloseHandle(j.handle); err != nil {
+			return NewWindowsError("CloseHandle", err)
+		}
+		j.handle = 0
+	}
+	return nil
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+//
+// All the methods below are boilerplate functions for accessing the Windows syscalls.
+//
+///////////////////////////////////////////////////////////////////////////////////////////
+
+type IoCounters struct {
+	ReadOperationCount  uint64
+	WriteOperationCount uint64
+	OtherOperationCount uint64
+	ReadTransferCount   uint64
+	WriteTransferCount  uint64
+	OtherTransferCount  uint64
+}
+
+type JobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit uint64
+	PerJobUserTimeLimit     uint64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+type JobObjectExtendedLimitInformation struct {
+	BasicLimitInformation JobObjectBasicLimitInformation
+	IoInfo                IoCounters
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+func OpenProcess(desiredAccess uint32, inheritHandle bool, processId uint32) (syscall.Handle, error) {
+	var inheritHandleRaw int32
+	if inheritHandle {
+		inheritHandleRaw = 1
+	} else {
+		inheritHandleRaw = 0
+	}
+	r1, _, e1 := procOpenProcess.Call(
+		uintptr(desiredAccess),
+		uintptr(inheritHandleRaw),
+		uintptr(processId))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return 0, e1
+		} else {
+			return 0, syscall.EINVAL
+		}
+	}
+	return syscall.Handle(r1), nil
+}
+
+func CreateJobObject(name *uint16) (syscall.Handle, error) {
+	jobAttributes := &struct {
+		Length             uint32
+		SecurityDescriptor *byte
+		InheritHandle      int32
+	}{}
+
+	r1, _, e1 := procCreateJobObjectW.Call(
+		uintptr(unsafe.Pointer(jobAttributes)),
+		uintptr(unsafe.Pointer(name)))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return 0, e1
+		} else {
+			return 0, syscall.EINVAL
+		}
+	}
+	return syscall.Handle(r1), nil
+}
+
+func AssignProcessToJobObject(job syscall.Handle, process syscall.Handle) error {
+	r1, _, e1 := procAssignProcessToJobObject.Call(uintptr(job), uintptr(process))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return e1
+		} else {
+			return syscall.EINVAL
+		}
+	}
+	return nil
+}
+
+func QueryInformationJobObjectProcessIdList(job syscall.Handle) (*JobObjectBasicProcessIdList, error) {
+	info := JobObjectBasicProcessIdList{}
+	_, err := QueryInformationJobObject(
+		job,
+		JobObjectInfoClassNameBasicProcessIdList,
+		unsafe.Pointer(&info),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func QueryInformationJobObject(job syscall.Handle, infoClass uint32, info unsafe.Pointer, length uint32) (uint32, error) {
+	var nLength uint32
+	r1, _, e1 := procQueryInformationJobObject.Call(
+		uintptr(job),
+		uintptr(infoClass),
+		uintptr(info),
+		uintptr(length),
+		uintptr(unsafe.Pointer(&nLength)),
+	)
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return 0, e1
+		} else {
+			return 0, syscall.EINVAL
+		}
+	}
+	return nLength, nil
+}
+
+func SetInformationJobObjectExtended(job syscall.Handle, info JobObjectExtendedLimitInformation) error {
+	r1, _, e1 := procSetInformationJobObject.Call(uintptr(job), JobObjectInfoClassNameExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uintptr(uint32(unsafe.Sizeof(info))))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return e1
+		} else {
+			return syscall.EINVAL
+		}
+	}
+	return nil
+}
+
+func WaitForSingleObject(object syscall.Handle, timeout time.Duration) (uintptr, error) {
+	timeoutMillis := int64(timeout * time.Millisecond)
+	r1, _, e1 := procWaitForSingleObject.Call(
+		uintptr(object),
+		uintptr(uint32(timeoutMillis)),
+	)
+	if r1 == WAIT_FAILED {
+		if e1 != ERROR_SUCCESS {
+			return r1, e1
+		} else {
+			return r1, syscall.EINVAL
+		}
+	}
+	return r1, nil
+}
+
+func OpenEvent(name string) (syscall.Handle, error) {
+	r1, _, e1 := procOpenEvent.Call(
+		uintptr(EVENT_MODIFY_STATE),
+		uintptr(0),
+		uintptr(unsafe.Pointer(&name)),
+	)
+	handle := syscall.Handle(r1)
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return handle, e1
+		} else {
+			return handle, syscall.EINVAL
+		}
+	}
+	return handle, nil
+}
+
+func SetEvent(event syscall.Handle) error {
+	r1, _, e1 := procSetEvent.Call(uintptr(event))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return e1
+		} else {
+			return syscall.EINVAL
+		}
+	}
+	return nil
+}
+
+func TerminateJobObject(job syscall.Handle, exitCode uint32) error {
+	r1, _, e1 := procTerminateJobObject.Call(uintptr(job), uintptr(exitCode))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return e1
+		} else {
+			return syscall.EINVAL
+		}
+	}
+	return nil
+}
+
+func CloseHandle(object syscall.Handle) error {
+	r1, _, e1 := procCloseHandle.Call(uintptr(object))
+	if r1 == 0 {
+		if e1 != ERROR_SUCCESS {
+			return e1
+		} else {
+			return syscall.EINVAL
+		}
+	}
+	return nil
+}
+
+type WindowsError struct {
+	functionName string
+	innerError   error
+}
+
+func NewWindowsError(functionName string, innerError error) *WindowsError {
+	return &WindowsError{functionName, innerError}
+}
+
+func (self *WindowsError) FunctionName() string {
+	return self.functionName
+}
+
+func (self *WindowsError) InnerError() error {
+	return self.innerError
+}
+
+func (self *WindowsError) Error() string {
+	return fmt.Sprintf("gowin32: %s failed: %v", self.functionName, self.innerError)
+}

--- a/subprocess_windows_amd64.go
+++ b/subprocess_windows_amd64.go
@@ -1,0 +1,7 @@
+package jasper
+
+type JobObjectBasicProcessIdList struct {
+	NumberOfAssignedProcesses uint32
+	NumberOfProcessIdsInList  uint32
+	ProcessIdList             [MAX_PROCESS_ID_LIST_LENGTH]uint64
+}

--- a/tracker.go
+++ b/tracker.go
@@ -1,0 +1,12 @@
+package jasper
+
+// processTracker provides a way to logically group processes that
+// should be managed collectively. Implementation details are
+// platform-specific since each one has its own means of managing
+// groups of processes.
+type processTracker interface {
+	// add begins tracking a process identified by its PID.
+	add(pid uint) error
+	// cleanup terminates this group of processes.
+	cleanup() error
+}

--- a/tracker_darwin.go
+++ b/tracker_darwin.go
@@ -1,0 +1,17 @@
+package jasper
+
+// TODO
+
+type darwinProcessTracker struct{}
+
+func newProcessTracker(name string) (processTracker, error) {
+	return &darwinProcessTracker{}, nil
+}
+
+func (_ *darwinProcessTracker) add(_ uint) error {
+	return nil
+}
+
+func (_ *darwinProcessTracker) cleanup() error {
+	return nil
+}

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -1,0 +1,17 @@
+package jasper
+
+// TODO: implement
+
+type linuxProcessTracker struct{}
+
+func newProcessTracker(name string) (processTracker, error) {
+	return &linuxProcessTracker{}, nil
+}
+
+func (_ *linuxProcessTracker) add(pid uint) error {
+	return nil
+}
+
+func (_ *linuxProcessTracker) cleanup() error {
+	return nil
+}

--- a/tracker_windows.go
+++ b/tracker_windows.go
@@ -1,0 +1,28 @@
+package jasper
+
+import (
+	"github.com/mongodb/grip"
+)
+
+type windowsProcessTracker struct {
+	job *Job
+}
+
+func newProcessTracker(name string) (processTracker, error) {
+	job, err := NewJob(name)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsProcessTracker{job: job}, nil
+}
+
+func (t *windowsProcessTracker) add(pid uint) error {
+	return t.job.AssignProcess(pid)
+}
+
+func (t *windowsProcessTracker) cleanup() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.Add(t.job.Terminate(0))
+	catcher.Add(t.job.Close())
+	return catcher.Resolve()
+}

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -1,0 +1,105 @@
+// +build windows
+
+package jasper
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTracker() (*windowsProcessTracker, error) {
+	tracker, err := newProcessTracker("foo" + uuid.Must(uuid.NewV4()).String())
+	if err != nil {
+		return nil, err
+	}
+
+	windowsTracker, ok := tracker.(*windowsProcessTracker)
+	if !ok {
+		return nil, errors.New("not a Windows process tracker")
+	}
+	return windowsTracker, nil
+}
+
+func makeAndStartYesCommand(ctx context.Context) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, "yes", "yes")
+	err := cmd.Start()
+	return cmd, err
+}
+
+func TestWindowsProcessTracker(t *testing.T) {
+	for testName, testCase := range map[string]func(context.Context, *windowsProcessTracker){
+		"NewWindowsProcessTrackerCreatesJob": func(_ context.Context, tracker *windowsProcessTracker) {
+			info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, int(info.NumberOfAssignedProcesses))
+
+			assert.NoError(t, tracker.job.Close())
+		},
+		"AddProcessToTrackerAssignsPid": func(ctx context.Context, tracker *windowsProcessTracker) {
+			cmd1, err := makeAndStartYesCommand(ctx)
+			require.NoError(t, err)
+			pid1 := uint(cmd1.Process.Pid)
+			assert.NoError(t, tracker.add(pid1))
+
+			cmd2, err := makeAndStartYesCommand(ctx)
+			require.NoError(t, err)
+			pid2 := uint(cmd2.Process.Pid)
+			assert.NoError(t, tracker.add(pid2))
+
+			info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, int(info.NumberOfAssignedProcesses))
+			assert.Equal(t, info.ProcessIdList[0], uint64(pid1))
+			assert.Equal(t, info.ProcessIdList[1], uint64(pid2))
+
+			assert.NoError(t, tracker.job.Close())
+		},
+		"AddedProcessIsTerminatedOnCleanup": func(ctx context.Context, tracker *windowsProcessTracker) {
+			cmd, err := makeAndStartYesCommand(ctx)
+			require.NoError(t, err)
+			pid := uint(cmd.Process.Pid)
+
+			assert.NoError(t, tracker.add(pid))
+
+			info, err := QueryInformationJobObjectProcessIdList(tracker.job.handle)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, int(info.NumberOfAssignedProcesses))
+
+			procHandle, err := OpenProcess(PROCESS_ALL_ACCESS, false, uint32(pid))
+			assert.NoError(t, err)
+
+			assert.NoError(t, tracker.cleanup())
+
+			windowsWaitStatus, err := WaitForSingleObject(procHandle, 60*time.Second)
+			assert.NoError(t, err)
+			assert.Equal(t, uintptr(WAIT_OBJECT_0), windowsWaitStatus)
+			assert.NoError(t, CloseHandle(procHandle))
+
+			assert.NoError(t, cmd.Wait())
+			assert.NotNil(t, cmd.ProcessState)
+			waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+			assert.True(t, waitStatus.Exited())
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
+				"(although they will pass if locally run).")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tracker, err := makeTracker()
+			require.NoError(t, err)
+			require.NotNil(t, tracker)
+
+			testCase(ctx, tracker)
+		})
+	}
+}

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -5,6 +5,7 @@ package jasper
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -90,10 +91,12 @@ func TestWindowsProcessTracker(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			// TODO: since processes can only be associated with 1 job, support Windows process and create them
-			// with the CREATE_BREAKAWAY_FROM_JOB flag.
-			t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
-				"(although they will pass if locally run).")
+			if _, runningInEvgAgent := os.LookupEnv("EVR_TASK_ID"); runningInEvgAgent {
+				// TODO: since processes can only be associated with 1 job, support Windows process and create them
+				// with the CREATE_BREAKAWAY_FROM_JOB flag.
+				t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
+					"(although they will pass if locally run).")
+			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -90,8 +90,6 @@ func TestWindowsProcessTracker(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
-				"(although they will pass if locally run).")
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -99,7 +97,7 @@ func TestWindowsProcessTracker(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, tracker)
 
-			testCase(ctx, tracker)
+			testCase(ctx, t, tracker)
 		})
 	}
 }

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -90,6 +90,10 @@ func TestWindowsProcessTracker(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
+			// TODO: since processes can only be associated with 1 job, support Windows process and create them
+			// with the CREATE_BREAKAWAY_FROM_JOB flag.
+			t.Skip("Evergreen makes its own job object, so these will not pass in Evergreen tests",
+				"(although they will pass if locally run).")
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 

--- a/triggers.go
+++ b/triggers.go
@@ -39,7 +39,6 @@ type SignalTriggerSequence []SignalTrigger
 // It returns a boolean indicating whether or not the signal should
 // be skipped after executing all of the signal triggers.
 func (s SignalTriggerSequence) Run(info ProcessInfo, sig syscall.Signal) (skipSignal bool) {
-	skipSignal = false
 	for _, trigger := range s {
 		skipSignal = skipSignal || trigger(info, sig)
 	}

--- a/triggers.go
+++ b/triggers.go
@@ -25,13 +25,25 @@ func (s ProcessTriggerSequence) Run(info ProcessInfo) {
 	}
 }
 
-type SignalTrigger func(ProcessInfo, syscall.Signal)
+// SignalTrigger describes the way to write hooks that will execute
+// before a process is about to be signaled. It returns a bool
+// indicating if the signal should be skipped after execution of the
+// trigger.
+type SignalTrigger func(ProcessInfo, syscall.Signal) (skipSignal bool)
+
+// SignalTriggerSequence is a convenience type to simplify running
+// more than one signal trigger.
 type SignalTriggerSequence []SignalTrigger
 
-func (s SignalTriggerSequence) Run(info ProcessInfo, sig syscall.Signal) {
+// Run loops over signal triggers and calls each of them successively.
+// It returns a boolean indicating whether or not the signal should
+// be skipped after executing all of the signal triggers.
+func (s SignalTriggerSequence) Run(info ProcessInfo, sig syscall.Signal) (skipSignal bool) {
+	skipSignal = false
 	for _, trigger := range s {
-		trigger(info, sig)
+		skipSignal = skipSignal || trigger(info, sig)
 	}
+	return
 }
 
 func makeOptionsCloseTrigger() ProcessTrigger {
@@ -69,7 +81,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 					continue
 				}
 				p.Tag(parentID)
-				p.RegisterTrigger(ctx, func(_ ProcessInfo) { cancel() })
+				_ = p.RegisterTrigger(ctx, func(_ ProcessInfo) { cancel() })
 			}
 		case info.Successful:
 			for _, opt := range opts.OnSuccess {

--- a/triggers_windows.go
+++ b/triggers_windows.go
@@ -21,8 +21,6 @@ const (
 // shutdown event and waiting for the process to return.
 func makeMongodShutdownSignalTrigger() SignalTrigger {
 	return func(info ProcessInfo, sig syscall.Signal) (skipSignal bool) {
-		skipSignal = false
-
 		// Only run if the program is mongod.
 		if len(info.Options.Args) == 0 || !strings.Contains(filepath.Base(info.Options.Args[0]), "mongod") {
 			return
@@ -51,15 +49,6 @@ func makeMongodShutdownSignalTrigger() SignalTrigger {
 			grip.Errorf(errors.Wrapf(err, "failed to signal event '%s'", eventName).Error())
 			return
 		}
-
-		mongodProc, err := OpenProcess(PROCESS_ALL_ACCESS, false, uint32(pid))
-		if err != nil {
-			grip.Errorf(errors.Wrapf(err, "failed to get process handle for pid %d", pid).Error())
-			return
-		}
-		defer CloseHandle(mongodProc)
-
-		grip.Infof("mongod with pid %d received termination signal %d and was cleanly shut down", pid, sig)
 		return true
 	}
 }

--- a/triggers_windows.go
+++ b/triggers_windows.go
@@ -47,7 +47,7 @@ func makeMongodShutdownSignalTrigger() SignalTrigger {
 
 		if err := SetEvent(event); err != nil {
 			grip.Errorf(errors.Wrapf(err, "failed to signal event '%s'", eventName).Error())
-			return
+			return false
 		}
 
 		return true

--- a/triggers_windows.go
+++ b/triggers_windows.go
@@ -1,0 +1,65 @@
+package jasper
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+const (
+	// The name for the mongod termination event has the format "Global\Mongo_<pid>".
+	mongodShutdownEventNamePrefix = "Global\\Mongo_"
+	mongodShutdownEventTimeout    = 60 * time.Second
+)
+
+// makeMongodEventTrigger is necessary to support clean termination of mongods on Windows by signaling the mongod
+// shutdown event and waiting for the process to return.
+func makeMongodShutdownSignalTrigger() SignalTrigger {
+	return func(info ProcessInfo, sig syscall.Signal) (skipSignal bool) {
+		skipSignal = false
+
+		// Only run if the program is mongod.
+		if len(info.Options.Args) == 0 || !strings.Contains(filepath.Base(info.Options.Args[0]), "mongod") {
+			return
+		}
+		// Only care about termination signals.
+		if sig != syscall.SIGKILL && sig != syscall.SIGTERM {
+			return
+		}
+
+		pid := info.PID
+		eventName := mongodShutdownEventNamePrefix + strconv.Itoa(pid)
+		utf16EventName, err := syscall.UTF16PtrFromString(eventName)
+		if err != nil {
+			grip.Errorf(errors.Wrapf(err, "failed to convert mongod shutdown event name '%s'", eventName).Error())
+			return
+		}
+
+		event, err := OpenEvent(utf16EventName)
+		if err != nil {
+			grip.Errorf(errors.Wrapf(err, "failed to open event '%s'", eventName).Error())
+			return
+		}
+		defer CloseHandle(event)
+
+		if err := SetEvent(event); err != nil {
+			grip.Errorf(errors.Wrapf(err, "failed to signal event '%s'", eventName).Error())
+			return
+		}
+
+		mongodProc, err := OpenProcess(PROCESS_ALL_ACCESS, false, uint32(pid))
+		if err != nil {
+			grip.Errorf(errors.Wrapf(err, "failed to get process handle for pid %d", pid).Error())
+			return
+		}
+		defer CloseHandle(mongodProc)
+
+		grip.Infof("mongod with pid %d received termination signal %d and was cleanly shut down", pid, sig)
+		return true
+	}
+}

--- a/triggers_windows_test.go
+++ b/triggers_windows_test.go
@@ -1,0 +1,84 @@
+// +build windows
+
+package jasper
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const mongodStartupTime = 15 * time.Second
+
+func TestMongodShutdownEventTrigger(t *testing.T) {
+	for procName, makeProc := range map[string]processConstructor{
+		"Basic":    newBasicProcess,
+		"Blocking": newBlockingProcess,
+	} {
+		t.Run(procName, func(t *testing.T) {
+			for testName, testParams := range map[string]struct {
+				signal               syscall.Signal
+				useMongod            bool
+				expectCleanTerminate bool
+			}{
+				"WithSIGTERMAndMongod":           {signal: syscall.SIGTERM, useMongod: true, expectCleanTerminate: true},
+				"WithSIGKILLAndMongod":           {signal: syscall.SIGKILL, useMongod: true, expectCleanTerminate: true},
+				"WithNonTerminationAndMongod":    {signal: syscall.SIGHUP, useMongod: true, expectCleanTerminate: false},
+				"WithSIGTERMAndNonMongod":        {signal: syscall.SIGTERM, useMongod: false, expectCleanTerminate: false},
+				"WithSIGKILLAndNonMongod":        {signal: syscall.SIGKILL, useMongod: false, expectCleanTerminate: false},
+				"WithNonTerminationAndNonMongod": {signal: syscall.SIGHUP, useMongod: false, expectCleanTerminate: false},
+			} {
+				t.Run(testName, func(t *testing.T) {
+					if testing.Short() {
+						t.Skip("skipping mongod shutdown tests in short mode")
+					}
+
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+
+					var opts CreateOptions
+					if testParams.useMongod {
+						dir, mongodPath := downloadMongoDB(t)
+						defer os.RemoveAll(dir)
+
+						optslist, dbPaths, err := setupMongods(1, mongodPath)
+						require.NoError(t, err)
+						defer removeDBPaths(dbPaths)
+						require.Equal(t, 1, len(optslist))
+
+						opts = optslist[0]
+						opts.Output.Loggers = []Logger{Logger{Type: LogDefault, Options: LogOptions{Format: LogFormatPlain}}}
+					} else {
+						opts = yesCreateOpts(0)
+					}
+
+					proc, err := makeProc(ctx, &opts)
+					require.NoError(t, err)
+
+					if testParams.useMongod {
+						// Give mongod time to start up and create the termination event.
+						time.Sleep(mongodStartupTime)
+					}
+
+					trigger := makeMongodShutdownSignalTrigger()
+					trigger(proc.Info(ctx), testParams.signal)
+
+					if testParams.expectCleanTerminate {
+						exitCode, err := proc.Wait(ctx)
+						assert.NoError(t, err)
+						assert.Zero(t, exitCode)
+						assert.False(t, proc.Running(ctx))
+					} else {
+						assert.True(t, proc.Running(ctx))
+						assert.NoError(t, proc.Signal(ctx, syscall.SIGKILL))
+					}
+				})
+			}
+		})
+	}
+}

--- a/vendor/github.com/mongodb/grip/message/composer_test.go
+++ b/vendor/github.com/mongodb/grip/message/composer_test.go
@@ -183,17 +183,17 @@ func TestStackMessages(t *testing.T) {
 	assert := assert.New(t) // nolint
 	// map objects to output (prefix)
 	cases := map[Composer]string{
-		NewStack(1, testMsg):                testMsg,
-		NewStackLines(1, testMsg):           testMsg,
-		NewStackLines(1):                    "",
-		NewStackFormatted(1, "%s", testMsg): testMsg,
+		NewStack(1, testMsg):                                       testMsg,
+		NewStackLines(1, testMsg):                                  testMsg,
+		NewStackLines(1):                                           "",
+		NewStackFormatted(1, "%s", testMsg):                        testMsg,
 		NewStackFormatted(1, string(testMsg[0])+"%s", testMsg[1:]): testMsg,
 
 		// with 0 frame
-		NewStack(0, testMsg):                testMsg,
-		NewStackLines(0, testMsg):           testMsg,
-		NewStackLines(0):                    "",
-		NewStackFormatted(0, "%s", testMsg): testMsg,
+		NewStack(0, testMsg):                                       testMsg,
+		NewStackLines(0, testMsg):                                  testMsg,
+		NewStackLines(0):                                           "",
+		NewStackFormatted(0, "%s", testMsg):                        testMsg,
 		NewStackFormatted(0, string(testMsg[0])+"%s", testMsg[1:]): testMsg,
 	}
 

--- a/vendor/github.com/tychoish/lru/makefile
+++ b/vendor/github.com/tychoish/lru/makefile
@@ -62,9 +62,9 @@ $(buildDir)/.lintSetup:$(lintDeps)
 # userfacing targets for basic build and development operations
 lint:$(buildDir)/output.lint
 build:$(deps) $(srcFiles) $(gopath)/src/$(projectPath)
-	$(vendorGopath) go build ./
+	go build ./
 build-race:$(deps) $(srcFiles) $(gopath)/src/$(projectPath)
-	$(vendorGopath) go build -race $(subst -,/,$(foreach pkg,$(packages),./$(pkg)))
+	go build -race $(subst -,/,$(foreach pkg,$(packages),./$(pkg)))
 test:$(testOutput)
 race:$(raceOutput)
 coverage:$(coverageOutput)
@@ -88,9 +88,9 @@ $(gopath)/src/$(projectPath):$(gopath)/src/$(orgPath)
 $(name):$(buildDir)/$(name)
 	@[ -L $@ ] || ln -s $< $@
 $(buildDir)/$(name):$(gopath)/src/$(projectPath) $(srcFiles) $(deps)
-	$(vendorGopath) go build -o $@ main/$(name).go
+	go build -o $@ main/$(name).go
 $(buildDir)/$(name).race:$(gopath)/src/$(projectPath) $(srcFiles) $(deps)
-	$(vendorGopath) go build -race -o $@ main/$(name).go
+	go build -race -o $@ main/$(name).go
 # end main build
 
 
@@ -121,75 +121,31 @@ coverDeps := golang.org/x/tools/cmd/cover
 coverDeps := $(addprefix $(gopath)/src/,$(coverDeps))
 #    implementation for package coverage and test running,mongodb to produce
 #    and save test output.
-$(buildDir)/test.%:$(testSrcFiles) $(coverDeps)
-	$(vendorGopath) go test $(if $(DISABLE_COVERAGE),,-covermode=count) -c -o $@ ./$(subst -,/,$*)
-$(buildDir)/race.%:$(testSrcFiles)
-	$(vendorGopath) go test -race -c -o $@ ./$(subst -,/,$*)
-#  targets to run any tests in the top-level package
-$(buildDir)/test.$(name):$(testSrcFiles) $(coverDeps)
-	$(vendorGopath) go test $(if $(DISABLE_COVERAGE),,-covermode=count) -c -o $@ ./
-$(buildDir)/race.$(name):$(testSrcFiles)
-	$(vendorGopath) go test -race -c -o $@ ./
-#  targets to run the tests and report the output
-$(buildDir)/output.%.test:$(buildDir)/test.% .FORCE
-	$(testRunEnv) ./$< $(testArgs) 2>&1 | tee $@
-$(buildDir)/output.%.race:$(buildDir)/race.% .FORCE
-	$(testRunEnv) ./$< $(testArgs) 2>&1 | tee $@
-#  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(testSrcFiles) .FORCE
-	@./$< --output=$@ --lintArgs='$(lintArgs)' --packages='$*'
-$(buildDir)/output.lint:$(buildDir)/run-linter .FORCE
-	@./$< --output="$@" --lintArgs='$(lintArgs)' --packages="$(packages)"
-#  targets to process and generate coverage reports
-$(buildDir)/output.%.coverage:$(buildDir)/test.% .FORCE $(coverDeps)
-	$(testRunEnv) ./$< $(testArgs) -test.coverprofile=$@ | tee $(subst coverage,test,$@)
+$(buildDir)/coverage.%.html:$(buildDir)/coverage.%.out
+	go tool cover -html=$(buildDir)/coverage.$(subst /,-,$*).out -o $(buildDir)/coverage.$(subst /,-,$*).html
+$(buildDir)/coverage.%.out:$(testRunDeps)
+	go test $(testArgs) -covermode=count -coverprofile=$(buildDir)/coverage.$(subst /,-,$*).out $(projectPath)/$(subst -,/,$*)
+	@-[ -f $(buildDir)/coverage.$(subst /,-,$*).out ] && go tool cover -func=$(buildDir)/coverage.$(subst /,-,$*).out | sed 's%$(projectPath)/%%' | column -t
+$(buildDir)/coverage.$(name).out:$(testRunDeps)
+	go test -covermode=count -coverprofile=$@ $(projectPath)
 	@-[ -f $@ ] && go tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage $(coverDeps)
-	$(vendorGopath) go tool cover -html=$< -o $@
+$(buildDir)/test.%.out:$(testRunDeps)
+	go test $(testArgs) ./$(subst -,/,$*) | tee $(buildDir)/test.$(subst /,-,$*).out
+$(buildDir)/race.%.out:$(testRunDeps)
+	go test $(testArgs) -race ./$(subst -,/,$*) | tee $(buildDir)/race.$(subst /,-,$*).out
+$(buildDir)/test.$(name).out:$(testRunDeps)
+	go test $(testArgs) ./ | tee $@
+$(buildDir)/race.$(name).out:$(testRunDeps)
+	go test $(testArgs) -race ./ | tee $@
 # end test and coverage artifacts
 
 
 # start vendoring configuration
-#    begin with configuration of dependencies
-vendorDeps := github.com/Masterminds/glide
-vendorDeps := $(addprefix $(gopath)/src/,$(vendorDeps))
-vendor-deps:$(vendorDeps)
-#   this allows us to store our vendored code in vendor and use
-#   symlinks to support vendored code both in the legacy style and with
-#   new-style vendor directories. When this codebase can drop support
-#   for go1.4, we can delete most of this.
--include $(buildDir)/makefile.vendor
-nestedVendored := vendor/github.com/mongodb/grip
-nestedVendored := $(foreach project,$(nestedVendored),$(project)/build/vendor)
-$(buildDir)/makefile.vendor:$(buildDir)/render-gopath makefile
-	@mkdir -p $(buildDir)
-	@echo "vendorGopath := \$$(shell \$$(buildDir)/render-gopath $(nestedVendored))" >| $@
-#   targets for the directory components and manipulating vendored files.
-vendor-sync:$(vendorDeps)
-	glide install -s
 vendor-clean:
 	rm -rf vendor/gopkg.in/mgo.v2/harness/
 	rm -rf vendor/github.com/stretchr/testify/vendor/
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -f
-change-go-version:
-	rm -rf $(buildDir)/make-vendor $(buildDir)/render-gopath
-	@$(MAKE) $(makeArgs) vendor > /dev/null 2>&1
-vendor:$(buildDir)/vendor/src
-	$(MAKE) $(makeArgs) -C vendor/github.com/mongodb/grip $@
-$(buildDir)/vendor/src:$(buildDir)/make-vendor $(buildDir)/render-gopath
-	@./$(buildDir)/make-vendor
-#   targets to build the small programs used to support vendoring.
-$(buildDir)/make-vendor:buildscripts/make-vendor.go
-	@mkdir -p $(buildDir)
-	go build -o $@ $<
-$(buildDir)/render-gopath:buildscripts/render-gopath.go
-	@mkdir -p $(buildDir)
-	go build -o $@ $<
-#   define dependencies for buildscripts
-buildscripts/make-vendor.go:buildscripts/vendoring/vendoring.go
-buildscripts/render-gopath.go:buildscripts/vendoring/vendoring.go
-#   add phony targets
-phony += vendor vendor-deps vendor-clean vendor-sync change-go-version
+phony += vendor-clean
 # end vendoring tooling configuration
 
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-638
https://jira.mongodb.org/browse/MAKE-659
## Changes
* Write wrappers for Windows API calls for events and job objects. Some of the job object stuff is taken from Evergreen's existing subprocess.
* Write an interface for platform-specific process tracking and unit tests for it.
    * All of the implementations are stubs for now aside from Windows, will be implemented later.
* Add process tracker to `basicProcessManager`.
* Windows process tracker keeps 1 job object per manager instance with a flag to create the manager with/without a job object for the processes.
* Wrote signal trigger to cleanly shut down mongod and tests.
* Trivial spellchecking

## Some questions:
* Would it be better to put this in its own subpackage to avoid messiness?
* Should process tracking support contexts (i.e. should process tracking functions be able to time out and cancel)?
* The Windows process tracking tests are skipped in Evergreen due to the agent making its own job objects. I can try fiddling with it to make the tests pass by ensuring processes break away from the Evergreen agent job, but I don't know if this is a worthwhile investment of time. They pass on Windows spawn hosts.