### PR TITLE
MAKE-736: detect when process has timed out

### DIFF
--- a/create.go
+++ b/create.go
@@ -25,12 +25,13 @@ type CreateOptions struct {
 	Output           OutputOptions     `json:"output"`
 	OverrideEnviron  bool              `json:"override_env,omitempty"`
 	TimeoutSecs      int               `json:"timeout_secs,omitempty"`
-	Timeout          time.Duration     `json:"-"`
-	Tags             []string          `json:"tags"`
-	OnSuccess        []*CreateOptions  `json:"on_success"`
-	OnFailure        []*CreateOptions  `json:"on_failure"`
-	OnTimeout        []*CreateOptions  `json:"on_timeout"`
-	StandardInput    io.Reader         `json:"-"`
+	// On remote interfaces, TimeoutSecs must be set instead of Timeout.
+	Timeout       time.Duration    `json:"-"`
+	Tags          []string         `json:"tags"`
+	OnSuccess     []*CreateOptions `json:"on_success"`
+	OnFailure     []*CreateOptions `json:"on_failure"`
+	OnTimeout     []*CreateOptions `json:"on_timeout"`
+	StandardInput io.Reader        `json:"-"`
 
 	closers []func() error
 }

--- a/create_test.go
+++ b/create_test.go
@@ -114,26 +114,26 @@ func TestCreateOptions(t *testing.T) {
 			assert.Error(t, opts.Validate())
 		},
 		"WorkingDirectoryUnresolveableShouldNotError": func(t *testing.T, opts *CreateOptions) {
-			cmd, err := opts.Resolve(ctx)
-			assert.NoError(t, err)
+			cmd, _, err := opts.Resolve(ctx)
+			require.NoError(t, err)
 			assert.NotNil(t, cmd)
 			assert.NotZero(t, cmd.Dir)
 			assert.Equal(t, opts.WorkingDirectory, cmd.Dir)
 		},
 		"ResolveFailsIfOptionsAreFatal": func(t *testing.T, opts *CreateOptions) {
 			opts.Args = []string{}
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.Error(t, err)
 			assert.Nil(t, cmd)
 		},
 		"WithoutOverrideEnvironmentEnvIsPopulated": func(t *testing.T, opts *CreateOptions) {
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
 			assert.NotZero(t, cmd.Env)
 		},
 		"WithOverrideEnvironmentEnvIsEmpty": func(t *testing.T, opts *CreateOptions) {
 			opts.OverrideEnviron = true
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
 			assert.Zero(t, cmd.Env)
 		},
