### PR TITLE
MAKE-790: fix RunParallel race to append to procs

### DIFF
--- a/command.go
+++ b/command.go
@@ -325,9 +325,9 @@ func (c *Command) RunParallel(ctx context.Context) error {
 				if err != nil {
 					errs <- err
 				}
-				procs <- innerCmd.procs
 			}()
 			errs <- innerCmd.Run(ctx)
+			procs <- innerCmd.procs
 		}(parallelCmd)
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-790

* Fixes a race in `RunParallel` due to `Command.procs` being copied between Commands.