### PR TITLE
MAKE-870: only return error from CLI over SSH Wait() if error text is non-empty

### DIFF
--- a/cli/ssh_process.go
+++ b/cli/ssh_process.go
@@ -117,7 +117,11 @@ func (p *sshProcess) Wait(ctx context.Context) (int, error) {
 		return resp.ExitCode, errors.WithStack(err)
 	}
 
-	return resp.ExitCode, errors.New(resp.Error)
+	if resp.Error != "" {
+		return resp.ExitCode, errors.New(resp.Error)
+	}
+
+	return resp.ExitCode, nil
 }
 
 func (p *sshProcess) Respawn(ctx context.Context) (jasper.Process, error) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-870