### PR TITLE
MAKE-976: remove unused lint package

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -40,9 +40,6 @@ imports:
   - name: github.com/evergreen-ci/timber
     version: d8ccb7cbe151e1466a7be084342653363a1be500
 
-  - name: github.com/surullabs/lint
-    version: 3c204a3ee0bd5ba72fdcd8ab0baa779adf879951
-
   # cgroup requirements
   - name: github.com/containerd/cgroups
     version: dbea6f2bd41658b84b00417ceefa416b979cbf10


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-976

Removed github.com/surullabs/lint since it's not in the vendor directory nor does anything seem to be using it.