### PR TITLE
MAKE-767: remove recursive read lock in Signal

### DIFF
--- a/manager_self_clearing.go
+++ b/manager_self_clearing.go
@@ -20,7 +20,7 @@ type selfClearingProcessManager struct {
 //
 // The self clearing process manager is not thread safe. Wrap with the
 // local process manager for multithreaded use.
-// TODO: allow local process manager to wrap other managers.
+// TODO: MAKE-803: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, error) {
 	pm, err := newBasicProcessManager(map[string]Process{}, false, false, trackProcs)
 	if err != nil {
@@ -43,7 +43,7 @@ func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, erro
 //
 // The self clearing process manager is not thread safe. Wrap with the
 // local process manager for multithreaded use.
-// TODO: allow local process manager to wrap other managers.
+// TODO: MAKE-803: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManagerBlockingProcesses(maxProcs int, trackProcs bool) (Manager, error) {
 	pm, err := newBasicProcessManager(map[string]Process{}, false, true, trackProcs)
 	if err != nil {

--- a/manager_self_clearing.go
+++ b/manager_self_clearing.go
@@ -20,6 +20,7 @@ type selfClearingProcessManager struct {
 //
 // The self clearing process manager is not thread safe. Wrap with the
 // local process manager for multithreaded use.
+// TODO: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, error) {
 	pm, err := newBasicProcessManager(map[string]Process{}, false, false, trackProcs)
 	if err != nil {
@@ -42,6 +43,7 @@ func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, erro
 //
 // The self clearing process manager is not thread safe. Wrap with the
 // local process manager for multithreaded use.
+// TODO: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManagerBlockingProcesses(maxProcs int, trackProcs bool) (Manager, error) {
 	pm, err := newBasicProcessManager(map[string]Process{}, false, true, trackProcs)
 	if err != nil {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-767

* Deadlock was because a test attempted to send `SIGTERM` via `Process.Signal()` and recursively read lock the `RWMutex` in `basicProcess`.