### PR TITLE
MAKE-849: add user option for CLI-started service

### DIFF
--- a/cli/service.go
+++ b/cli/service.go
@@ -35,6 +35,10 @@ const (
 	CombinedService = "combined"
 )
 
+const (
+	userFlagName = "user"
+)
+
 // Service encapsulates the functionality to set up Jasper services.
 // Except for run, the subcommands will generally require elevated privileges to
 // execute.

--- a/cli/service_combined.go
+++ b/cli/service_combined.go
@@ -52,6 +52,10 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 				Name:  rpcCredsFilePathFlagName,
 				Usage: "the path to the RPC service credentials file",
 			},
+			cli.StringFlag{
+				Name:  userFlagName,
+				Usage: "the user who will run the services",
+			},
 		},
 		Before: mergeBeforeFuncs(
 			validatePort(restPortFlagName),
@@ -69,6 +73,7 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 			)
 
 			config := serviceConfig(CombinedService, buildRunCommand(c, CombinedService))
+			config.UserName = c.String(userFlagName)
 
 			return operation(daemon, config)
 		},

--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -34,6 +34,10 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 				Usage:  "the port running the REST service",
 				Value:  defaultRESTPort,
 			},
+			cli.StringFlag{
+				Name:  userFlagName,
+				Usage: "the user who will run the REST service",
+			},
 		},
 		Before: validatePort(portFlagName),
 		Action: func(c *cli.Context) error {
@@ -45,6 +49,7 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 			daemon := newRESTDaemon(c.String(hostFlagName), c.Int(portFlagName), manager)
 
 			config := serviceConfig(RESTService, buildRunCommand(c, RESTService))
+			config.UserName = c.String(userFlagName)
 
 			return operation(daemon, config)
 		},

--- a/cli/service_rpc.go
+++ b/cli/service_rpc.go
@@ -40,6 +40,10 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 				Name:  credsFilePathFlagName,
 				Usage: "the path to the file containing the RPC service credentials",
 			},
+			cli.StringFlag{
+				Name:  userFlagName,
+				Usage: "the user who will run the RPC service",
+			},
 		},
 		Before: validatePort(portFlagName),
 		Action: func(c *cli.Context) error {
@@ -51,6 +55,7 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 			daemon := newRPCDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, c.String(credsFilePathFlagName))
 
 			config := serviceConfig(RPCService, buildRunCommand(c, RPCService))
+			config.UserName = c.String(userFlagName)
 
 			return operation(daemon, config)
 		},


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-849

Add option to set the user running the service.