### PR TITLE
MAKE-803: allow arbitrary manager types to be wrapped in thread-safe manager

### DIFF
--- a/manager_basic.go
+++ b/manager_basic.go
@@ -55,7 +55,9 @@ func (m *basicProcessManager) CreateProcess(ctx context.Context, opts *CreateOpt
 		return nil, errors.Wrap(err, "problem constructing local process")
 	}
 
-	// TODO this will race because it runs later
+	// This trigger is not guaranteed to be registered since the process may
+	// have already completed. One way to guarantee it runs could be to add this
+	// as a closer to CreateOptions.
 	_ = proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
 
 	if m.tracker != nil {

--- a/manager_basic.go
+++ b/manager_basic.go
@@ -11,19 +11,17 @@ import (
 )
 
 type basicProcessManager struct {
-	id                 string
-	procs              map[string]Process
-	skipDefaultTrigger bool
-	blocking           bool
-	tracker            ProcessTracker
+	id       string
+	procs    map[string]Process
+	blocking bool
+	tracker  ProcessTracker
 }
 
-func newBasicProcessManager(procs map[string]Process, skipDefaultTrigger bool, blocking bool, trackProcs bool) (Manager, error) {
+func newBasicProcessManager(procs map[string]Process, blocking bool, trackProcs bool) (Manager, error) {
 	m := basicProcessManager{
-		procs:              procs,
-		blocking:           blocking,
-		skipDefaultTrigger: skipDefaultTrigger,
-		id:                 uuid.Must(uuid.NewV4()).String(),
+		procs:    procs,
+		blocking: blocking,
+		id:       uuid.Must(uuid.NewV4()).String(),
 	}
 	if trackProcs {
 		tracker, err := NewProcessTracker(m.id)
@@ -58,9 +56,7 @@ func (m *basicProcessManager) CreateProcess(ctx context.Context, opts *CreateOpt
 	}
 
 	// TODO this will race because it runs later
-	if !m.skipDefaultTrigger {
-		_ = proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
-	}
+	_ = proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
 
 	if m.tracker != nil {
 		// The process may have terminated already, so don't return on error.

--- a/manager_local.go
+++ b/manager_local.go
@@ -7,32 +7,35 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewLocalManager is a constructor for a thread-safe Manager.
-func NewLocalManager(trackProcs bool) (Manager, error) {
-	basicManager, err := newBasicProcessManager(map[string]Process{}, false, false, trackProcs)
-	if err != nil {
-		return nil, err
-	}
-	return &localProcessManager{
-		manager: basicManager.(*basicProcessManager),
-	}, nil
+// MakeLocalManager wraps the given manager in a thread-safe Manager.
+func MakeLocalManager(manager Manager) (Manager, error) {
+	return &localProcessManager{manager: manager}, nil
 }
 
-// NewLocalManagerBlockingProcesses is a constructor for localProcessManager,
-// that uses blockingProcess instead of the default basicProcess.
-func NewLocalManagerBlockingProcesses(trackProcs bool) (Manager, error) {
-	basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, false, true, trackProcs)
+// NewLocalManager is a constructor for a thread-safe Manager.
+func NewLocalManager(trackProcs bool) (Manager, error) {
+	basicManager, err := newBasicProcessManager(map[string]Process{}, false, trackProcs)
 	if err != nil {
 		return nil, err
 	}
-	return &localProcessManager{
-		manager: basicBlockingManager.(*basicProcessManager),
-	}, nil
+
+	return &localProcessManager{manager: basicManager}, nil
+}
+
+// NewLocalManagerBlockingProcesses is a constructor for a thread-safe Manager
+// that uses blockingProcess instead of the default basicProcess.
+func NewLocalManagerBlockingProcesses(trackProcs bool) (Manager, error) {
+	basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, true, trackProcs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &localProcessManager{manager: basicBlockingManager}, nil
 }
 
 type localProcessManager struct {
 	mu      sync.RWMutex
-	manager *basicProcessManager
+	manager Manager
 }
 
 func (m *localProcessManager) ID() string {
@@ -43,18 +46,12 @@ func (m *localProcessManager) CreateProcess(ctx context.Context, opts *CreateOpt
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.manager.skipDefaultTrigger = true
 	proc, err := m.manager.CreateProcess(ctx, opts)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	_ = proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, m, opts, proc.ID()))
-
-	proc = &localProcess{proc: proc}
-	m.manager.procs[proc.ID()] = proc
-
-	return proc, nil
+	return &localProcess{proc: proc}, nil
 }
 
 func (m *localProcessManager) CreateCommand(ctx context.Context) *Command {

--- a/manager_self_clearing.go
+++ b/manager_self_clearing.go
@@ -22,7 +22,7 @@ type selfClearingProcessManager struct {
 // local process manager for multithreaded use.
 // TODO: MAKE-803: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, error) {
-	pm, err := newBasicProcessManager(map[string]Process{}, false, false, trackProcs)
+	pm, err := newBasicProcessManager(map[string]Process{}, false, trackProcs)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -45,7 +45,7 @@ func NewSelfClearingProcessManager(maxProcs int, trackProcs bool) (Manager, erro
 // local process manager for multithreaded use.
 // TODO: MAKE-803: allow local process manager to wrap other managers.
 func NewSelfClearingProcessManagerBlockingProcesses(maxProcs int, trackProcs bool) (Manager, error) {
-	pm, err := newBasicProcessManager(map[string]Process{}, false, true, trackProcs)
+	pm, err := newBasicProcessManager(map[string]Process{}, true, trackProcs)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -18,12 +18,12 @@ func TestBasicManagerWithTrackedProcesses(t *testing.T) {
 
 	for managerName, makeManager := range map[string]func(ctx context.Context, t *testing.T) *basicProcessManager{
 		"Basic/NoLock/BasicProcs": func(ctx context.Context, t *testing.T) *basicProcessManager {
-			basicManager, err := newBasicProcessManager(map[string]Process{}, false, false, true)
+			basicManager, err := newBasicProcessManager(map[string]Process{}, false, true)
 			require.NoError(t, err)
 			return basicManager.(*basicProcessManager)
 		},
 		"Basic/NoLock/BlockingProcs": func(ctx context.Context, t *testing.T) *basicProcessManager {
-			basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, false, true, true)
+			basicBlockingManager, err := newBasicProcessManager(map[string]Process{}, true, true)
 			require.NoError(t, err)
 			return basicBlockingManager.(*basicProcessManager)
 		},

--- a/triggers_test.go
+++ b/triggers_test.go
@@ -157,8 +157,7 @@ func TestDefaultTrigger(t *testing.T) {
 
 			testcase(ctx, t, &localProcessManager{
 				manager: &basicProcessManager{
-					skipDefaultTrigger: true,
-					procs:              map[string]Process{},
+					procs: map[string]Process{},
 				},
 			})
 		})


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-803

* Local managers can wrap any other manager.
* Remove skipDefaultTrigger since it's never used.