### PR TITLE
MAKE-673: ensure triggers run before the process is marked as complete

### DIFF
--- a/process_blocking.go
+++ b/process_blocking.go
@@ -151,11 +151,9 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 				}))
 			}()
 
+			p.triggers.Run(info)
 			p.setErr(err)
 			p.setInfo(info)
-			p.mu.RLock()
-			p.triggers.Run(info)
-			p.mu.RUnlock()
 			return
 		case <-ctx.Done():
 			// note, the process might take a moment to
@@ -165,8 +163,8 @@ func (p *blockingProcess) reactor(ctx context.Context, cmd *exec.Cmd) {
 			info.IsRunning = false
 			info.Successful = false
 
-			p.setInfo(info)
 			p.triggers.Run(info)
+			p.setInfo(info)
 			return
 		case op := <-p.ops:
 			if op != nil {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-673

This test was failing because triggers run after the process state is considered complete (so the loggers are not flushed until after the process is complete).