### PR TITLE
MAKE-839: add optional ServerName for Credentials

### DIFF
--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -780,5 +780,4 @@ func TestRPCProcess(t *testing.T) {
 
 		})
 	}
-
 }

--- a/rpc/creds.go
+++ b/rpc/creds.go
@@ -23,6 +23,9 @@ type Credentials struct {
 	Cert []byte `bson:"cert" json:"cert"`
 	// Key is the PEM-encoded private key.
 	Key []byte `bson:"key" json:"key"`
+
+	// ServerName is the name of the service being contacted.
+	ServerName string
 }
 
 // NewCredentials initializes a new Credential struct.
@@ -104,7 +107,8 @@ func (c *Credentials) Resolve() (*tls.Config, error) {
 		ClientCAs:  caCerts,
 
 		// Client-specific options
-		RootCAs: caCerts,
+		RootCAs:    caCerts,
+		ServerName: c.ServerName,
 	}, nil
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-839

Allows server to present the correct credentials to the client if the client connects to a server on an IP that doesn't match the server's certificate.