### PR TITLE
MAKE-801: remove unnecessary locks from basic process

### DIFF
--- a/process_basic.go
+++ b/process_basic.go
@@ -23,7 +23,6 @@ type basicProcess struct {
 	triggers       ProcessTriggerSequence
 	signalTriggers SignalTriggerSequence
 	waitProcessed  chan struct{}
-	initialized    chan struct{}
 	sync.RWMutex
 }
 
@@ -42,7 +41,6 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 		cmd:           cmd,
 		tags:          make(map[string]struct{}),
 		waitProcessed: make(chan struct{}),
-		initialized:   make(chan struct{}),
 	}
 
 	for _, t := range opts.Tags {
@@ -61,6 +59,7 @@ func newBasicProcess(ctx context.Context, opts *CreateOptions) (Process, error) 
 	p.info.Options = p.opts
 	p.info.Host, _ = os.Hostname()
 	p.info.IsRunning = true
+	p.info.PID = cmd.Process.Pid
 
 	go p.transition(ctx, deadline, cmd)
 
@@ -74,16 +73,6 @@ func (p *basicProcess) transition(ctx context.Context, deadline time.Time, cmd *
 		defer close(waitFinished)
 		waitFinished <- cmd.Wait()
 	}()
-
-	initialize := func() {
-		p.Lock()
-		defer p.Unlock()
-		defer close(p.initialized)
-		p.info.IsRunning = true
-		p.info.PID = p.cmd.Process.Pid
-		p.cmd = cmd
-	}
-	initialize()
 
 	finish := func(err error) {
 		p.Lock()
@@ -112,13 +101,9 @@ func (p *basicProcess) transition(ctx context.Context, deadline time.Time, cmd *
 }
 
 func (p *basicProcess) ID() string {
-	p.RLock()
-	defer p.RUnlock()
-
 	return p.id
 }
 func (p *basicProcess) Info(_ context.Context) ProcessInfo {
-	<-p.initialized
 	p.RLock()
 	defer p.RUnlock()
 
@@ -130,14 +115,12 @@ func (p *basicProcess) Complete(_ context.Context) bool {
 }
 
 func (p *basicProcess) Running(_ context.Context) bool {
-	<-p.initialized
 	p.RLock()
 	defer p.RUnlock()
 	return p.info.IsRunning
 }
 
 func (p *basicProcess) Signal(_ context.Context, sig syscall.Signal) error {
-	<-p.initialized
 	p.RLock()
 	defer p.RUnlock()
 
@@ -153,7 +136,6 @@ func (p *basicProcess) Signal(_ context.Context, sig syscall.Signal) error {
 }
 
 func (p *basicProcess) Respawn(ctx context.Context) (Process, error) {
-	<-p.initialized
 	p.RLock()
 	defer p.RUnlock()
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-801

* Since a process's ID never changes after first initialization, it doesn't need a lock.
* Removed the initialize step from `(*basicProcess).transition()` because the values can be set before the goroutine starts in `newBasicProcess`.