### PR TITLE
MAKE-807: make it easier to parse JSON CLI output into response structs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -5,6 +5,9 @@ import (
 )
 
 const (
+	// JasperCommand represents the Jasper interface as a CLI command.
+	JasperCommand = "jasper"
+
 	hostFlagName         = "host"
 	portFlagName         = "port"
 	serviceFlagName      = "service"
@@ -16,7 +19,7 @@ const (
 // Jasper is the CLI interface to Jasper services.
 func Jasper() cli.Command {
 	return cli.Command{
-		Name:  "jasper",
+		Name:  JasperCommand,
 		Usage: "Jasper CLI to interact with Jasper services",
 		Subcommands: []cli.Command{
 			Client(),

--- a/cli/client.go
+++ b/cli/client.go
@@ -6,16 +6,21 @@ import (
 	"github.com/urfave/cli"
 )
 
-// clientConnectionTimeout is the max time an operation can run before being
-// cancelled.
-const clientConnectionTimeout = 30 * time.Second
+const (
+	// ClientCommand represents the Jasper client interface as a CLI command.
+	ClientCommand = "client"
 
-// Client encapsulates the client-side interface to a Jasper service. Operations
-// read from standard input (if necessary) and write the result to standard
-// output.
+	// clientConnectionTimeout is the max time an operation can run before being
+	// cancelled.
+	clientConnectionTimeout = 30 * time.Second
+)
+
+// Client encapsulates the client-side interface to a Jasper service.
+// Operations read from standard input (if necessary) and write the result to
+// standard output.
 func Client() cli.Command {
 	return cli.Command{
-		Name:  "client",
+		Name:  ClientCommand,
 		Usage: "tools for making requests to Jasper services",
 		Subcommands: []cli.Command{
 			Manager(),

--- a/cli/io_test.go
+++ b/cli/io_test.go
@@ -1,0 +1,247 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mongodb/jasper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractResponse(t *testing.T) {
+	const (
+		errMsg = "fail"
+		s1     = "foo"
+		s2     = "bar"
+		n1     = 1
+		n2     = 2
+	)
+	for outcomeName, outcome := range map[string]OutcomeResponse{
+		"Success": OutcomeResponse{
+			Success: true,
+		},
+		"Unsuccessful": OutcomeResponse{
+			Success: false,
+			Message: errMsg,
+		},
+		"UnsuccessfulDefaultError": OutcomeResponse{
+			Success: false,
+		},
+	} {
+		t.Run(outcomeName, func(t *testing.T) {
+			for testName, testCase := range map[string]struct {
+				input           string
+				extractAndCheck func(*testing.T, []byte)
+			}{
+				"OperationOutcome": {
+					input: fmt.Sprintf(`{
+						"success": %t,
+						"message": "%s"
+					}`, outcome.Success, outcome.Message),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractOutcomeResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+					},
+				},
+				"InfoResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"info": {
+						"id": "%s"
+					}
+					}`, outcome.Success, outcome.Message, s1),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractInfoResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						assert.Equal(t, s1, resp.Info.ID)
+					},
+				},
+				"InfosResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"infos": [{
+						"id": "%s"
+					}, {
+						"id": "%s"
+					}]
+					}`, outcome.Success, outcome.Message, s1, s2),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractInfosResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						info1, info2 := jasper.ProcessInfo{ID: s1}, jasper.ProcessInfo{ID: s2}
+						info1Found, info2Found := false, false
+						for _, info := range resp.Infos {
+							if info.ID == info1.ID {
+								info1Found = true
+							}
+							if info.ID == info2.ID {
+								info2Found = true
+							}
+						}
+						assert.True(t, info1Found && info2Found)
+					},
+				},
+				"TagsResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"tags": ["%s", "%s"]
+					}`, outcome.Success, outcome.Message, s1, s2),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractTagsResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						assert.Contains(t, resp.Tags, s1)
+						assert.Contains(t, resp.Tags, s2)
+					},
+				},
+				"WaitResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"exit_code": %d,
+					"error": "%s"
+					}`, outcome.Success, outcome.Message, n1, errMsg),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractWaitResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						assert.Equal(t, n1, resp.ExitCode)
+						assert.Equal(t, errMsg, resp.Error)
+					},
+				},
+				"RunningResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"running": %t
+					}`, outcome.Success, outcome.Message, true),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractRunningResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						assert.True(t, resp.Running)
+					},
+				},
+				"CompleteResponse": {
+					input: fmt.Sprintf(`{
+					"outcome": {
+						"success": %t,
+						"message": "%s"
+					},
+					"complete": %t
+					}`, outcome.Success, outcome.Message, true),
+					extractAndCheck: func(t *testing.T, input []byte) {
+						resp, err := ExtractCompleteResponse(input)
+						if outcome.Success {
+							require.NoError(t, err)
+							assert.True(t, resp.Successful())
+						} else {
+							require.Error(t, err)
+							assert.False(t, resp.Successful())
+
+							if outcome.Message != "" {
+								assert.Contains(t, resp.ErrorMessage(), outcome.Message)
+							} else {
+								assert.Contains(t, resp.ErrorMessage(), unspecifiedRequestFailure)
+							}
+						}
+
+						assert.True(t, resp.Complete)
+					},
+				},
+			} {
+				t.Run(testName, func(t *testing.T) {
+					testCase.extractAndCheck(t, []byte(testCase.input))
+				})
+			}
+		})
+	}
+}

--- a/cli/manager.go
+++ b/cli/manager.go
@@ -9,13 +9,25 @@ import (
 	"github.com/urfave/cli"
 )
 
+// Constants representing the Jasper Manager interface as CLI commands.
+const (
+	ManagerCommand       = "manager"
+	CreateProcessCommand = "create-process"
+	CreateCommand        = "create-command"
+	GetCommand           = "get"
+	GroupCommand         = "group"
+	ListCommand          = "list"
+	ClearCommand         = "clear"
+	CloseCommand         = "close"
+)
+
 // Manager creates a cli.Command that interfaces with a Jasper manager. Each
 // subcommand optionally reads the arguments as JSON from stdin if any are
 // required, calls the jasper.Manager function corresponding to that subcommand,
 // and writes the response as JSON to stdout.
 func Manager() cli.Command {
 	return cli.Command{
-		Name: "manager",
+		Name: ManagerCommand,
 		Subcommands: []cli.Command{
 			managerCreateProcess(),
 			managerCreateCommand(),
@@ -30,7 +42,7 @@ func Manager() cli.Command {
 
 func managerCreateProcess() cli.Command {
 	return cli.Command{
-		Name:   "create-process",
+		Name:   CreateProcessCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -48,21 +60,20 @@ func managerCreateProcess() cli.Command {
 
 func managerCreateCommand() cli.Command {
 	return cli.Command{
-		Name:   "create-command",
+		Name:   CreateCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
 			opts := &CommandInput{}
 			return doPassthroughInputOutput(c, opts, func(ctx context.Context, client jasper.RemoteClient) interface{} {
-				cmd := client.CreateCommand(ctx).Background(opts.Background)
-				if level.IsValidPriority(opts.Priority) {
-					cmd = cmd.Priority(opts.Priority)
-				}
-				cmd = cmd.Extend(opts.Commands)
-				cmd = cmd.Background(opts.Background).
+				cmd := client.CreateCommand(ctx).Extend(opts.Commands).
+					Background(opts.Background).
 					ContinueOnError(opts.ContinueOnError).
 					IgnoreError(opts.IgnoreError).
 					ApplyFromOpts(&opts.CreateOptions)
+				if level.IsValidPriority(opts.Priority) {
+					cmd = cmd.Priority(opts.Priority)
+				}
 				return makeOutcomeResponse(cmd.Run(ctx))
 			})
 		},
@@ -71,7 +82,7 @@ func managerCreateCommand() cli.Command {
 
 func managerGet() cli.Command {
 	return cli.Command{
-		Name:   "get",
+		Name:   GetCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -89,7 +100,7 @@ func managerGet() cli.Command {
 
 func managerList() cli.Command {
 	return cli.Command{
-		Name:   "list",
+		Name:   ListCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -111,7 +122,7 @@ func managerList() cli.Command {
 
 func managerGroup() cli.Command {
 	return cli.Command{
-		Name:   "group",
+		Name:   GroupCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -133,7 +144,7 @@ func managerGroup() cli.Command {
 
 func managerClear() cli.Command {
 	return cli.Command{
-		Name:   "clear",
+		Name:   ClearCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -147,7 +158,7 @@ func managerClear() cli.Command {
 
 func managerClose() cli.Command {
 	return cli.Command{
-		Name:   "close",
+		Name:   CloseCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {

--- a/cli/process.go
+++ b/cli/process.go
@@ -9,10 +9,25 @@ import (
 	"github.com/urfave/cli"
 )
 
+// Constants representing the Jasper Process interface as CLI commands.
+const (
+	ProcessCommand                 = "process"
+	InfoCommand                    = "info"
+	CompleteCommand                = "complete"
+	RegisterSignalTriggerIDCommand = "register-signal-trigger-id"
+	RespawnCommand                 = "respawn"
+	RunningCommand                 = "running"
+	SignalCommand                  = "signal"
+	TagCommand                     = "tag"
+	GetTagsCommand                 = "get-tags"
+	ResetTagsCommand               = "reset-tags"
+	WaitCommand                    = "wait"
+)
+
 // Process creates a cli.Command that interfaces with a Jasper process.
 func Process() cli.Command {
 	return cli.Command{
-		Name: "process",
+		Name: ProcessCommand,
 		Subcommands: []cli.Command{
 			processInfo(),
 			processRunning(),
@@ -30,7 +45,7 @@ func Process() cli.Command {
 
 func processInfo() cli.Command {
 	return cli.Command{
-		Name:   "info",
+		Name:   InfoCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -48,7 +63,7 @@ func processInfo() cli.Command {
 
 func processRunning() cli.Command {
 	return cli.Command{
-		Name:   "running",
+		Name:   RunningCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -66,7 +81,7 @@ func processRunning() cli.Command {
 
 func processComplete() cli.Command {
 	return cli.Command{
-		Name:   "complete",
+		Name:   CompleteCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -84,7 +99,7 @@ func processComplete() cli.Command {
 
 func processSignal() cli.Command {
 	return cli.Command{
-		Name: "signal",
+		Name: SignalCommand,
 		Action: func(c *cli.Context) error {
 			input := &SignalInput{}
 			return doPassthroughInputOutput(c, input, func(ctx context.Context, client jasper.RemoteClient) interface{} {
@@ -100,7 +115,7 @@ func processSignal() cli.Command {
 
 func processWait() cli.Command {
 	return cli.Command{
-		Name:   "wait",
+		Name:   WaitCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -122,7 +137,7 @@ func processWait() cli.Command {
 
 func processRespawn() cli.Command {
 	return cli.Command{
-		Name: "respawn",
+		Name: RespawnCommand,
 		Action: func(c *cli.Context) error {
 			input := &IDInput{}
 			return doPassthroughInputOutput(c, input, func(ctx context.Context, client jasper.RemoteClient) interface{} {
@@ -142,7 +157,7 @@ func processRespawn() cli.Command {
 
 func processRegisterSignalTriggerID() cli.Command {
 	return cli.Command{
-		Name:   "register-signal-trigger-id",
+		Name:   RegisterSignalTriggerIDCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -160,7 +175,7 @@ func processRegisterSignalTriggerID() cli.Command {
 
 func processTag() cli.Command {
 	return cli.Command{
-		Name:   "tag",
+		Name:   TagCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -179,7 +194,7 @@ func processTag() cli.Command {
 
 func processGetTags() cli.Command {
 	return cli.Command{
-		Name:   "get-tags",
+		Name:   GetTagsCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -197,7 +212,7 @@ func processGetTags() cli.Command {
 
 func processResetTags() cli.Command {
 	return cli.Command{
-		Name:   "reset-tags",
+		Name:   ResetTagsCommand,
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {

--- a/cli/service.go
+++ b/cli/service.go
@@ -15,22 +15,36 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Service encapsulates the functionality to set up Jasper services. Except for
-// run, the subcommands will generally require elevated privileges to execute.
+// Constants representing the Jasper service interface as a CLI command.
+const (
+	ServiceCommand        = "service"
+	InstallCommand        = "install"
+	UninstallCommand      = "uninstall"
+	StartCommand          = "start"
+	StopCommand           = "stop"
+	RestartCommand        = "restart"
+	RunCommand            = "run"
+	StatusCommand         = "status"
+	ForceReinstallCommand = "force-reinstall"
+)
+
+// Service encapsulates the functionality to set up Jasper services.
+// Except for run, the subcommands will generally require elevated privileges to
+// execute.
 func Service() cli.Command {
 	return cli.Command{
-		Name:  "service",
+		Name:  ServiceCommand,
 		Usage: "tools for running Jasper services",
 		Flags: []cli.Flag{},
 		Subcommands: []cli.Command{
-			serviceCommand("force-reinstall", forceReinstall),
-			serviceCommand("install", install),
-			serviceCommand("uninstall", uninstall),
-			serviceCommand("start", start),
-			serviceCommand("stop", stop),
-			serviceCommand("restart", restart),
-			serviceCommand("run", run),
-			serviceCommand("status", status),
+			serviceCommand(ForceReinstallCommand, forceReinstall),
+			serviceCommand(InstallCommand, install),
+			serviceCommand(UninstallCommand, uninstall),
+			serviceCommand(StartCommand, start),
+			serviceCommand(StopCommand, stop),
+			serviceCommand(RestartCommand, restart),
+			serviceCommand(RunCommand, run),
+			serviceCommand(StatusCommand, status),
 		},
 	}
 }
@@ -58,7 +72,7 @@ func handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, exit ch
 // the flags set in the cli.Context.
 func buildRunCommand(c *cli.Context, serviceType string) []string {
 	args := unparseFlagSet(c)
-	subCmd := []string{"jasper", "service", "run", serviceType}
+	subCmd := []string{JasperCommand, ServiceCommand, RunCommand, serviceType}
 	return append(subCmd, args...)
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-807

* Convenience functions to convert JSON output from CLI commands to structs.
* Added consts for CLI subcommand names.