### PR TITLE
MAKE-756: change CreateOption semantics in Command to set Environment and WorkingDirectory on remote command being executed rather than local SSH command

### DIFF
--- a/create.go
+++ b/create.go
@@ -119,9 +119,7 @@ func (opts *CreateOptions) Resolve(ctx context.Context) (*exec.Cmd, error) {
 		env = os.Environ()
 	}
 
-	for k, v := range opts.Environment {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
+	env = append(env, opts.getEnvSlice()...)
 
 	var args []string
 	if len(opts.Args) > 1 {
@@ -172,6 +170,16 @@ func (opts *CreateOptions) Resolve(ctx context.Context) (*exec.Cmd, error) {
 	})
 
 	return cmd, nil
+}
+
+// getEnvSlice returns the (CreateOptions).Environment as a slice of environment
+// variables in the form "key=value".
+func (opts *CreateOptions) getEnvSlice() []string {
+	env := []string{}
+	for k, v := range opts.Environment {
+		env = append(env, fmt.Sprintf("%s='%s'", k, v))
+	}
+	return env
 }
 
 // AddEnvVar adds an environment variable to the CreateOptions struct on which

--- a/create_test.go
+++ b/create_test.go
@@ -144,8 +144,8 @@ func TestCreateOptions(t *testing.T) {
 
 			cmd, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
-			assert.Contains(t, cmd.Env, "foo=bar")
-			assert.NotContains(t, cmd.Env, "bar=foo")
+			assert.Contains(t, cmd.Env, "foo='bar'")
+			assert.NotContains(t, cmd.Env, "bar='foo'")
 		},
 		"MultipleArgsArePropagated": func(t *testing.T, opts *CreateOptions) {
 			opts.Args = append(opts.Args, "-lha")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-756

* Environment and working directory are set for the remote command instead of the local SSH command.