### PR TITLE
MAKE-988: synchronize process info tags and process tags field

### DIFF
--- a/process_basic.go
+++ b/process_basic.go
@@ -19,7 +19,6 @@ type basicProcess struct {
 	cmd            *exec.Cmd
 	err            error
 	id             string
-	opts           options.Create
 	tags           map[string]struct{}
 	triggers       ProcessTriggerSequence
 	signalTriggers SignalTriggerSequence
@@ -38,7 +37,6 @@ func newBasicProcess(ctx context.Context, opts *options.Create) (Process, error)
 
 	p := &basicProcess{
 		id:            id,
-		opts:          *opts,
 		cmd:           cmd,
 		tags:          make(map[string]struct{}),
 		waitProcessed: make(chan struct{}),
@@ -58,7 +56,7 @@ func newBasicProcess(ctx context.Context, opts *options.Create) (Process, error)
 
 	p.info.StartAt = time.Now()
 	p.info.ID = p.id
-	p.info.Options = p.opts
+	p.info.Options = *opts
 	p.info.Host, _ = os.Hostname()
 	p.info.IsRunning = true
 	p.info.PID = cmd.Process.Pid
@@ -212,12 +210,12 @@ func (p *basicProcess) Tag(t string) {
 	}
 
 	p.tags[t] = struct{}{}
-	p.opts.Tags = append(p.opts.Tags, t)
+	p.info.Options.Tags = append(p.info.Options.Tags, t)
 }
 
 func (p *basicProcess) ResetTags() {
 	p.tags = make(map[string]struct{})
-	p.opts.Tags = []string{}
+	p.info.Options.Tags = []string{}
 }
 
 func (p *basicProcess) GetTags() []string {

--- a/process_basic.go
+++ b/process_basic.go
@@ -210,11 +210,15 @@ func (p *basicProcess) Tag(t string) {
 	}
 
 	p.tags[t] = struct{}{}
+	p.Lock()
+	defer p.Unlock()
 	p.info.Options.Tags = append(p.info.Options.Tags, t)
 }
 
 func (p *basicProcess) ResetTags() {
 	p.tags = make(map[string]struct{})
+	p.Lock()
+	defer p.Unlock()
 	p.info.Options.Tags = []string{}
 }
 

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -33,7 +33,7 @@ func TestBlockingProcess(t *testing.T) {
 					assert.NotNil(t, ctx)
 					assert.NotZero(t, proc.ID())
 					assert.False(t, proc.Complete(ctx))
-					assert.NotNil(t, makeDefaultTrigger(ctx, nil, &proc.opts, "foo"))
+					assert.NotNil(t, makeDefaultTrigger(ctx, nil, &proc.info.Options, "foo"))
 				},
 				"InfoIDPopulatedInBasicCase": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
 					infoReturned := make(chan struct{})
@@ -88,13 +88,13 @@ func TestBlockingProcess(t *testing.T) {
 					proc.info.Complete = true
 					assert.True(t, proc.Complete(ctx))
 					assert.Error(t, proc.RegisterTrigger(ctx, nil))
-					assert.Error(t, proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, nil, &proc.opts, "foo")))
+					assert.Error(t, proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, nil, &proc.info.Options, "foo")))
 					assert.Len(t, proc.triggers, 0)
 				},
 				"TestRegisterPopulatedTrigger": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
 					assert.False(t, proc.Complete(ctx))
 					assert.Error(t, proc.RegisterTrigger(ctx, nil))
-					assert.NoError(t, proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, nil, &proc.opts, "foo")))
+					assert.NoError(t, proc.RegisterTrigger(ctx, makeDefaultTrigger(ctx, nil, &proc.info.Options, "foo")))
 					assert.Len(t, proc.triggers, 1)
 				},
 				"RunningIsFalseWhenCompleteIsSatisfied": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
@@ -189,12 +189,12 @@ func TestBlockingProcess(t *testing.T) {
 					<-signal
 				},
 				"WaitSomeBeforeCanceling": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.opts = *testutil.SleepCreateOpts(10)
+					proc.info.Options = *testutil.SleepCreateOpts(10)
 					proc.complete = make(chan struct{})
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()
 
-					cmd, deadline, err := proc.opts.Resolve(ctx)
+					cmd, deadline, err := proc.info.Options.Resolve(ctx)
 					require.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 
@@ -204,10 +204,10 @@ func TestBlockingProcess(t *testing.T) {
 					assert.Contains(t, err.Error(), "operation canceled")
 				},
 				"WaitShouldReturnNilForSuccessfulCommandsWithoutIDs": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.opts.Args = []string{"sleep", "10"}
+					proc.info.Options.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, _, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.info.Options.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})
@@ -239,10 +239,10 @@ func TestBlockingProcess(t *testing.T) {
 					<-signal
 				},
 				"WaitShouldReturnNilForSuccessfulCommands": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.opts.Args = []string{"sleep", "10"}
+					proc.info.Options.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, _, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.info.Options.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})
@@ -275,10 +275,10 @@ func TestBlockingProcess(t *testing.T) {
 					<-signal
 				},
 				"WaitShouldReturnErrorForFailedCommands": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.opts.Args = []string{"sleep", "10"}
+					proc.info.Options.Args = []string{"sleep", "10"}
 					proc.ops = make(chan func(*exec.Cmd))
 
-					cmd, _, err := proc.opts.Resolve(ctx)
+					cmd, _, err := proc.info.Options.Resolve(ctx)
 					assert.NoError(t, err)
 					assert.NoError(t, cmd.Start())
 					signal := make(chan struct{})
@@ -401,7 +401,6 @@ func TestBlockingProcess(t *testing.T) {
 					proc := &blockingProcess{
 						id:   id,
 						ops:  make(chan func(*exec.Cmd), 1),
-						opts: options.Create{},
 						info: ProcessInfo{ID: id},
 					}
 

--- a/process_test.go
+++ b/process_test.go
@@ -74,6 +74,19 @@ func TestProcessImplementations(t *testing.T) {
 					tags := proc.GetTags()
 					assert.Contains(t, tags, "foo")
 				},
+				"InfoTagsMatchGetTags": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
+					opts.Tags = []string{"foo"}
+					proc, err := makep(ctx, opts)
+					require.NoError(t, err)
+					tags := proc.GetTags()
+					assert.Contains(t, tags, "foo")
+					assert.Equal(t, tags, proc.Info(ctx).Options.Tags)
+
+					proc.ResetTags()
+					tags = proc.GetTags()
+					assert.Empty(t, tags)
+					assert.Empty(t, proc.Info(ctx).Options.Tags)
+				},
 				"InfoHasMatchingID": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-988

This is primarily to avoid confusion about `Info()` returning different tags from `GetTags()`.