### PR TITLE
MAKE-728: fix TestProcessDownloadJob timeout

### DIFF
--- a/download.go
+++ b/download.go
@@ -245,7 +245,7 @@ func processDownloadJobs(ctx context.Context, processFile func(string) error) fu
 				catcher.Add(errors.New("problem retrieving download job from queue"))
 				continue
 			}
-			if err := processFile(downloadJob.FileName); err != nil {
+			if err := processFile(filepath.Join(downloadJob.Directory, downloadJob.FileName)); err != nil {
 				catcher.Add(err)
 			}
 		}

--- a/download.go
+++ b/download.go
@@ -229,7 +229,7 @@ func createDownloadJobs(path string, urls <-chan string, catcher grip.Catcher) <
 func processDownloadJobs(ctx context.Context, processFile func(string) error) func(amboy.Queue) error {
 	return func(q amboy.Queue) error {
 		grip.Infof("waiting for %d download jobs to complete", q.Stats().Total)
-		if completed := amboy.WaitCtxInterval(ctx, q, 1000*time.Millisecond); !completed {
+		if !amboy.WaitCtxInterval(ctx, q, 1000*time.Millisecond) {
 			return errors.New("context cancelled before download job completed")
 		}
 		grip.Info("all download tasks complete, processing errors now")

--- a/download.go
+++ b/download.go
@@ -229,7 +229,9 @@ func createDownloadJobs(path string, urls <-chan string, catcher grip.Catcher) <
 func processDownloadJobs(ctx context.Context, processFile func(string) error) func(amboy.Queue) error {
 	return func(q amboy.Queue) error {
 		grip.Infof("waiting for %d download jobs to complete", q.Stats().Total)
-		_ = amboy.WaitCtxInterval(ctx, q, 1000*time.Millisecond)
+		if completed := amboy.WaitCtxInterval(ctx, q, 1000*time.Millisecond); !completed {
+			return errors.New("context cancelled before download job completed")
+		}
 		grip.Info("all download tasks complete, processing errors now")
 
 		if err := amboy.ResolveErrors(ctx, q); err != nil {

--- a/download_test.go
+++ b/download_test.go
@@ -163,10 +163,10 @@ func TestProcessDownloadJobs(t *testing.T) {
 	}
 	assert.NoError(t, catcher.Resolve())
 
-	_ = amboy.WaitCtxInterval(ctx, q, 100*time.Millisecond)
+	require.False(t, amboy.WaitCtxInterval(ctx, q, 100*time.Millisecond))
 	require.NoError(t, amboy.ResolveErrors(ctx, q))
 
-	assert.NoError(t, processDownloadJobs(ctx, addMongoDBFilesToCache(cache, absDir))(q))
+	require.NoError(t, processDownloadJobs(ctx, addMongoDBFilesToCache(cache, absDir))(q))
 
 	downloadedFiles := []string{}
 	filepath.Walk(absDir, func(path string, info os.FileInfo, err error) error {

--- a/download_test.go
+++ b/download_test.go
@@ -82,7 +82,7 @@ func TestSetupDownloadMongoDBReleasesFailsWithZeroOptions(t *testing.T) {
 	opts := MongoDBDownloadOptions{}
 	err := SetupDownloadMongoDBReleases(ctx, lru.NewCache(), opts)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "problem creating enclsoing directories")
+	assert.Contains(t, err.Error(), "problem creating enclosing directories")
 }
 
 func TestSetupDownloadMongoDBReleasesWithInvalidPath(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-728

* Timeout was because it had to download the entire mongo .tar.gz, which was taking a long time on Windows.