### PR TITLE
MAKE-756: fix env due to shell interpretation

### DIFF
--- a/command.go
+++ b/command.go
@@ -56,12 +56,12 @@ func (c *Command) getRemoteCreateOpt(ctx context.Context, args []string) (*Creat
 
 	var remoteCmd string
 
-	if env := c.opts.getEnvSlice(); len(env) != 0 {
-		remoteCmd += strings.Join(env, " ") + "; "
-	}
-
 	if c.opts.WorkingDirectory != "" {
 		remoteCmd += fmt.Sprintf("cd '%s' && ", c.opts.WorkingDirectory)
+	}
+
+	if env := c.opts.getEnvSlice(); len(env) != 0 {
+		remoteCmd += strings.Join(env, " ") + " "
 	}
 
 	switch len(args) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-756

Okay, this one should actually allow a command to run over SSH with the environment. The previous commit didn't work due to how the command after the ssh args are interpreted.