### PR TITLE
MAKE-707: add more usable constructor for RPC server/client

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"runtime"
 	"strings"
 	"syscall"
@@ -19,7 +21,7 @@ import (
 
 func TestRPCManager(t *testing.T) {
 	assert.NotPanics(t, func() {
-		NewClient(nil)
+		newRPCManager(nil)
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -27,12 +29,14 @@ func TestRPCManager(t *testing.T) {
 
 	for mname, factory := range map[string]func(ctx context.Context, t *testing.T) jasper.Manager{
 		"Basic": func(ctx context.Context, t *testing.T) jasper.Manager {
-			mngr, err := jasper.NewLocalManager(false)
-			require.NoError(t, err)
-			addr, err := startRPC(ctx, mngr)
+			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
 			require.NoError(t, err)
 
-			client, err := getClient(ctx, addr)
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
+			require.NoError(t, err)
+
+			require.NoError(t, startTestServer(ctx, mngr, addr))
+			client, err := newTestClient(ctx, addr)
 			require.NoError(t, err)
 
 			return client
@@ -40,10 +44,12 @@ func TestRPCManager(t *testing.T) {
 		"Blocking": func(ctx context.Context, t *testing.T) jasper.Manager {
 			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
 			require.NoError(t, err)
-			addr, err := startRPC(ctx, mngr)
+
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
 			require.NoError(t, err)
 
-			client, err := getClient(ctx, addr)
+			require.NoError(t, startTestServer(ctx, mngr, addr))
+			client, err := newTestClient(ctx, addr)
 			require.NoError(t, err)
 
 			return client
@@ -247,7 +253,6 @@ func TestRPCManager(t *testing.T) {
 					require.NoError(t, jasper.Terminate(ctx, sleepProc)) // Clean up
 				},
 				// "": func(ctx context.Context, t *testing.T, manager jasper.Manager) {},
-				// "": func(ctx context.Context, t *testing.T, manager jasper.Manager) {},
 
 				///////////////////////////////////
 				//
@@ -313,35 +318,43 @@ func TestRPCProcess(t *testing.T) {
 	for cname, makeProc := range map[string]processConstructor{
 		"Basic": func(ctx context.Context, opts *jasper.CreateOptions) (jasper.Process, error) {
 			mngr, err := jasper.NewLocalManager(false)
-			require.NoError(t, err)
-			addr, err := startRPC(ctx, mngr)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			if err := startTestServer(ctx, mngr, addr); err != nil {
+				return nil, errors.WithStack(err)
+			}
 
-			client, err := getClient(ctx, addr)
+			client, err := newTestClient(ctx, addr)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
 
 			return client.CreateProcess(ctx, opts)
-
 		},
 		"Blocking": func(ctx context.Context, opts *jasper.CreateOptions) (jasper.Process, error) {
 			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
-			require.NoError(t, err)
-			addr, err := startRPC(ctx, mngr)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			if err := startTestServer(ctx, mngr, addr); err != nil {
+				return nil, errors.WithStack(err)
+			}
 
-			client, err := getClient(ctx, addr)
+			client, err := newTestClient(ctx, addr)
 			if err != nil {
 				return nil, errors.WithStack(err)
 			}
 
 			return client.CreateProcess(ctx, opts)
-
 		},
 	} {
 		t.Run(cname, func(t *testing.T) {

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -29,7 +29,7 @@ func TestRPCManager(t *testing.T) {
 
 	for mname, factory := range map[string]func(ctx context.Context, t *testing.T) jasper.Manager{
 		"Basic": func(ctx context.Context, t *testing.T) jasper.Manager {
-			mngr, err := jasper.NewLocalManagerBlockingProcesses(false)
+			mngr, err := jasper.NewLocalManager(false)
 			require.NoError(t, err)
 
 			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -1,10 +1,14 @@
 package rpc
 
 import (
+	"context"
+	"net"
+
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/rpc/internal"
 	"github.com/pkg/errors"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // AttachService attaches the jasper GRPC server to the given manager. After
@@ -12,4 +16,36 @@ import (
 // over GRPC to the Jasper GRPC server.
 func AttachService(manager jasper.Manager, s *grpc.Server) error {
 	return errors.WithStack(internal.AttachService(manager, s))
+}
+
+// CloseFunc is a function used to close the service or client.
+type CloseFunc func() error
+
+// StartServer starts an RPC server with the specified address. If certFile
+// and keyFile are non-empty, the credentials will be read from the files to
+// start a TLS service; otherwise it will start an insecure service. The caller
+// is responsible for closing the connection using the returned CloseFunc.
+func StartServer(ctx context.Context, manager jasper.Manager, address net.Addr, certFile string, keyFile string) (CloseFunc, error) {
+	lis, err := net.Listen(address.Network(), address.String())
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var service *grpc.Server
+	if certFile != "" && keyFile != "" {
+		creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get server credentials from cert file '%s' and key file '%s'", certFile, keyFile)
+		}
+		service = grpc.NewServer(grpc.Creds(creds))
+	} else {
+		service = grpc.NewServer()
+	}
+
+	if err := AttachService(manager, service); err != nil {
+		return nil, errors.Wrap(err, "could not attach manager to service")
+	}
+	go service.Serve(lis)
+
+	return func() error { service.Stop(); return nil }, nil
 }

--- a/rpc/service_test.go
+++ b/rpc/service_test.go
@@ -2,7 +2,9 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -162,10 +164,11 @@ func TestRPCService(t *testing.T) {
 
 					manager, err := makeManager(false)
 					require.NoError(t, err)
-					addr, err := startRPC(ctx, manager)
+					addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
 					require.NoError(t, err)
+					require.NoError(t, startTestServer(ctx, manager, addr))
 
-					conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
+					conn, err := grpc.DialContext(ctx, addr.String(), grpc.WithInsecure(), grpc.WithBlock())
 					require.NoError(t, err)
 					client := internal.NewJasperProcessManagerClient(conn)
 

--- a/rpc/service_windows_test.go
+++ b/rpc/service_windows_test.go
@@ -51,7 +51,7 @@ func TestWindowsRPCService(t *testing.T) {
 					require.NoError(t, err)
 					require.NoError(t, startTestServer(ctx, manager, addr))
 
-					conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
+					conn, err := grpc.DialContext(ctx, addr.String(), grpc.WithInsecure(), grpc.WithBlock())
 					require.NoError(t, err)
 					client := internal.NewJasperProcessManagerClient(conn)
 

--- a/rpc/service_windows_test.go
+++ b/rpc/service_windows_test.go
@@ -2,6 +2,8 @@ package rpc
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"syscall"
 	"testing"
 
@@ -45,8 +47,9 @@ func TestWindowsRPCService(t *testing.T) {
 
 					manager, err := makeManager(false)
 					require.NoError(t, err)
-					addr, err := startRPC(ctx, manager)
+					addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", getPortNumber()))
 					require.NoError(t, err)
+					require.NoError(t, startTestServer(ctx, manager, addr))
 
 					conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithBlock())
 					require.NoError(t, err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-707

* Add option to specify TLS credentials.