### PR TITLE
MAKE-938: allow service operations to run in quiet mode

### DIFF
--- a/cli/manager_test.go
+++ b/cli/manager_test.go
@@ -133,7 +133,7 @@ func TestCLIManager(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 					port := testutil.GetPortNumber()
 					c := mockCLIContext(remoteType, port)

--- a/cli/process_test.go
+++ b/cli/process_test.go
@@ -173,7 +173,7 @@ func TestCLIProcess(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 					port := testutil.GetPortNumber()
 					c := mockCLIContext(remoteType, port)
@@ -186,7 +186,7 @@ func TestCLIProcess(t *testing.T) {
 					}()
 
 					resp := &InfoResponse{}
-					input, err := json.Marshal(jasperutil.SleepCreateOpts(int(testTimeout.Seconds()) - 1))
+					input, err := json.Marshal(jasperutil.SleepCreateOpts(1))
 					require.NoError(t, err)
 					require.NoError(t, execCLICommandInputOutput(t, c, managerCreateProcess(), input, resp))
 					require.True(t, resp.Successful())

--- a/cli/remote_test.go
+++ b/cli/remote_test.go
@@ -109,7 +109,7 @@ func TestCLIRemote(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 
 					port := testutil.GetPortNumber()

--- a/cli/remote_unix_test.go
+++ b/cli/remote_unix_test.go
@@ -30,7 +30,7 @@ func TestCLIRemoteUnix(t *testing.T) {
 				},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 
 					port := testutil.GetPortNumber()

--- a/cli/remote_windows_test.go
+++ b/cli/remote_windows_test.go
@@ -38,7 +38,7 @@ func TestCLIRemoteWindows(t *testing.T) {
 			} {
 
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 
 					port := testutil.GetPortNumber()

--- a/cli/service.go
+++ b/cli/service.go
@@ -40,7 +40,8 @@ const (
 
 // Constants representing service flags.
 const (
-	userFlagName = "user"
+	quietFlagName = "quiet"
+	userFlagName  = "user"
 
 	logNameFlagName = "log_name"
 	defaultLogName  = "jasper"
@@ -91,8 +92,16 @@ func handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, exit ch
 	}
 }
 
-func serviceLoggingFlags() []cli.Flag {
+func serviceFlags() []cli.Flag {
 	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  quietFlagName,
+			Usage: "quiet mode - suppress errors when running the command",
+		},
+		cli.StringFlag{
+			Name:  userFlagName,
+			Usage: "the user who running the service",
+		},
 		cli.StringFlag{
 			Name:  logNameFlagName,
 			Value: defaultLogName,
@@ -118,13 +127,6 @@ func serviceLoggingFlags() []cli.Flag {
 			EnvVar: "GRIP_SPLUNK_CHANNEL",
 		},
 	}
-}
-
-func serviceBefore() func(*cli.Context) error {
-	return mergeBeforeFuncs(
-		validatePort(portFlagName),
-		validateLogLevel(logLevelFlagName),
-	)
 }
 
 func validateLogLevel(flagName string) func(*cli.Context) error {

--- a/cli/service_combined.go
+++ b/cli/service_combined.go
@@ -23,7 +23,7 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 	return cli.Command{
 		Name:  CombinedService,
 		Usage: fmt.Sprintf("%s a combined service", cmd),
-		Flags: append(serviceLoggingFlags(),
+		Flags: append(serviceFlags(),
 			cli.StringFlag{
 				Name:   restHostFlagName,
 				EnvVar: restHostEnvVar,
@@ -52,14 +52,11 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 				Name:  rpcCredsFilePathFlagName,
 				Usage: "the path to the RPC service credentials file",
 			},
-			cli.StringFlag{
-				Name:  userFlagName,
-				Usage: "the user who will run the services",
-			},
 		),
 		Before: mergeBeforeFuncs(
 			validatePort(restPortFlagName),
 			validatePort(rpcPortFlagName),
+			validateLogLevel(logLevelFlagName),
 		),
 		Action: func(c *cli.Context) error {
 			manager, err := jasper.NewLocalManager(false)
@@ -75,7 +72,11 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 			config := serviceConfig(CombinedService, buildRunCommand(c, CombinedService))
 			config.UserName = c.String(userFlagName)
 
-			return operation(daemon, config)
+			err = operation(daemon, config)
+			if !c.Bool(quietFlagName) {
+				return err
+			}
+			return nil
 		},
 	}
 }

--- a/cli/service_combined.go
+++ b/cli/service_combined.go
@@ -72,8 +72,7 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 			config := serviceConfig(CombinedService, buildRunCommand(c, CombinedService))
 			config.UserName = c.String(userFlagName)
 
-			err = operation(daemon, config)
-			if !c.Bool(quietFlagName) {
+			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err
 			}
 			return nil

--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -22,7 +22,7 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 	return cli.Command{
 		Name:  RESTService,
 		Usage: fmt.Sprintf("%s a REST service", cmd),
-		Flags: append(serviceLoggingFlags(),
+		Flags: append(serviceFlags(),
 			cli.StringFlag{
 				Name:   hostFlagName,
 				EnvVar: restHostEnvVar,
@@ -35,12 +35,11 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 				Usage:  "the port running the REST service",
 				Value:  defaultRESTPort,
 			},
-			cli.StringFlag{
-				Name:  userFlagName,
-				Usage: "the user who will run the REST service",
-			},
 		),
-		Before: validatePort(portFlagName),
+		Before: mergeBeforeFuncs(
+			validatePort(portFlagName),
+			validateLogLevel(logLevelFlagName),
+		),
 		Action: func(c *cli.Context) error {
 			manager, err := jasper.NewLocalManager(false)
 			if err != nil {
@@ -52,7 +51,11 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 			config := serviceConfig(RESTService, buildRunCommand(c, RESTService))
 			config.UserName = c.String(userFlagName)
 
-			return operation(daemon, config)
+			err = operation(daemon, config)
+			if !c.Bool(quietFlagName) {
+				return err
+			}
+			return nil
 		},
 	}
 }

--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -51,8 +51,7 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 			config := serviceConfig(RESTService, buildRunCommand(c, RESTService))
 			config.UserName = c.String(userFlagName)
 
-			err = operation(daemon, config)
-			if !c.Bool(quietFlagName) {
+			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err
 			}
 			return nil
@@ -82,9 +81,11 @@ func (d *restDaemon) Start(s service.Service) error {
 	if d.Logger != nil {
 		sender, err := d.Logger.Configure()
 		if err != nil {
-			return errors.Wrap(err, "could not set up logging")
+			return errors.Wrap(err, "could not configure logging")
 		}
-		grip.SetSender(sender)
+		if err := grip.SetSender(sender); err != nil {
+			return errors.Wrap(err, "could not set logging sender")
+		}
 	}
 
 	d.exit = make(chan struct{})

--- a/cli/service_rpc.go
+++ b/cli/service_rpc.go
@@ -56,8 +56,7 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 			config := serviceConfig(RPCService, buildRunCommand(c, RPCService))
 			config.UserName = c.String(userFlagName)
 
-			err = operation(daemon, config)
-			if !c.Bool(quietFlagName) {
+			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err
 			}
 			return nil
@@ -89,9 +88,11 @@ func (d *rpcDaemon) Start(s service.Service) error {
 	if d.Logger != nil {
 		sender, err := d.Logger.Configure()
 		if err != nil {
-			return errors.Wrap(err, "could not set up logging")
+			return errors.Wrap(err, "could not configure logging")
 		}
-		grip.SetSender(sender)
+		if err := grip.SetSender(sender); err != nil {
+			return errors.Wrap(err, "could not set logging sender")
+		}
 	}
 
 	d.exit = make(chan struct{})

--- a/cli/service_test.go
+++ b/cli/service_test.go
@@ -78,7 +78,7 @@ func TestDaemon(t *testing.T) {
 		},
 	} {
 		t.Run(daemonAndClientName, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 			defer cancel()
 
 			manager, err := jasper.NewLocalManager(false)

--- a/cli/ssh_client_test.go
+++ b/cli/ssh_client_test.go
@@ -493,7 +493,7 @@ func TestSSHClient(t *testing.T) {
 			mockManager := &mock.Manager{}
 			sshClient.manager = jasper.Manager(mockManager)
 
-			tctx, cancel := context.WithTimeout(ctx, testTimeout)
+			tctx, cancel := context.WithTimeout(ctx, testutil.TestTimeout)
 			defer cancel()
 
 			testCase(tctx, t, sshClient, mockManager)

--- a/cli/ssh_process_test.go
+++ b/cli/ssh_process_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/mock"
+	"github.com/mongodb/jasper/testutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -334,7 +335,7 @@ func TestSSHProcess(t *testing.T) {
 			mockManager := &mock.Manager{}
 			sshClient.manager = jasper.Manager(mockManager)
 
-			tctx, cancel := context.WithTimeout(ctx, testTimeout)
+			tctx, cancel := context.WithTimeout(ctx, testutil.TestTimeout)
 			defer cancel()
 
 			proc, err := newSSHProcess(sshClient.runClientCommand, jasper.ProcessInfo{ID: "foo"})

--- a/cli/util_for_test.go
+++ b/cli/util_for_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/testutil"
@@ -17,8 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 )
-
-const testTimeout = 2 * time.Second
 
 // buildDir gets the Jasper build directory.
 func buildDir(t *testing.T) string {

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -98,7 +98,7 @@ func TestMakeRemoteClient(t *testing.T) {
 		RPCService:  makeTestRPCServiceAndClient,
 	} {
 		t.Run(remoteType, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 			defer cancel()
 			manager, err := jasper.NewLocalManager(false)
 			require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestCLICommon(t *testing.T) {
 				// "": func(ctx context.Context, t *testing.T, c *cli.Context, client jasper.RemoteClient) {},
 			} {
 				t.Run(testName, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 					port := testutil.GetPortNumber()
 					c := mockCLIContext(remoteType, port)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-938

* Suppresses errors from running an operation, mostly to suppress errors from calling commands multiple times.
* Use testutil constants