@@ -142,20 +142,20 @@ func TestCreateOptions(t *testing.T) {
 				"foo": "bar",
 			}
 
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
 			assert.Contains(t, cmd.Env, "foo=bar")
 			assert.NotContains(t, cmd.Env, "bar=foo")
 		},
 		"MultipleArgsArePropagated": func(t *testing.T, opts *CreateOptions) {
 			opts.Args = append(opts.Args, "-lha")
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
 			assert.Contains(t, cmd.Path, "ls")
 			assert.Len(t, cmd.Args, 2)
 		},
 		"WithOnlyCommandsArgsHasOneVal": func(t *testing.T, opts *CreateOptions) {
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.NoError(t, err)
 			assert.Contains(t, cmd.Path, "ls")
 			assert.Len(t, cmd.Args, 1)
@@ -165,9 +165,38 @@ func TestCreateOptions(t *testing.T) {
 			opts.Timeout = time.Second
 			opts.Args = []string{"sleep", "2"}
 
-			cmd, err := opts.Resolve(ctx)
-			assert.NoError(t, err)
+			cmd, cmdCtx, err := opts.Resolve(ctx)
+			require.NoError(t, err)
+			assert.NoError(t, cmdCtx.Err())
 			assert.Error(t, cmd.Run())
+			assert.Error(t, cmdCtx.Err())
+		},
+		"ReturnedContextWrapsResolveContext": func(t *testing.T, opts *CreateOptions) {
+			opts = sleepCreateOpts(10)
+			opts.Timeout = 2 * time.Second
+			tctx, tcancel := context.WithTimeout(ctx, time.Millisecond)
+			defer tcancel()
+
+			cmd, cmdCtx, err := opts.Resolve(ctx)
+			require.NoError(t, err)
+			assert.Error(t, cmd.Run())
+			assert.Equal(t, context.DeadlineExceeded, tctx.Err())
+			assert.Equal(t, context.DeadlineExceeded, cmdCtx.Err())
+		},
+		"ReturnedContextErrorsOnTimeout": func(t *testing.T, opts *CreateOptions) {
+			opts = sleepCreateOpts(10)
+			opts.Timeout = time.Second
+			tctx, tcancel := context.WithTimeout(ctx, 5*time.Second)
+			defer tcancel()
+
+			start := time.Now()
+			cmd, cmdCtx, err := opts.Resolve(ctx)
+			require.NoError(t, err)
+			assert.Error(t, cmd.Run())
+			elapsed := time.Since(start)
+			assert.True(t, elapsed > opts.Timeout)
+			assert.NoError(t, tctx.Err())
+			assert.Equal(t, context.DeadlineExceeded, cmdCtx.Err())
 		},
 		"ClosersAreAlwaysCalled": func(t *testing.T, opts *CreateOptions) {
 			var counter int
@@ -201,14 +230,14 @@ func TestCreateOptions(t *testing.T) {
 		},
 		"ResolveFailsWithInvalidLoggingConfiguration": func(t *testing.T, opts *CreateOptions) {
 			opts.Output.Loggers = []Logger{Logger{Type: LogSumologic, Options: LogOptions{Format: LogFormatPlain}}}
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.Error(t, err)
 			assert.Nil(t, cmd)
 		},
 		"ResolveFailsWithInvalidErrorLoggingConfiguration": func(t *testing.T, opts *CreateOptions) {
 			opts.Output.Loggers = []Logger{Logger{Type: LogSumologic, Options: LogOptions{Format: LogFormatPlain}}}
 			opts.Output.SuppressOutput = true
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			assert.Error(t, err)
 			assert.Nil(t, cmd)
 		},
@@ -241,6 +270,7 @@ func TestFileLogging(t *testing.T) {
 
 	goodFileName := goodFile.Name()
 	numBytes, err := goodFile.Write([]byte(catOutputMessage))
+	require.NoError(t, err)
 	require.NotZero(t, numBytes)
 
 	type Command struct {
@@ -345,6 +375,7 @@ func TestFileLogging(t *testing.T) {
 				require.NoError(t, err)
 				defer os.Remove(file.Name())
 				info, err := file.Stat()
+				require.NoError(t, err)
 				assert.Zero(t, info.Size())
 				files = append(files, file)
 			}
@@ -362,7 +393,7 @@ func TestFileLogging(t *testing.T) {
 			}
 			opts.Args = testParams.command.args
 
-			cmd, err := opts.Resolve(ctx)
+			cmd, _, err := opts.Resolve(ctx)
 			require.NoError(t, err)
 			require.NoError(t, cmd.Start())
 

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -35,7 +35,7 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 	id := uuid.Must(uuid.NewV4()).String()
 	opts.AddEnvVar(EnvironID, id)
 
-	cmd, cmdCtx, err := opts.Resolve(ctx)
+	cmd, deadline, err := opts.Resolve(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "problem building command from options")
 	}
@@ -68,7 +68,7 @@ func newBlockingProcess(ctx context.Context, opts *CreateOptions) (Process, erro
 	}
 	p.info.Host, _ = os.Hostname()
 
-	go p.reactor(ctx, cmdCtx, cmd)
+	go p.reactor(ctx, deadline, cmd)
 
 	return p, nil
 }
@@ -106,7 +106,7 @@ func (p *blockingProcess) getErr() error {
 	return p.err
 }
 
-func (p *blockingProcess) reactor(ctx context.Context, cmdCtx context.Context, cmd *exec.Cmd) {
+func (p *blockingProcess) reactor(ctx context.Context, deadline time.Time, cmd *exec.Cmd) {
 	signal := make(chan error)
 	go func() {
 		defer close(signal)
@@ -118,6 +118,7 @@ func (p *blockingProcess) reactor(ctx context.Context, cmdCtx context.Context, c
 		select {
 		case err := <-signal:
 			var info ProcessInfo
+			finishTime := time.Now()
 
 			func() {
 				p.mu.RLock()
@@ -132,11 +133,14 @@ func (p *blockingProcess) reactor(ctx context.Context, cmdCtx context.Context, c
 					procWaitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
 					if procWaitStatus.Signaled() {
 						info.ExitCode = int(procWaitStatus.Signal())
-						info.Timeout = procWaitStatus.Signal() == syscall.SIGKILL && cmdCtx.Err() == context.DeadlineExceeded
+						if !deadline.IsZero() {
+							info.Timeout = procWaitStatus.Signal() == syscall.SIGKILL && finishTime.After(deadline)
+
+						}
 					} else {
 						info.ExitCode = procWaitStatus.ExitStatus()
-						if runtime.GOOS == "windows" {
-							info.Timeout = procWaitStatus.ExitStatus() == 1 && cmdCtx.Err() == context.DeadlineExceeded
+						if runtime.GOOS == "windows" && !deadline.IsZero() {
+							info.Timeout = procWaitStatus.ExitStatus() == 1 && finishTime.After(deadline)
 						}
 					}
 				} else {

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -132,11 +132,11 @@ func (p *blockingProcess) reactor(ctx context.Context, cmdCtx context.Context, c
 					procWaitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
 					if procWaitStatus.Signaled() {
 						info.ExitCode = int(procWaitStatus.Signal())
-						p.info.Timeout = procWaitStatus.Signal() == syscall.SIGKILL && cmdCtx.Err() == context.DeadlineExceeded
+						info.Timeout = procWaitStatus.Signal() == syscall.SIGKILL && cmdCtx.Err() == context.DeadlineExceeded
 					} else {
 						info.ExitCode = procWaitStatus.ExitStatus()
 						if runtime.GOOS == "windows" {
-							p.info.Timeout = procWaitStatus.ExitStatus() == 1 && cmdCtx.Err() == context.DeadlineExceeded
+							info.Timeout = procWaitStatus.ExitStatus() == 1 && cmdCtx.Err() == context.DeadlineExceeded
 						}
 					}
 				} else {
@@ -170,16 +170,6 @@ func (p *blockingProcess) reactor(ctx context.Context, cmdCtx context.Context, c
 			p.mu.RUnlock()
 			p.setInfo(info)
 			return
-		case <-cmdCtx.Done():
-			info := p.getInfo()
-			info.Complete = true
-			info.IsRunning = false
-			info.Successful = false
-
-			p.mu.RLock()
-			p.triggers.Run(info)
-			p.mu.RUnlock()
-			p.setInfo(info)
 		case op := <-p.ops:
 			if op != nil {
 				op(cmd)

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -191,11 +191,11 @@ func TestBlockingProcess(t *testing.T) {
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 
-					cmd, cmdCtx, err := proc.opts.Resolve(ctx)
+					cmd, deadline, err := proc.opts.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 
-					go proc.reactor(ctx, cmdCtx, cmd)
+					go proc.reactor(ctx, deadline, cmd)
 					_, err = proc.Wait(cctx)
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), "operation canceled")

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -191,11 +191,11 @@ func TestBlockingProcess(t *testing.T) {
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 
-					cmd, err := proc.opts.Resolve(ctx)
+					cmd, cmdCtx, err := proc.opts.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 
-					go proc.reactor(ctx, cmd)
+					go proc.reactor(ctx, cmdCtx, cmd)
 					_, err = proc.Wait(cctx)
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), "operation canceled")
@@ -204,7 +204,7 @@ func TestBlockingProcess(t *testing.T) {
 					proc.opts.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.opts.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})
@@ -236,7 +236,7 @@ func TestBlockingProcess(t *testing.T) {
 					proc.opts.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.opts.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})
@@ -269,7 +269,7 @@ func TestBlockingProcess(t *testing.T) {
 					proc.opts.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.opts.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})

--- a/process_test.go
+++ b/process_test.go
@@ -544,7 +544,11 @@ func TestProcessImplementations(t *testing.T) {
 
 					exitCode, err := proc.Wait(ctx)
 					assert.Error(t, err)
-					assert.Equal(t, int(syscall.SIGKILL), exitCode)
+					if runtime.GOOS == "windows" {
+						assert.Equal(t, 1, exitCode)
+					} else {
+						assert.Equal(t, int(syscall.SIGKILL), exitCode)
+					}
 					assert.True(t, proc.Info(ctx).Timeout)
 				},
 				// "": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep ProcessConstructor) {},

--- a/process_test.go
+++ b/process_test.go
@@ -535,6 +535,18 @@ func TestProcessImplementations(t *testing.T) {
 					}
 					require.NoError(t, Terminate(ctx, proc)) // Clean up.
 				},
+				"InfoHasTimeoutWhenProcessTimesOut": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep ProcessConstructor) {
+					opts = sleepCreateOpts(100)
+					opts.Timeout = time.Second
+					opts.TimeoutSecs = 1
+					proc, err := makep(ctx, opts)
+					require.NoError(t, err)
+
+					exitCode, err := proc.Wait(ctx)
+					assert.Error(t, err)
+					assert.Equal(t, int(syscall.SIGKILL), exitCode)
+					assert.True(t, proc.Info(ctx).Timeout)
+				},
 				// "": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep ProcessConstructor) {},
 			} {
 				t.Run(name, func(t *testing.T) {

--- a/rest_service.go
+++ b/rest_service.go
@@ -181,13 +181,7 @@ func (s *Service) createProcess(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var ctx context.Context
-	var cancel context.CancelFunc
-	if opts.Timeout > 0 {
-		ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
-	} else {
-		ctx, cancel = context.WithCancel(context.Background())
-	}
+	ctx, cancel := context.WithCancel(context.Background())
 
 	proc, err := s.manager.CreateProcess(ctx, opts)
 	if err != nil {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-736

* `ProcessInfo.Timeout` is set by processes when `exec.Command` is killed by timeout.
* Fixed minor bug in handling timeout on REST `CreateProcess()`.