### PR TITLE
MAKE-1027: re-add ExtendRemoteArgs and export RemoteConfig

### DIFF
--- a/command.go
+++ b/command.go
@@ -153,6 +153,15 @@ func (c *Command) Port(p int) *Command {
 	return c
 }
 
+// ExtendRemoteArgs allows you to add arguments, when needed, to the
+// Password sets the password in order to authenticate to a remote host.
+// underlying ssh command, for remote commands.
+func (c *Command) ExtendRemoteArgs(args ...string) *Command {
+	c.initRemote()
+	c.opts.Remote.Args = append(c.opts.Remote.Args, args...)
+	return c
+}
+
 // PrivKey sets the private key in order to authenticate to a remote host.
 func (c *Command) PrivKey(key string) *Command {
 	c.initRemote()

--- a/options/remote.go
+++ b/options/remote.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-type remoteConfig struct {
+type RemoteConfig struct {
 	Host string
 	User string
 
@@ -32,18 +32,18 @@ type remoteConfig struct {
 
 // Remote represents options to SSH into a remote machine.
 type Remote struct {
-	remoteConfig
+	RemoteConfig
 	Proxy *Proxy
 }
 
 // Proxy represents the remote configuration to access a remote proxy machine.
 type Proxy struct {
-	remoteConfig
+	RemoteConfig
 }
 
 const defaultSSHPort = 22
 
-func (opts *remoteConfig) validate() error {
+func (opts *RemoteConfig) validate() error {
 	catcher := grip.NewBasicCatcher()
 	if opts.Host == "" {
 		catcher.New("host cannot be empty")
@@ -66,7 +66,7 @@ func (opts *remoteConfig) validate() error {
 	return catcher.Resolve()
 }
 
-func (opts *remoteConfig) resolve() (*ssh.ClientConfig, error) {
+func (opts *RemoteConfig) resolve() (*ssh.ClientConfig, error) {
 	var auth []ssh.AuthMethod
 	if opts.Key != "" || opts.KeyFile != "" {
 		pubkey, err := opts.publicKeyAuth()
@@ -86,7 +86,7 @@ func (opts *remoteConfig) resolve() (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-func (opts *remoteConfig) publicKeyAuth() (ssh.AuthMethod, error) {
+func (opts *RemoteConfig) publicKeyAuth() (ssh.AuthMethod, error) {
 	var key []byte
 	if opts.KeyFile != "" {
 		var err error

--- a/options/remote.go
+++ b/options/remote.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// RemoteConfig represents the arguments to connect to a remote host.
 type RemoteConfig struct {
 	Host string
 	User string


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1027

I accidentally removed `ExtendRemoteArgs()`.