### PR TITLE
MAKE-1002: standardize cache pruning behavior

### DIFF
--- a/rest/service.go
+++ b/rest/service.go
@@ -79,7 +79,7 @@ func (s *Service) App(ctx context.Context) *gimlet.APIApp {
 	app.AddRoute("/clear").Version(1).Post().Handler(s.clearManager)
 	app.AddRoute("/close").Version(1).Delete().Handler(s.closeManager)
 
-	go s.backgroundPrune(ctx)
+	go s.pruneCache(ctx)
 
 	return app
 }
@@ -111,13 +111,13 @@ func (s *Service) SetPruneDelay(dur time.Duration) {
 	s.cacheOpts.PruneDelay = dur
 }
 
-func (s *Service) backgroundPrune(ctx context.Context) {
+func (s *Service) pruneCache(ctx context.Context) {
 	defer func() {
 		err := recovery.HandlePanicWithError(recover(), nil, "background pruning")
 		if ctx.Err() != nil || err == nil {
 			return
 		}
-		go s.backgroundPrune(ctx)
+		go s.pruneCache(ctx)
 	}()
 
 	s.cacheMutex.RLock()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1002

* Handle cache pruning panics in the RPC service.
* Stop the cache pruning for the RPC service when the service is closed.