### PR TITLE
MAKE-804: change default Jasper ports

### DIFF
--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -14,7 +14,7 @@ import (
 const (
 	restHostEnvVar  = "JASPER_REST_HOST"
 	restPortEnvVar  = "JASPER_REST_PORT"
-	defaultRESTPort = 2287
+	defaultRESTPort = 2487
 )
 
 func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {

--- a/cli/service_rpc.go
+++ b/cli/service_rpc.go
@@ -18,7 +18,7 @@ const (
 
 	rpcHostEnvVar  = "JASPER_RPC_HOST"
 	rpcPortEnvVar  = "JASPER_RPC_PORT"
-	defaultRPCPort = 2286
+	defaultRPCPort = 2486
 )
 
 func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-804

The numbers don't mean anything, but it avoids conflicting with Evergreen, which uses ports around 2285.