### PR TITLE
MAKE-680: clone CreateOptions before spawning new processes with them

### DIFF
--- a/create.go
+++ b/create.go
@@ -192,9 +192,9 @@ func (opts *CreateOptions) Close() error {
 	return catcher.Resolve()
 }
 
-// Copy returns a copy of the exported fields in CreateOptions. The caller is
-// responsible for re-populating the unexported fields, which are cleared.
-func (opts *CreateOptions) CopyExported() *CreateOptions {
+// Copy returns a copy of the options for only the exported fields. Unexported
+// fields are cleared.
+func (opts *CreateOptions) Copy() *CreateOptions {
 	optsCopy := *opts
 
 	if opts.Args != nil {
@@ -229,7 +229,7 @@ func (opts *CreateOptions) CopyExported() *CreateOptions {
 		_ = copy(optsCopy.OnTimeout, opts.OnTimeout)
 	}
 
-	optsCopy.Output = *opts.Output.CopyExported()
+	optsCopy.Output = *opts.Output.Copy()
 
 	optsCopy.closers = nil
 	optsCopy.started = false

--- a/create.go
+++ b/create.go
@@ -16,6 +16,7 @@ import (
 
 // CreateOptions contains options related to starting a process. This includes
 // execution configuration, post-execution triggers, and output configuration.
+// It is not safe for concurrent access.
 type CreateOptions struct {
 	Args             []string          `json:"args"`
 	Environment      map[string]string `json:"env,omitempty"`
@@ -30,7 +31,6 @@ type CreateOptions struct {
 	OnFailure        []*CreateOptions  `json:"on_failure"`
 	OnTimeout        []*CreateOptions  `json:"on_timeout"`
 
-	//
 	closers []func() error
 	started bool
 }
@@ -190,4 +190,49 @@ func (opts *CreateOptions) Close() error {
 		catcher.Add(c())
 	}
 	return catcher.Resolve()
+}
+
+// Copy returns a copy of the exported fields in CreateOptions. The caller is
+// responsible for re-populating the unexported fields, which are cleared.
+func (opts *CreateOptions) CopyExported() *CreateOptions {
+	optsCopy := *opts
+
+	if opts.Args != nil {
+		optsCopy.Args = make([]string, len(opts.Args))
+		_ = copy(optsCopy.Args, opts.Args)
+	}
+
+	if opts.Tags != nil {
+		optsCopy.Tags = make([]string, len(opts.Tags))
+		_ = copy(optsCopy.Tags, opts.Tags)
+	}
+
+	if opts.Environment != nil {
+		optsCopy.Environment = make(map[string]string)
+		for key, val := range opts.Environment {
+			optsCopy.Environment[key] = val
+		}
+	}
+
+	if opts.OnSuccess != nil {
+		optsCopy.OnSuccess = make([]*CreateOptions, len(opts.OnSuccess))
+		_ = copy(optsCopy.OnSuccess, opts.OnSuccess)
+	}
+
+	if opts.OnFailure != nil {
+		optsCopy.OnFailure = make([]*CreateOptions, len(opts.OnFailure))
+		_ = copy(optsCopy.OnFailure, opts.OnFailure)
+	}
+
+	if opts.OnTimeout != nil {
+		optsCopy.OnTimeout = make([]*CreateOptions, len(opts.OnTimeout))
+		_ = copy(optsCopy.OnTimeout, opts.OnTimeout)
+	}
+
+	optsCopy.Output = *opts.Output.CopyExported()
+
+	optsCopy.closers = nil
+	optsCopy.started = false
+
+	return &optsCopy
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -84,7 +84,7 @@ func TestManagerInterface(t *testing.T) {
 					proc, err := manager.CreateProcess(ctx, opts)
 					assert.NoError(t, err)
 					assert.NotNil(t, proc)
-					assert.True(t, opts.started)
+					assert.True(t, proc.Info(ctx).Options.started)
 				},
 				"CreateProcessFails": func(ctx context.Context, t *testing.T, manager Manager) {
 					proc, err := manager.CreateProcess(ctx, &CreateOptions{})

--- a/output.go
+++ b/output.go
@@ -412,9 +412,9 @@ func (o *OutputOptions) GetError() (io.Writer, error) {
 	return o.errorMulti, nil
 }
 
-// CopyExported returns a copy of the options for only the exported fields.
-// Unexported fields are cleared.
-func (o *OutputOptions) CopyExported() *OutputOptions {
+// Copy returns a copy of the options for only the exported fields. Unexported
+// fields are cleared.
+func (o *OutputOptions) Copy() *OutputOptions {
 	optsCopy := *o
 
 	optsCopy.outputSender = nil

--- a/output.go
+++ b/output.go
@@ -411,3 +411,21 @@ func (o *OutputOptions) GetError() (io.Writer, error) {
 
 	return o.errorMulti, nil
 }
+
+// CopyExported returns a copy of the options for only the exported fields.
+// Unexported fields are cleared.
+func (o *OutputOptions) CopyExported() *OutputOptions {
+	optsCopy := *o
+
+	optsCopy.outputSender = nil
+	optsCopy.errorSender = nil
+	optsCopy.outputMulti = nil
+	optsCopy.errorMulti = nil
+
+	if o.Loggers != nil {
+		optsCopy.Loggers = make([]Logger, len(o.Loggers))
+		_ = copy(optsCopy.Loggers, o.Loggers)
+	}
+
+	return &optsCopy
+}

--- a/process_basic.go
+++ b/process_basic.go
@@ -152,7 +152,7 @@ func (p *basicProcess) Respawn(ctx context.Context) (Process, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	optsCopy := p.info.Options.CopyExported()
+	optsCopy := p.info.Options.Copy()
 	return newBasicProcess(ctx, optsCopy)
 }
 

--- a/process_basic.go
+++ b/process_basic.go
@@ -52,9 +52,8 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 		return nil, errors.Wrap(err, "problem registering options closer trigger")
 	}
 
-	err = cmd.Start()
-	if err != nil {
-		return nil, errors.Wrap(err, "problem creating command")
+	if err = cmd.Start(); err != nil {
+		return nil, errors.Wrap(err, "problem starting command")
 	}
 
 	p.info.ID = p.id
@@ -152,10 +151,8 @@ func (p *basicProcess) Respawn(ctx context.Context) (Process, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	opts := p.info.Options
-	opts.closers = []func() error{}
-
-	return newBasicProcess(ctx, &opts)
+	optsCopy := p.info.Options.CopyExported()
+	return newBasicProcess(ctx, optsCopy)
 }
 
 func (p *basicProcess) Wait(ctx context.Context) (int, error) {

--- a/process_basic.go
+++ b/process_basic.go
@@ -60,9 +60,11 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 	p.info.Options = p.opts
 	p.info.Host = p.opts.Hostname
 
-	go p.transition(ctx, cmd)
-
+	p.info.Options.started = true
+	p.opts.started = true
 	opts.started = true
+
+	go p.transition(ctx, cmd)
 
 	return p, nil
 }
@@ -79,7 +81,6 @@ func (p *basicProcess) transition(ctx context.Context, cmd *exec.Cmd) {
 		p.Lock()
 		defer p.Unlock()
 		defer close(p.initialized)
-		p.opts.started = true
 		p.info.IsRunning = true
 		p.info.PID = p.cmd.Process.Pid
 		p.cmd = cmd

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -346,7 +346,7 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 
 func (p *blockingProcess) Respawn(ctx context.Context) (Process, error) {
 	opts := p.Info(ctx).Options
-	optsCopy := opts.CopyExported()
+	optsCopy := opts.Copy()
 	return newBlockingProcess(ctx, optsCopy)
 }
 

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -58,6 +58,7 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 		return nil, errors.Wrap(err, "problem starting command")
 	}
 
+	p.info.Options.started = true
 	p.opts.started = true
 	opts.started = true
 

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -345,11 +345,8 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 
 func (p *blockingProcess) Respawn(ctx context.Context) (Process, error) {
 	opts := p.Info(ctx).Options
-	opts.closers = []func() error{}
-
-	newProc, err := newBlockingProcess(ctx, &opts)
-
-	return newProc, err
+	optsCopy := opts.CopyExported()
+	return newBlockingProcess(ctx, optsCopy)
 }
 
 func (p *blockingProcess) Tag(t string) {

--- a/process_test.go
+++ b/process_test.go
@@ -409,7 +409,8 @@ func TestProcessImplementations(t *testing.T) {
 					require.NoError(t, err)
 
 					newProc, err := proc.Respawn(ctx)
-					assert.NoError(t, err)
+					require.NoError(t, err)
+					require.NotNil(t, newProc)
 					_, err = newProc.Wait(ctx)
 					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)
@@ -421,7 +422,8 @@ func TestProcessImplementations(t *testing.T) {
 					require.NotNil(t, proc)
 
 					newProc, err := proc.Respawn(ctx)
-					assert.NoError(t, err)
+					require.NoError(t, err)
+					require.NotNil(t, newProc)
 					_, err = newProc.Wait(ctx)
 					require.NoError(t, err)
 					assert.True(t, newProc.Info(ctx).Successful)

--- a/rpc/internal/jasper.ext.go
+++ b/rpc/internal/jasper.ext.go
@@ -10,7 +10,8 @@ import (
 )
 
 // Export takes a protobuf RPC CreateOptions struct and returns the analogous
-// Jasper CreateOptions struct.
+// Jasper CreateOptions struct. It is not safe to concurrently access the
+// exported RPC CreateOptions and the returned Jasper CreateOptions.
 func (opts *CreateOptions) Export() *jasper.CreateOptions {
 	out := &jasper.CreateOptions{
 		Args:             opts.Args,
@@ -41,7 +42,9 @@ func (opts *CreateOptions) Export() *jasper.CreateOptions {
 
 // ConvertCreateOptions takes a Jasper CreateOptions struct and returns an
 // equivalent protobuf RPC *CreateOptions struct. ConvertCreateOptions is the
-// inverse of (*CreateOptions) Export().
+// inverse of (*CreateOptions) Export(). It is not safe to concurrently
+// access the converted Jasper CreateOptions and the returned RPC
+// CreateOptions.
 func ConvertCreateOptions(opts *jasper.CreateOptions) *CreateOptions {
 	if opts.TimeoutSecs == 0 && opts.Timeout != 0 {
 		opts.TimeoutSecs = int(opts.Timeout.Seconds())

--- a/triggers.go
+++ b/triggers.go
@@ -85,7 +85,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 					newctx, cancel = context.WithCancel(ctx)
 				}
 
-				p, err := m.CreateProcess(newctx, opt.CopyExported())
+				p, err := m.CreateProcess(newctx, opt.Copy())
 				if err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"trigger": "on-timeout",
@@ -99,7 +99,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 			}
 		case info.Successful:
 			for _, opt := range opts.OnSuccess {
-				p, err := m.CreateProcess(ctx, opt.CopyExported())
+				p, err := m.CreateProcess(ctx, opt.Copy())
 				if err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"trigger": "on-success",
@@ -111,7 +111,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 			}
 		case !info.Successful:
 			for _, opt := range opts.OnFailure {
-				p, err := m.CreateProcess(ctx, opt.CopyExported())
+				p, err := m.CreateProcess(ctx, opt.Copy())
 				if err != nil {
 
 					grip.Warning(message.WrapError(err, message.Fields{

--- a/triggers.go
+++ b/triggers.go
@@ -12,7 +12,8 @@ import (
 
 // ProcessTrigger describes the way to write cleanup functions for
 // processes, which provide ways of adding behavior to processes after
-// they complete.
+// they complete. A ProcessTrigger can read the fields within
+// ProcessInfo.Options but should not mutate them.
 type ProcessTrigger func(ProcessInfo)
 
 // ProcessTriggerSequence is simply a convenience type to simplify
@@ -29,7 +30,8 @@ func (s ProcessTriggerSequence) Run(info ProcessInfo) {
 // SignalTrigger describes the way to write hooks that will execute
 // before a process is about to be signaled. It returns a bool
 // indicating if the signal should be skipped after execution of the
-// trigger.
+// trigger. A SignalTrigger can read the fields within ProcessInfo.Options but
+// should not mutate them.
 type SignalTrigger func(ProcessInfo, syscall.Signal) (skipSignal bool)
 
 // SignalTriggerSequence is a convenience type to simplify running
@@ -83,7 +85,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 					newctx, cancel = context.WithCancel(ctx)
 				}
 
-				p, err := m.CreateProcess(newctx, opt)
+				p, err := m.CreateProcess(newctx, opt.CopyExported())
 				if err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"trigger": "on-timeout",
@@ -97,7 +99,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 			}
 		case info.Successful:
 			for _, opt := range opts.OnSuccess {
-				p, err := m.CreateProcess(ctx, opt)
+				p, err := m.CreateProcess(ctx, opt.CopyExported())
 				if err != nil {
 					grip.Warning(message.WrapError(err, message.Fields{
 						"trigger": "on-success",
@@ -109,7 +111,7 @@ func makeDefaultTrigger(ctx context.Context, m Manager, opts *CreateOptions, par
 			}
 		case !info.Successful:
 			for _, opt := range opts.OnFailure {
-				p, err := m.CreateProcess(ctx, opt)
+				p, err := m.CreateProcess(ctx, opt.CopyExported())
 				if err != nil {
 
 					grip.Warning(message.WrapError(err, message.Fields{

--- a/triggers_test.go
+++ b/triggers_test.go
@@ -34,7 +34,7 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.Len(t, out, 1)
 			_, err = out[0].Wait(ctx)
 			assert.NoError(t, err)
-			assert.True(t, tcmd.started)
+			assert.True(t, out[0].Info(ctx).Options.started)
 		},
 		"OneOnSuccess": func(ctx context.Context, t *testing.T, manager Manager) {
 			opts := trueCreateOpts()
@@ -46,6 +46,7 @@ func TestDefaultTrigger(t *testing.T) {
 			out, err := manager.List(ctx, All)
 			assert.NoError(t, err)
 			assert.Len(t, out, 1)
+			assert.True(t, out[0].Info(ctx).Options.started)
 		},
 		"FailureTriggerDoesNotWorkWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager) {
 			cctx, cancel := context.WithCancel(ctx)
@@ -102,7 +103,7 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.Len(t, out, 1)
 			_, err = out[0].Wait(ctx)
 			assert.NoError(t, err)
-			assert.True(t, tcmd.started)
+			assert.True(t, out[0].Info(ctx).Options.started)
 		},
 		"TimeoutWithoutTimeout": func(ctx context.Context, t *testing.T, manager Manager) {
 			opts := falseCreateOpts()
@@ -117,7 +118,7 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.Len(t, out, 1)
 			_, err = out[0].Wait(ctx)
 			assert.NoError(t, err)
-			assert.True(t, tcmd.started)
+			assert.True(t, out[0].Info(ctx).Options.started)
 		},
 		"TimeoutWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager) {
 			cctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-680

## Changes
* Added copy function.
* Copied all CreateOptions in any place that spawns new processes.
* Added more documentation for CreateOptions.