### PR TITLE
MAKE-681: fix potential hang until context is done in blocking process if the process finishes while an operation is waiting to be processed.

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -300,15 +300,14 @@ func TestCommandImplementation(t *testing.T) {
 	}
 }
 
-// TODO: fix failure due to context deadline exceeded.
 func TestRunParallelRunsInParallel(t *testing.T) {
 	cmd := NewCommand().Extend([][]string{
 		[]string{"sleep", "3"},
 		[]string{"sleep", "3"},
 		[]string{"sleep", "3"},
 	})
-	threePointTwoSeconds := time.Second*3 + time.Millisecond*200
-	maxRunTimeAllowed := threePointTwoSeconds
+	threePointFiveSeconds := time.Second*3 + time.Millisecond*500
+	maxRunTimeAllowed := threePointFiveSeconds
 	cctx, cancel := context.WithTimeout(context.Background(), maxRunTimeAllowed)
 	defer cancel()
 	// If this does not run in parallel, the context will timeout and we will

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -45,7 +45,7 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 		opts:     *opts,
 		tags:     make(map[string]struct{}),
 		ops:      make(chan func(*exec.Cmd)),
-		complete: make(chan struct{}, 0),
+		complete: make(chan struct{}),
 	}
 
 	for _, t := range opts.Tags {

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -17,10 +17,11 @@ import (
 )
 
 type blockingProcess struct {
-	id   string
-	opts CreateOptions
-	ops  chan func(*exec.Cmd)
-	err  error
+	id       string
+	opts     CreateOptions
+	ops      chan func(*exec.Cmd)
+	complete chan struct{}
+	err      error
 
 	mu             sync.RWMutex
 	tags           map[string]struct{}
@@ -40,10 +41,11 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 	}
 
 	p := &blockingProcess{
-		id:   id,
-		opts: *opts,
-		tags: make(map[string]struct{}),
-		ops:  make(chan func(*exec.Cmd)),
+		id:       id,
+		opts:     *opts,
+		tags:     make(map[string]struct{}),
+		ops:      make(chan func(*exec.Cmd)),
+		complete: make(chan struct{}, 0),
 	}
 
 	for _, t := range opts.Tags {
@@ -113,6 +115,7 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 		defer close(signal)
 		signal <- cmd.Wait()
 	}()
+	defer close(p.complete)
 
 	for {
 		select {
@@ -191,8 +194,12 @@ func (p *blockingProcess) Info(ctx context.Context) ProcessInfo {
 			return res
 		case <-ctx.Done():
 			return p.getInfo()
+		case <-p.complete:
+			return p.getInfo()
 		}
 	case <-ctx.Done():
+		return p.getInfo()
+	case <-p.complete:
 		return p.getInfo()
 	}
 }
@@ -221,9 +228,18 @@ func (p *blockingProcess) Running(ctx context.Context) bool {
 
 	select {
 	case p.ops <- operation:
-		return <-out
+		select {
+		case res := <-out:
+			return res
+		case <-ctx.Done():
+			return p.getInfo().IsRunning
+		case <-p.complete:
+			return p.getInfo().IsRunning
+		}
 	case <-ctx.Done():
-		return false
+		return p.getInfo().IsRunning
+	case <-p.complete:
+		return p.getInfo().IsRunning
 	}
 }
 
@@ -261,9 +277,13 @@ func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error 
 			return res
 		case <-ctx.Done():
 			return errors.New("context canceled")
+		case <-p.complete:
+			return errors.New("cannot signal after process is complete")
 		}
 	case <-ctx.Done():
 		return errors.New("context canceled")
+	case <-p.complete:
+		return errors.New("cannot signal after process is complete")
 	}
 }
 
@@ -335,10 +355,8 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 			return -1, errors.New("wait operation canceled")
 		case err := <-out:
 			return p.getInfo().ExitCode, errors.WithStack(err)
-		default:
-			if p.hasCompleteInfo() {
-				return p.getInfo().ExitCode, p.getErr()
-			}
+		case <-p.complete:
+			return p.getInfo().ExitCode, p.getErr()
 		}
 	}
 }

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -187,7 +187,7 @@ func TestBlockingProcess(t *testing.T) {
 				},
 				"WaitSomeBeforeCanceling": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
 					proc.opts.Args = []string{"sleep", "1"}
-					proc.complete = make(chan struct{}, 0)
+					proc.complete = make(chan struct{})
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const gracefulTimeout = 1000 * time.Millisecond
@@ -186,6 +187,7 @@ func TestBlockingProcess(t *testing.T) {
 				},
 				"WaitSomeBeforeCanceling": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
 					proc.opts.Args = []string{"sleep", "1"}
+					proc.complete = make(chan struct{}, 0)
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 
@@ -296,6 +298,86 @@ func TestBlockingProcess(t *testing.T) {
 						}
 					}()
 					<-signal
+				},
+				"InfoDoesNotWaitForContextTimeoutAfterProcessCompletes": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
+					opts := &CreateOptions{
+						Args: []string{"ls"},
+					}
+
+					process, err := newBlockingProcess(ctx, opts)
+					require.NoError(t, err)
+
+					opCompleted := make(chan struct{})
+
+					go func() {
+						defer close(opCompleted)
+						_ = process.Info(ctx)
+					}()
+
+					_, err = process.Wait(ctx)
+					require.NoError(t, err)
+
+					longCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+					defer cancel()
+
+					select {
+					case <-opCompleted:
+					case <-longCtx.Done():
+						assert.Fail(t, "context timed out waiting for op to return")
+					}
+				},
+				"RunningDoesNotWaitForContextTimeoutAfterProcessCompletes": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
+					opts := &CreateOptions{
+						Args: []string{"ls"},
+					}
+
+					process, err := newBlockingProcess(ctx, opts)
+					require.NoError(t, err)
+
+					opCompleted := make(chan struct{})
+
+					go func() {
+						defer close(opCompleted)
+						_ = process.Running(ctx)
+					}()
+
+					_, err = process.Wait(ctx)
+					require.NoError(t, err)
+
+					longCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+					defer cancel()
+
+					select {
+					case <-opCompleted:
+					case <-longCtx.Done():
+						assert.Fail(t, "context timed out waiting for op to return")
+					}
+				},
+				"SignalDoesNotWaitForContextTimeoutAfterProcessCompletes": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
+					opts := &CreateOptions{
+						Args: []string{"ls"},
+					}
+
+					process, err := newBlockingProcess(ctx, opts)
+					require.NoError(t, err)
+
+					opCompleted := make(chan struct{})
+
+					go func() {
+						defer close(opCompleted)
+						_ = process.Signal(ctx, syscall.SIGKILL)
+					}()
+
+					_, _ = process.Wait(ctx)
+
+					longCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+					defer cancel()
+
+					select {
+					case <-opCompleted:
+					case <-longCtx.Done():
+						assert.Fail(t, "context timed out waiting for op to return")
+					}
 				},
 				// "": func(ctx context.Context, t *testing.T, proc *blockingProcess) {},
 			} {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-681

## Changes
* Blocking process operations (e.g. `Info()`) won't wait until context is done if the `ops` channel stops processing operations (when `reactor` returns).