### PR TITLE
MAKE-670: make (*CreateOptions) Close() consistent with other close functions

### DIFF
--- a/command.go
+++ b/command.go
@@ -217,12 +217,7 @@ func (c *Command) RunParallel(ctx context.Context) error {
 
 // Close closes this command and its resources.
 func (c *Command) Close() error {
-	catcher := grip.NewBasicCatcher()
-	for _, closer := range c.opts.closers {
-		catcher.Add(closer())
-	}
-
-	return catcher.Resolve()
+	return c.opts.Close()
 }
 
 // SetErrorSender sets a Sender to be used by this Command for its output to

--- a/create_test.go
+++ b/create_test.go
@@ -175,7 +175,7 @@ func TestCreateOptions(t *testing.T) {
 				func() (_ error) { counter++; return },
 				func() (_ error) { counter += 2; return },
 			)
-			opts.Close()
+			assert.NoError(t, opts.Close())
 			assert.Equal(t, counter, 3)
 
 		},
@@ -367,7 +367,7 @@ func TestFileLogging(t *testing.T) {
 			require.NoError(t, cmd.Start())
 
 			cmd.Wait()
-			opts.Close()
+			assert.NoError(t, opts.Close())
 
 			for _, file := range files {
 				info, err := file.Stat()

--- a/manager_local.go
+++ b/manager_local.go
@@ -45,7 +45,7 @@ func (m *localProcessManager) Create(ctx context.Context, opts *CreateOptions) (
 		return nil, errors.WithStack(err)
 	}
 
-	proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
+	_ = proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
 
 	proc = &localProcess{proc: proc}
 	m.manager.procs[proc.ID()] = proc

--- a/triggers.go
+++ b/triggers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
 )
 
 // ProcessTrigger describes the way to write cleanup functions for
@@ -47,7 +48,9 @@ func (s SignalTriggerSequence) Run(info ProcessInfo, sig syscall.Signal) (skipSi
 
 func makeOptionsCloseTrigger() ProcessTrigger {
 	return func(info ProcessInfo) {
-		info.Options.Close()
+		if err := info.Options.Close(); err != nil {
+			grip.Warning(errors.Wrap(err, "error occurred while closing options"))
+		}
 	}
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-670

## Changes
CreateOptions closers was changed in MAKE-624 so the functions now return errors. This just updates `(*CreateOptions) Close()` to propagate the errors. It also makes it more consistent with the other `Close()` functions.