### PR TITLE
MAKE-832: fix wait on Jasper user CLI; fix RPC success checking on Wait

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -170,11 +171,10 @@ func RunCMD() cli.Command {
 
 									if logLines.Done {
 										timer.Reset(0)
-										continue
+										break LOG_SINGLE_PROCESS
 									}
 
 									timer.Reset(randDur(logPollInterval))
-									break LOG_SINGLE_PROCESS
 								}
 							}
 							t.AddLine()
@@ -183,6 +183,9 @@ func RunCMD() cli.Command {
 					}()
 
 					<-logDone
+					exitCode, err := cmd.Wait(ctx)
+					grip.Error(err)
+					os.Exit(exitCode)
 				} else {
 					t := tabby.New()
 					t.AddHeader("ID")
@@ -216,7 +219,7 @@ func ListCMD() cli.Command {
 				Usage: "filter processes by status (all, running, successful, failed, terminated)",
 			},
 			cli.StringFlag{
-				Name:  "group",
+				Name:  groupFlagName,
 				Usage: "return a list of processes with a tag",
 			},
 		),

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -85,7 +85,7 @@ func clientFlags() []cli.Flag {
 			Usage: fmt.Sprintf("the port running the Jasper service (if service is '%s', default port is %d; if service is '%s', default port is %d)", restService, defaultRESTPort, rpcService, defaultRPCPort),
 		},
 		cli.StringFlag{
-			Name:  serviceFlagName,
+			Name:  joinFlagNames(serviceFlagName, "s"),
 			Usage: fmt.Sprintf("the type of Jasper service ('%s' or '%s')", restService, rpcService),
 		},
 		cli.StringFlag{

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -311,14 +311,11 @@ func (p *rpcProcess) Wait(ctx context.Context) (int, error) {
 		return -1, errors.WithStack(err)
 	}
 
-	if resp.Success {
-		if resp.ExitCode != 0 {
-			return int(resp.ExitCode), errors.Wrapf(errors.New(resp.Text), "exit code was non-zero")
-		}
-		return int(resp.ExitCode), nil
+	if !resp.Success {
+		return int(resp.ExitCode), errors.Wrapf(errors.New(resp.Text), "process exited with error")
 	}
 
-	return -1, errors.New(resp.Text)
+	return int(resp.ExitCode), nil
 }
 
 func (p *rpcProcess) Respawn(ctx context.Context) (jasper.Process, error) {

--- a/rpc/internal/service.go
+++ b/rpc/internal/service.go
@@ -203,7 +203,7 @@ func (s *jasperService) Wait(ctx context.Context, id *JasperProcessID) (*Operati
 	}
 
 	exitCode, err := proc.Wait(ctx)
-	if err != nil && exitCode == -1 {
+	if err != nil {
 		err = errors.Wrap(err, "problem encountered while waiting")
 		return &OperationOutcome{
 			Success:  false,

--- a/signal.go
+++ b/signal.go
@@ -2,7 +2,6 @@ package jasper
 
 import (
 	"context"
-	"runtime"
 	"syscall"
 
 	"github.com/mongodb/grip"
@@ -38,12 +37,7 @@ func TerminateAll(ctx context.Context, procs []Process) error {
 	}
 
 	for _, proc := range procs {
-		if runtime.GOOS == "windows" {
-			_, _ = proc.Wait(ctx)
-		} else {
-			_, err := proc.Wait(ctx)
-			catcher.Add(err)
-		}
+		_, _ = proc.Wait(ctx)
 	}
 
 	return catcher.Resolve()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-832

* Fix minor issues in Jasper user CLI when waiting.
* Fix an RPC issue where wait returns an oblique error if the exit code is nonzero (this should be handled by the caller anyways, who should handle the exit code themselves).