### PR TITLE
MAKE-817, MAKE-840: fix various download test issues

### DIFF
--- a/cli/utils_for_test.go
+++ b/cli/utils_for_test.go
@@ -143,6 +143,7 @@ func withMockStdout(t *testing.T, operation func(*os.File) error) error {
 // waitForRESTService waits until the REST service becomes available to serve
 // requests or the context times out.
 func waitForRESTService(ctx context.Context, t *testing.T, url string) {
+	client := &http.Client{}
 	// Block until the service comes up
 	timeoutInterval := 10 * time.Millisecond
 	timer := time.NewTimer(timeoutInterval)
@@ -158,7 +159,7 @@ func waitForRESTService(ctx context.Context, t *testing.T, url string) {
 				continue
 			}
 			req = req.WithContext(ctx)
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			if err != nil {
 				timer.Reset(timeoutInterval)
 				continue

--- a/cli/utils_for_test.go
+++ b/cli/utils_for_test.go
@@ -143,7 +143,9 @@ func withMockStdout(t *testing.T, operation func(*os.File) error) error {
 // waitForRESTService waits until the REST service becomes available to serve
 // requests or the context times out.
 func waitForRESTService(ctx context.Context, t *testing.T, url string) {
-	client := &http.Client{}
+	client := jasper.GetHTTPClient()
+	defer jasper.PutHTTPClient(client)
+
 	// Block until the service comes up
 	timeoutInterval := 10 * time.Millisecond
 	timer := time.NewTimer(timeoutInterval)

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -160,7 +160,9 @@ outerRetry:
 // waitForRESTService waits until the REST service becomes available to serve
 // requests or the context times out.
 func waitForRESTService(ctx context.Context, url string) error {
-	client := &http.Client{}
+	client := GetHTTPClient()
+	defer PutHTTPClient(client)
+
 	// Block until the service comes up
 	timeoutInterval := 10 * time.Millisecond
 	timer := time.NewTimer(timeoutInterval)

--- a/jasper_test.go
+++ b/jasper_test.go
@@ -156,3 +156,35 @@ outerRetry:
 		}
 	}
 }
+
+// waitForRESTService waits until the REST service becomes available to serve
+// requests or the context times out.
+func waitForRESTService(ctx context.Context, url string) error {
+	client := &http.Client{}
+	// Block until the service comes up
+	timeoutInterval := 10 * time.Millisecond
+	timer := time.NewTimer(timeoutInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		case <-timer.C:
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				timer.Reset(timeoutInterval)
+				continue
+			}
+			req = req.WithContext(ctx)
+			resp, err := client.Do(req)
+			if err != nil {
+				timer.Reset(timeoutInterval)
+				continue
+			}
+			if resp.StatusCode != http.StatusOK {
+				timer.Reset(timeoutInterval)
+				continue
+			}
+			return nil
+		}
+	}
+}

--- a/manager_test.go
+++ b/manager_test.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"runtime"
 	"testing"
 
@@ -16,7 +15,9 @@ var echoSubCmd = []string{"echo", "foo"}
 func TestManagerInterface(t *testing.T) {
 	t.Parallel()
 
-	httpClient := &http.Client{}
+	httpClient := GetHTTPClient()
+	defer PutHTTPClient(httpClient)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -186,18 +186,18 @@ func TestBlockingProcess(t *testing.T) {
 					<-signal
 				},
 				"WaitSomeBeforeCanceling": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.opts.Args = []string{"sleep", "1"}
+					proc.opts = *sleepCreateOpts(10)
 					proc.complete = make(chan struct{})
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 
 					cmd, deadline, err := proc.opts.Resolve(ctx)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 
 					go proc.reactor(ctx, deadline, cmd)
 					_, err = proc.Wait(cctx)
-					assert.Error(t, err)
+					require.Error(t, err)
 					assert.Contains(t, err.Error(), "operation canceled")
 				},
 				"WaitShouldReturnNilForSuccessfulCommandsWithoutIDs": func(ctx context.Context, t *testing.T, proc *blockingProcess) {

--- a/process_test.go
+++ b/process_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"runtime"
 	"syscall"
@@ -20,7 +19,8 @@ func TestProcessImplementations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	httpClient := &http.Client{}
+	httpClient := GetHTTPClient()
+	defer PutHTTPClient(httpClient)
 
 	for cname, makeProc := range map[string]ProcessConstructor{
 		"BlockingNoLock":   newBlockingProcess,

--- a/rest_client.go
+++ b/rest_client.go
@@ -22,7 +22,7 @@ import (
 func NewRESTClient(addr net.Addr) RemoteClient {
 	return &restClient{
 		prefix: fmt.Sprintf("http://%s/jasper/v1", addr.String()),
-		client: http.DefaultClient,
+		client: GetHTTPClient(),
 	}
 }
 
@@ -32,6 +32,7 @@ type restClient struct {
 }
 
 func (c *restClient) CloseConnection() error {
+	PutHTTPClient(c.client)
 	return nil
 }
 

--- a/rest_test.go
+++ b/rest_test.go
@@ -28,7 +28,8 @@ func (n *neverJSON) Read(p []byte) (int, error)    { return 0, errors.New("alway
 func (n *neverJSON) Close() error                  { return errors.New("always error") }
 
 func TestRestService(t *testing.T) {
-	httpClient := &http.Client{}
+	httpClient := GetHTTPClient()
+	defer PutHTTPClient(httpClient)
 
 	for name, test := range map[string]func(context.Context, *testing.T, *Service, *restClient){
 		"VerifyFixtures": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {

--- a/rest_windows_test.go
+++ b/rest_windows_test.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"syscall"
 	"testing"
 
@@ -12,7 +11,8 @@ import (
 )
 
 func TestWindowsRESTService(t *testing.T) {
-	httpClient := &http.Client{}
+	httpClient := GetHTTPClient()
+	defer PutHTTPClient(httpClient)
 
 	for testName, testCase := range map[string]func(context.Context, *testing.T, *Service, *restClient){
 		"SignalEventWithNonexistentEvent": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {

--- a/rpc/internal/service.go
+++ b/rpc/internal/service.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -71,7 +70,6 @@ func getProcInfoNoHang(ctx context.Context, p jasper.Process) *ProcessInfo {
 type jasperService struct {
 	hostID     string
 	manager    jasper.Manager
-	client     http.Client
 	cache      *lru.Cache
 	cacheOpts  jasper.CacheOptions
 	cacheMutex sync.RWMutex

--- a/utils.go
+++ b/utils.go
@@ -2,12 +2,34 @@ package jasper
 
 import (
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
+
+var httpClientPool *sync.Pool
+
+func init() {
+	httpClientPool = &sync.Pool{
+		New: func() interface{} {
+			return &http.Client{}
+		},
+	}
+}
+
+// GetHTTPClient gets an HTTP client from the client pool.
+func GetHTTPClient() *http.Client {
+	return httpClientPool.Get().(*http.Client)
+}
+
+// PutHTTPClient returns the given HTTP client back to the pool.
+func PutHTTPClient(client *http.Client) {
+	httpClientPool.Put(client)
+}
 
 func sliceContains(group []string, name string) bool {
 	for _, g := range group {

--- a/vendor/github.com/tychoish/bond/util.go
+++ b/vendor/github.com/tychoish/bond/util.go
@@ -38,6 +38,6 @@ func init() {
 
 func GetHTTPClient() *http.Client { return httpClientPool.Get().(*http.Client) }
 func PutHTTPClient(c *http.Client) {
-	c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = false
+	// c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify = false
 	httpClientPool.Put(c)
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-817

Instead of downloading the mongo tarball and extracting it, the REST service download test just downloads a tiny test file. Hopefully this will make this test less flaky.