### PR TITLE
MAKE-939: allow launchd daemons to run as a user agent

### DIFF
--- a/cli/service.go
+++ b/cli/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/kardianos/service"
@@ -176,24 +177,34 @@ func buildRunCommand(c *cli.Context, serviceType string) []string {
 	return append(subCmd, args...)
 }
 
-// serviceOptions returns all options specific to particular service management
-// systems.
-func serviceOptions() service.KeyValue {
-	return service.KeyValue{
-		// launchd-specific options
-		"RunAtLoad": true,
-	}
-}
-
 // serviceConfig returns the daemon service configuration.
-func serviceConfig(serviceType string, args []string) *service.Config {
-	return &service.Config{
+func serviceConfig(serviceType string, args []string, user string) *service.Config {
+	config := &service.Config{
 		Name:        fmt.Sprintf("%s_jasperd", serviceType),
 		DisplayName: fmt.Sprintf("Jasper %s service", serviceType),
 		Description: "Jasper is a service for process management",
 		Executable:  "", // No executable refers to the current executable.
 		Arguments:   args,
-		Option:      serviceOptions(),
+		Option:      service.KeyValue{},
+	}
+
+	configOptions(config, user)
+
+	return config
+}
+
+func configOptions(config *service.Config, user string) {
+	if runtime.GOOS == "darwin" {
+		config.Option["RunAtLoad"] = true
+	}
+
+	if user == "" {
+		return
+	}
+
+	config.UserName = user
+	if user != "root" && runtime.GOOS == "darwin" {
+		config.Option["UserService"] = true
 	}
 }
 

--- a/cli/service_combined.go
+++ b/cli/service_combined.go
@@ -68,9 +68,7 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 				newRESTDaemon(c.String(restHostFlagName), c.Int(restPortFlagName), manager, makeLogger(c)),
 				newRPCDaemon(c.String(rpcHostFlagName), c.Int(rpcPortFlagName), manager, c.String(rpcCredsFilePathFlagName), makeLogger(c)),
 			)
-
-			config := serviceConfig(CombinedService, buildRunCommand(c, CombinedService))
-			config.UserName = c.String(userFlagName)
+			config := serviceConfig(CombinedService, buildRunCommand(c, CombinedService), c.String(userFlagName))
 
 			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err

--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -47,9 +47,7 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 			}
 
 			daemon := newRESTDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, makeLogger(c))
-
-			config := serviceConfig(RESTService, buildRunCommand(c, RESTService))
-			config.UserName = c.String(userFlagName)
+			config := serviceConfig(RESTService, buildRunCommand(c, RESTService), c.String(userFlagName))
 
 			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err

--- a/cli/service_rpc.go
+++ b/cli/service_rpc.go
@@ -52,9 +52,7 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 			}
 
 			daemon := newRPCDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, c.String(credsFilePathFlagName), makeLogger(c))
-
-			config := serviceConfig(RPCService, buildRunCommand(c, RPCService))
-			config.UserName = c.String(userFlagName)
+			config := serviceConfig(RPCService, buildRunCommand(c, RPCService), c.String(userFlagName))
 
 			if err := operation(daemon, config); !c.Bool(quietFlagName) {
 				return err


### PR DESCRIPTION
MAKE-939: https://jira.mongodb.org/browse/MAKE-939

The Jasper service can run as a user agent if not running with root.