### PR TITLE
MAKE-830: various fixes to user CLI; improve service status command readability

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -229,6 +229,10 @@ func ListCMD() cli.Command {
 					return nil
 				}
 				filter := jasper.Filter(c.String(filterFlagName))
+				if filter == "" {
+					filter = jasper.All
+					return errors.Wrap(c.Set(filterFlagName, string(filter)), "problem setting default filter")
+				}
 				return errors.Wrapf(filter.Validate(), "invalid filter '%s'", filter)
 			}),
 		Action: func(c *cli.Context) error {

--- a/cli/command.go
+++ b/cli/command.go
@@ -36,11 +36,11 @@ func RunCMD() cli.Command {
 
 	return cli.Command{
 		Name:  "run",
-		Usage: "Run a command with Jasper",
+		Usage: "run a command with Jasper service",
 		Flags: append(clientFlags(),
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(commandFlagName, "c"),
-				Usage: "specify a command to run on a remote jasper service. may specify more than once",
+				Usage: "specify command(s) to run on a remote Jasper service. may specify more than once",
 			},
 			cli.StringSliceFlag{
 				Name:  envFlagName,
@@ -48,20 +48,19 @@ func RunCMD() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  sudoFlagName,
-				Usage: "use this flag to run the command with sudo",
+				Usage: "run the command with sudo",
 			},
 			cli.StringFlag{
 				Name:  sudoAsFlagName,
-				Usage: "use this to run commands as another user as in 'sudo -u <user>'",
+				Usage: "run commands as another user as in 'sudo -u <user>'",
 			},
 			cli.StringFlag{
 				Name:  idFlagName,
-				Usage: "specify an id for this process (optional)",
-				Value: defaultID.String(),
+				Usage: "specify an ID for this command (optional). note: this ID cannot be used to track the subcommands.",
 			},
 			cli.BoolFlag{
 				Name:  execFlagName,
-				Usage: "when specified execute commands directly without shell. If multiple commands are specified they do not share a shell environment",
+				Usage: "execute commands directly without shell",
 			},
 			cli.StringSliceFlag{
 				Name:  tagFlagName,
@@ -69,16 +68,22 @@ func RunCMD() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  waitFlagName,
-				Usage: "specify to block until the process returns (subject to service timeouts), propagating the exit code from process",
+				Usage: "block until the process returns (subject to service timeouts), propagating the exit code from the process. if set, writes the output of each command to stdout; otherwise, prints the process IDs.",
 			},
 		),
 		Before: mergeBeforeFuncs(clientBefore(),
 			func(c *cli.Context) error {
 				if len(c.StringSlice(commandFlagName)) == 0 {
 					if c.NArg() == 0 {
-						return errors.New("must specify a command")
+						return errors.New("must specify at least one command")
 					}
 					return errors.Wrap(c.Set(commandFlagName, strings.Join(c.Args(), " ")), "problem setting command")
+				}
+				return nil
+			},
+			func(c *cli.Context) error {
+				if c.String(idFlagName) == "" {
+					return errors.Wrap(c.Set(idFlagName, defaultID.String()), "problem setting ID")
 				}
 				return nil
 			}),
@@ -100,7 +105,9 @@ func RunCMD() cli.Command {
 				cmd := client.CreateCommand(ctx).Sudo(useSudo).ID(cmdID).SetTags(tags)
 
 				if wait {
-					cmd.Background(true).AppendLoggers(logger).RedirectErrorToOutput(true)
+					cmd.AppendLoggers(logger).RedirectErrorToOutput(true)
+				} else {
+					cmd.Background(true)
 				}
 
 				for _, cmdStr := range cmds {
@@ -121,8 +128,17 @@ func RunCMD() cli.Command {
 				}
 
 				if err := cmd.Run(ctx); err != nil {
-					return errors.WithStack(err)
+					if wait {
+						// Don't return on error, because if any of the
+						// sub-commands fail, it will fail to print the log
+						// lines.
+						grip.Error(errors.Wrap(err, "problem encountered while running commands"))
+					} else {
+						os.Exit(1)
+					}
 				}
+
+				ids := cmd.GetProcIDs()
 
 				if wait {
 					logDone := make(chan struct{})
@@ -132,36 +148,50 @@ func RunCMD() cli.Command {
 						timer := time.NewTimer(0)
 						defer timer.Stop()
 
-						for {
-							select {
-							case <-ctx.Done():
-								grip.Notice("operation canceled")
-								return
-							case <-timer.C:
-								logLines, err := client.GetLogStream(ctx, cmdID, logger.Options.InMemoryCap)
-								if err != nil {
-									grip.Error(message.WrapError(err, "problem polling for log lines, aborting log following"))
+						t := tabby.New()
+						t.AddHeader("ID", "Logs")
+						for _, id := range ids {
+						LOG_SINGLE_PROCESS:
+							for {
+								select {
+								case <-ctx.Done():
+									grip.Notice("operation canceled")
 									return
-								}
+								case <-timer.C:
+									logLines, err := client.GetLogStream(ctx, id, logger.Options.InMemoryCap)
+									if err != nil {
+										grip.Error(message.WrapError(err, "problem polling for log lines, aborting log streaming"))
+										break LOG_SINGLE_PROCESS
+									}
 
-								for _, ln := range logLines.Logs {
-									grip.Info(ln)
-								}
+									for _, ln := range logLines.Logs {
+										t.AddLine(id, ln)
+										t.Print()
+									}
 
-								if !logLines.Done {
-									timer.Reset(0)
-									continue
-								}
+									if logLines.Done {
+										timer.Reset(0)
+										continue
+									}
 
-								timer.Reset(randDur(logPollInterval))
+									timer.Reset(randDur(logPollInterval))
+									break LOG_SINGLE_PROCESS
+								}
 							}
+							t.AddLine()
+							t.Print()
 						}
 					}()
 
-					exit, err := cmd.Wait(ctx)
-					grip.Notice(err)
 					<-logDone
-					os.Exit(exit)
+				} else {
+					t := tabby.New()
+					t.AddHeader("ID")
+					t.Print()
+					for _, id := range ids {
+						t.AddLine(id)
+						t.Print()
+					}
 				}
 
 				return nil
@@ -174,50 +204,40 @@ func RunCMD() cli.Command {
 // jasper instance and their state. The output of the command is a
 // human-readable table.
 func ListCMD() cli.Command {
+	const (
+		filterFlagName = "filter"
+		groupFlagName  = "group"
+	)
 	return cli.Command{
 		Name:  "list",
-		Usage: "list jasper managed commands with human readable output",
+		Usage: "list Jasper managed processes with human readable output",
 		Flags: append(clientFlags(),
-			cli.BoolFlag{
-				Name:  "running",
-				Usage: "show only running processes",
-			},
-			cli.BoolFlag{
-				Name:  "terminated",
-				Usage: "show only terminated (complete) processes",
-			},
-			cli.BoolFlag{
-				Name:  "failed",
-				Usage: "show only failed processes",
-			},
-			cli.BoolFlag{
-				Name:  "successful",
-				Usage: "show only successful processes",
+			cli.StringFlag{
+				Name:  filterFlagName,
+				Usage: "filter processes by status (all, running, successful, failed, terminated)",
 			},
 			cli.StringFlag{
 				Name:  "group",
-				Usage: "specify a tag to return a list of processes, overrides other options",
+				Usage: "return a list of processes with a tag",
 			},
 		),
-		Before: clientBefore(),
+		Before: mergeBeforeFuncs(clientBefore(),
+			func(c *cli.Context) error {
+				if c.String(filterFlagName) != "" && c.String(groupFlagName) != "" {
+					return errors.New("cannot set both filter and group")
+				}
+				if c.String(groupFlagName) != "" {
+					return nil
+				}
+				filter := jasper.Filter(c.String(filterFlagName))
+				return errors.Wrapf(filter.Validate(), "invalid filter '%s'", filter)
+			}),
 		Action: func(c *cli.Context) error {
+			filter := jasper.Filter(c.String(filterFlagName))
+			group := c.String(groupFlagName)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
-			filter := jasper.All
-
-			switch {
-			case c.Bool("running"):
-				filter = jasper.Running
-			case c.Bool("terminated"):
-				filter = jasper.Terminated
-			case c.Bool("failed"):
-				filter = jasper.Failed
-			case c.Bool("successful"):
-				filter = jasper.Successful
-			}
-
-			group := c.String("group")
 
 			return withConnection(ctx, c, func(client jasper.RemoteClient) error {
 				var (
@@ -257,7 +277,7 @@ func KillCMD() cli.Command {
 	)
 	return cli.Command{
 		Name:  "kill",
-		Usage: "terminate processes",
+		Usage: "terminate a process",
 		Flags: append(clientFlags(),
 			cli.StringFlag{
 				Name:  joinFlagNames(idFlagName, "i"),
@@ -265,7 +285,7 @@ func KillCMD() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  killFlagName,
-				Usage: "send KILL (9) rather than term (15)",
+				Usage: "send KILL (9) rather than TERM (15)",
 			},
 		),
 		Before: mergeBeforeFuncs(
@@ -273,7 +293,7 @@ func KillCMD() cli.Command {
 			func(c *cli.Context) error {
 				if len(c.StringSlice(idFlagName)) == 0 {
 					if c.NArg() != 1 {
-						return errors.New("must specify a command ID")
+						return errors.New("must specify a process ID")
 					}
 					return errors.Wrap(c.Set(idFlagName, c.Args().First()), "problem setting id from positional flags")
 				}
@@ -300,12 +320,11 @@ func KillCMD() cli.Command {
 	}
 }
 
-// ClearCMD removes all terminated/exited tracked processes from
-// jasper Manger.
+// ClearCMD removes all terminated/exited processes from Jasper Manager.
 func ClearCMD() cli.Command {
 	return cli.Command{
 		Name:   "clear",
-		Usage:  "terminate processes",
+		Usage:  "clean up terminated processes",
 		Flags:  clientFlags(),
 		Before: clientBefore(),
 		Action: func(c *cli.Context) error {
@@ -320,7 +339,8 @@ func ClearCMD() cli.Command {
 	}
 }
 
-// KillAllCMD terminates all processes with a given tag, sending either TERM or KILL.
+// KillAllCMD terminates all processes with a given tag, sending either TERM or
+// KILL.
 func KillAllCMD() cli.Command {
 	const (
 		groupFlagName = "group"
@@ -328,16 +348,16 @@ func KillAllCMD() cli.Command {
 	)
 
 	return cli.Command{
-		Name:  "kill",
-		Usage: "terminate processes",
+		Name:  "kill-all",
+		Usage: "terminate a group of tagged processes",
 		Flags: append(clientFlags(),
 			cli.StringFlag{
 				Name:  groupFlagName,
 				Usage: "specify the group of process to kill",
 			},
 			cli.BoolFlag{
-				Name:  "kill",
-				Usage: "send KILL (9) rather than term (15)",
+				Name:  killFlagName,
+				Usage: "send KILL (9) rather than TERM (15)",
 			},
 		),
 		Before: mergeBeforeFuncs(

--- a/cli/command.go
+++ b/cli/command.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"os"
 	"strings"
 	"time"
 
@@ -134,7 +133,7 @@ func RunCMD() cli.Command {
 						// lines.
 						grip.Error(errors.Wrap(err, "problem encountered while running commands"))
 					} else {
-						os.Exit(1)
+						return errors.Wrap(err, "problem running command")
 					}
 				}
 

--- a/cli/command.go
+++ b/cli/command.go
@@ -294,7 +294,7 @@ func KillCMD() cli.Command {
 		Before: mergeBeforeFuncs(
 			clientBefore(),
 			func(c *cli.Context) error {
-				if len(c.StringSlice(idFlagName)) == 0 {
+				if len(c.String(idFlagName)) == 0 {
 					if c.NArg() != 1 {
 						return errors.New("must specify a process ID")
 					}

--- a/cli/io.go
+++ b/cli/io.go
@@ -170,6 +170,21 @@ func ExtractWaitResponse(input []byte) (WaitResponse, error) {
 	return resp, resp.successOrError()
 }
 
+type ServiceStatusResponse struct {
+	OutcomeResponse `json:"outcome"`
+	Status          ServiceStatus `json:"status"`
+}
+
+// ExtractServiceStatusResponse unmarshals the input bytes into a
+// ServiceStatusResponse and checks if the request was successful.
+func ExtractServiceStatusResponse(input []byte) (ServiceStatusResponse, error) {
+	resp := ServiceStatusResponse{}
+	if err := json.Unmarshal(input, &resp); err != nil {
+		return resp, errors.Wrap(err, unmarshalFailed)
+	}
+	return resp, resp.successOrError()
+}
+
 // IDInput represents CLI-specific input representing a Jasper process ID.
 type IDInput struct {
 	ID string `json:"id"`

--- a/process_test.go
+++ b/process_test.go
@@ -63,17 +63,17 @@ func TestProcessImplementations(t *testing.T) {
 					assert.Nil(t, proc)
 				},
 				"CanceledContextTimesOutEarly": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep ProcessConstructor) {
-					pctx, pcancel := context.WithTimeout(ctx, 200*time.Millisecond)
+					pctx, pcancel := context.WithTimeout(ctx, 5*time.Second)
 					defer pcancel()
 					startAt := time.Now()
-					opts.Args = []string{"sleep", "20"}
+					opts = sleepCreateOpts(20)
 					proc, err := makep(pctx, opts)
-					assert.NoError(t, err)
-
-					time.Sleep(100 * time.Millisecond) // let time pass...
+					require.NoError(t, err)
 					require.NotNil(t, proc)
+
+					time.Sleep(5 * time.Millisecond) // let time pass...
 					assert.False(t, proc.Info(ctx).Successful)
-					assert.True(t, time.Since(startAt) < 400*time.Millisecond)
+					assert.True(t, time.Since(startAt) < 20*time.Second)
 				},
 				"ProcessLacksTagsByDefault": func(ctx context.Context, t *testing.T, opts *CreateOptions, makep ProcessConstructor) {
 					proc, err := makep(ctx, opts)

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -313,7 +313,7 @@ func (p *rpcProcess) Wait(ctx context.Context) (int, error) {
 
 	if resp.Success {
 		if resp.ExitCode != 0 {
-			return int(resp.ExitCode), errors.Wrap(errors.New(resp.Text), "operation failed")
+			return int(resp.ExitCode), errors.Wrapf(errors.New(resp.Text), "exit code was non-zero")
 		}
 		return int(resp.ExitCode), nil
 	}

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -490,21 +490,17 @@ func TestRPCProcess(t *testing.T) {
 							assert.Nil(t, proc)
 						},
 						"CanceledContextTimesOutEarly": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
-							if runtime.GOOS == "windows" {
-								t.Skip("the sleep tests don't block correctly on windows")
-							}
-
-							pctx, pcancel := context.WithTimeout(ctx, 200*time.Millisecond)
+							pctx, pcancel := context.WithTimeout(ctx, 5*time.Second)
 							defer pcancel()
 							startAt := time.Now()
-							opts.Args = []string{"sleep", "10"}
+							opts = sleepCreateOpts(20)
 							proc, err := makep(pctx, opts)
-							assert.NoError(t, err)
-
-							time.Sleep(100 * time.Millisecond) // let time pass...
+							require.NoError(t, err)
 							require.NotNil(t, proc)
+
+							time.Sleep(5 * time.Millisecond) // let time pass...
 							assert.False(t, proc.Info(ctx).Successful)
-							assert.True(t, time.Since(startAt) < 400*time.Millisecond)
+							assert.True(t, time.Since(startAt) < 20*time.Second)
 						},
 						"ProcessLacksTagsByDefault": func(ctx context.Context, t *testing.T, opts *jasper.CreateOptions, makep processConstructor) {
 							proc, err := makep(ctx, opts)

--- a/rpc/internal/service.go
+++ b/rpc/internal/service.go
@@ -124,7 +124,7 @@ func (s *jasperService) List(f *Filter, stream JasperProcessManager_ListServer) 
 
 	for _, p := range procs {
 		if ctx.Err() != nil {
-			return errors.New("operation canceled")
+			return errors.New("list canceled")
 		}
 
 		if err := stream.Send(getProcInfoNoHang(ctx, p)); err != nil {
@@ -144,7 +144,7 @@ func (s *jasperService) Group(t *TagName, stream JasperProcessManager_GroupServe
 
 	for _, p := range procs {
 		if ctx.Err() != nil {
-			return errors.New("operation canceled")
+			return errors.New("list canceled")
 		}
 
 		if err := stream.Send(getProcInfoNoHang(ctx, p)); err != nil {
@@ -214,7 +214,7 @@ func (s *jasperService) Wait(ctx context.Context, id *JasperProcessID) (*Operati
 
 	return &OperationOutcome{
 		Success:  true,
-		Text:     fmt.Sprintf("'%s' operation complete", id.Value),
+		Text:     fmt.Sprintf("wait completed on process with id '%s'", id.Value),
 		ExitCode: int32(exitCode),
 	}, nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-830

Miscellaneous fixes and improvements.
* Fix some usage strings.
* Fix logging issue where process ID wasn't used.
* Ensure processes with in-memory logger get to write output/error even if a subcommand fails.
* Fix issue where non-waited commands weren't backgrounded properly.
* Make some RPC errors more descriptive.
* `service status` command writes readable JSON string output for status.