### PR TITLE
MAKE-808: correctly check for shell command

### DIFF
--- a/command.go
+++ b/command.go
@@ -577,7 +577,7 @@ func (c *Command) getCreateOpt(ctx context.Context, args []string) (*CreateOptio
 	case 0:
 		return nil, errors.New("cannot have empty args")
 	case 1:
-		if strings.Contains(args[0], " \"'") {
+		if strings.ContainsAny(args[0], " \"'") {
 			spl, err := shlex.Split(args[0])
 			if err != nil {
 				return nil, errors.Wrap(err, "problem splitting argstring")

--- a/command_test.go
+++ b/command_test.go
@@ -510,6 +510,21 @@ func TestCommandImplementation(t *testing.T) {
 								})
 							}
 						},
+						"SingleArgCommandSplitsShellCommandCorrectly": func(ctx context.Context, t *testing.T, cmd Command) {
+							cmd.Extend([][]string{
+								[]string{"echo hello world"},
+								[]string{"echo 'hello world'"},
+								[]string{"echo 'hello\"world\"'"},
+							})
+
+							optslist, err := cmd.Export(ctx)
+							require.NoError(t, err)
+
+							require.Len(t, optslist, 3)
+							assert.Equal(t, []string{"echo", "hello", "world"}, optslist[0].Args)
+							assert.Equal(t, []string{"echo", "hello world"}, optslist[1].Args)
+							assert.Equal(t, []string{"echo", "hello\"world\""}, optslist[2].Args)
+						},
 						// "": func(ctx context.Context, t *testing.T, cmd Command) {},
 					} {
 						t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-808

When given a command with only one arg, there is a check to ensure that we are not accidentally passing a shell command, but currently, this `strings.Contains` is never true because it looks for a substring instead of looking for each individual character. `Command` will now check if it is actually a shell command by checking for any shell-syntax characters (space, double quote, single quote) inside the first arg (i.e. the program name).