### PR TITLE
MAKE-1150: fix file handles in Windows tests

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   - name: github.com/stretchr/testify
     version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   - name: github.com/mongodb/grip
-    version: 7037e69a48d124757a3c61b53c8a4a24d0de2699
+    version: c55591ce17342e8b8dc5ce7cded6de3837ab025a
   - name: github.com/evergreen-ci/gimlet
     version: 8a317d725d0315a97c5d0c08ec04921f3ba498d5
   - name: github.com/tychoish/bond

--- a/options/log.go
+++ b/options/log.go
@@ -135,7 +135,6 @@ type Logger struct {
 	Options Log     `bson:"log_options" json:"log_options" yaml:"log_options"`
 
 	sender send.Sender
-	closed bool
 }
 
 // Validate ensures that LogOptions is valid.
@@ -251,12 +250,8 @@ func (l *Logger) Configure() (send.Sender, error) { //nolint: gocognit
 // Close closes the underlying sender. This should be called once the logger is
 // finished logging.
 func (l *Logger) Close() error {
-	if l.closed {
-		return nil
-	}
 	if l.sender != nil {
 		l.sender.Close()
 	}
-	l.closed = true
 	return nil
 }

--- a/options/output.go
+++ b/options/output.go
@@ -19,7 +19,10 @@ type Output struct {
 	SuppressError     bool      `bson:"suppress_error" json:"suppress_error" yaml:"suppress_error"`
 	SendOutputToError bool      `bson:"redirect_output_to_error" json:"redirect_output_to_error" yaml:"redirect_output_to_error"`
 	SendErrorToOutput bool      `bson:"redirect_error_to_output" json:"redirect_error_to_output" yaml:"redirect_error_to_output"`
-	Loggers           []Logger  `bson:"loggers" json:"loggers,omitempty" yaml:"loggers"`
+	// Loggers are self-contained and specific to the process they are attached
+	// to. They are closed and cleaned up when the process exits. If this
+	// behavior is not desired, use Output instead of Loggers.
+	Loggers []Logger `bson:"loggers" json:"loggers,omitempty" yaml:"loggers"`
 
 	outputSender *send.WriterSender
 	errorSender  *send.WriterSender
@@ -99,9 +102,10 @@ func (o *Output) Validate() error {
 	return catcher.Resolve()
 }
 
-// GetOutput returns a Writer that has the stdout output from the process that the
-// Output that this method is called on is attached to.
-func (o *Output) GetOutput() (io.Writer, error) {
+// GetOutput returns a Writer that has the stdout output from the process that
+// the Output that this method is called on is attached to. The caller is
+// responsible for calling closeLoggers when the loggers are not needed anymore.
+func (o *Output) GetOutput() (w io.Writer, err error) {
 	if o.SendOutputToError {
 		return o.GetError()
 	}
@@ -115,22 +119,22 @@ func (o *Output) GetOutput() (io.Writer, error) {
 	}
 
 	if o.outputLogging() {
-		outSenders := []send.Sender{}
+		outLoggers := []send.Sender{}
 
 		for i := range o.Loggers {
 			sender, err := o.Loggers[i].Configure()
 			if err != nil {
 				return ioutil.Discard, err
 			}
-			outSenders = append(outSenders, sender)
+			outLoggers = append(outLoggers, sender)
 		}
 
 		var outMulti send.Sender
-		if len(outSenders) == 1 {
-			outMulti = outSenders[0]
+		if len(outLoggers) == 1 {
+			outMulti = outLoggers[0]
 		} else {
 			var err error
-			outMulti, err = send.NewMultiSender(DefaultLogName, send.LevelInfo{Default: level.Info, Threshold: level.Trace}, outSenders)
+			outMulti, err = send.NewMultiSender(DefaultLogName, send.LevelInfo{Default: level.Info, Threshold: level.Trace}, outLoggers)
 			if err != nil {
 				return ioutil.Discard, err
 			}
@@ -179,6 +183,7 @@ func (o *Output) GetError() (io.Writer, error) {
 		if err != nil {
 			return ioutil.Discard, err
 		}
+		// This will not close the Loggers' underlying senders.
 		o.errorSender = send.NewWriterSender(errMulti)
 	}
 
@@ -214,6 +219,8 @@ func (o *Output) Copy() *Output {
 // Close calls all of the processes' output senders' Close method.
 func (o *Output) Close() error {
 	catcher := grip.NewBasicCatcher()
+	// Closing the outputSender and errorSender does not close the underlying
+	// send.Sender.
 	if o.outputSender != nil {
 		catcher.Add(o.outputSender.Close())
 	}
@@ -223,9 +230,15 @@ func (o *Output) Close() error {
 	if o.outputSender != nil {
 		catcher.Add(o.outputSender.Sender.Close())
 	}
-	// Since senders are shared, only close error's senders if output hasn't already closed them.
+	// Since senders are shared, only close error's senders if output hasn't
+	// already closed them.
 	if o.errorSender != nil && (o.SuppressOutput || o.SendOutputToError) {
 		catcher.Add(o.errorSender.Sender.Close())
+	}
+	// Since loggers are not shared outside of this process, we close the
+	// loggers to clean up their underlying send.Senders.
+	for _, logger := range o.Loggers {
+		catcher.Add(logger.Close())
 	}
 
 	return errors.WithStack(catcher.Resolve())

--- a/process_test.go
+++ b/process_test.go
@@ -254,12 +254,12 @@ func TestProcessImplementations(t *testing.T) {
 				"ProcessLogDefault": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
+					assert.NoError(t, file.Close())
 					defer func() {
-						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := file.Stat()
-					assert.NoError(t, err)
+					info, err := os.Stat(file.Name())
+					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
 					opts.Output.Loggers = []options.Logger{{Type: options.LogDefault, Options: options.Log{Format: options.LogFormatPlain}}}
@@ -274,12 +274,12 @@ func TestProcessImplementations(t *testing.T) {
 				"ProcessWritesToLog": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
+					assert.NoError(t, file.Close())
 					defer func() {
-						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := file.Stat()
-					assert.NoError(t, err)
+					info, err := os.Stat(file.Name())
+					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
 					opts.Output.Loggers = []options.Logger{{Type: options.LogFile, Options: options.Log{FileName: file.Name(), Format: options.LogFormatPlain}}}
@@ -297,7 +297,8 @@ func TestProcessImplementations(t *testing.T) {
 					go func() {
 						done := false
 						for !done {
-							info, err = file.Stat()
+							info, err = os.Stat(file.Name())
+							require.NoError(t, err)
 							if info.Size() > 0 {
 								done = true
 								fileWrite <- done
@@ -309,20 +310,20 @@ func TestProcessImplementations(t *testing.T) {
 					case <-ctx.Done():
 						assert.Fail(t, "file write took too long to complete")
 					case <-fileWrite:
-						info, err = file.Stat()
-						assert.NoError(t, err)
+						info, err = os.Stat(file.Name())
+						require.NoError(t, err)
 						assert.NotZero(t, info.Size())
 					}
 				},
 				"ProcessWritesToBufferedLog": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
+					assert.NoError(t, file.Close())
 					defer func() {
-						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := file.Stat()
-					assert.NoError(t, err)
+					info, err := os.Stat(file.Name())
+					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
 					opts.Output.Loggers = []options.Logger{
@@ -345,7 +346,8 @@ func TestProcessImplementations(t *testing.T) {
 					fileWrite := make(chan int64)
 					go func() {
 						for {
-							info, err = file.Stat()
+							info, err = os.Stat(file.Name())
+							require.NoError(t, err)
 							if info.Size() > 0 {
 								fileWrite <- info.Size()
 								break

--- a/process_test.go
+++ b/process_test.go
@@ -254,11 +254,11 @@ func TestProcessImplementations(t *testing.T) {
 				"ProcessLogDefault": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
-					assert.NoError(t, file.Close())
 					defer func() {
+						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := os.Stat(file.Name())
+					info, err := file.Stat()
 					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
@@ -274,11 +274,11 @@ func TestProcessImplementations(t *testing.T) {
 				"ProcessWritesToLog": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
-					assert.NoError(t, file.Close())
 					defer func() {
+						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := os.Stat(file.Name())
+					info, err := file.Stat()
 					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
@@ -297,7 +297,7 @@ func TestProcessImplementations(t *testing.T) {
 					go func() {
 						done := false
 						for !done {
-							info, err = os.Stat(file.Name())
+							info, err = file.Stat()
 							require.NoError(t, err)
 							if info.Size() > 0 {
 								done = true
@@ -310,7 +310,7 @@ func TestProcessImplementations(t *testing.T) {
 					case <-ctx.Done():
 						assert.Fail(t, "file write took too long to complete")
 					case <-fileWrite:
-						info, err = os.Stat(file.Name())
+						info, err = file.Stat()
 						require.NoError(t, err)
 						assert.NotZero(t, info.Size())
 					}
@@ -318,11 +318,11 @@ func TestProcessImplementations(t *testing.T) {
 				"ProcessWritesToBufferedLog": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
 					file, err := ioutil.TempFile("build", "out.txt")
 					require.NoError(t, err)
-					assert.NoError(t, file.Close())
 					defer func() {
+						assert.NoError(t, file.Close())
 						assert.NoError(t, os.RemoveAll(file.Name()))
 					}()
-					info, err := os.Stat(file.Name())
+					info, err := file.Stat()
 					require.NoError(t, err)
 					assert.Zero(t, info.Size())
 
@@ -346,7 +346,7 @@ func TestProcessImplementations(t *testing.T) {
 					fileWrite := make(chan int64)
 					go func() {
 						for {
-							info, err = os.Stat(file.Name())
+							info, err = file.Stat()
 							require.NoError(t, err)
 							if info.Size() > 0 {
 								fileWrite <- info.Size()

--- a/vendor/github.com/mongodb/grip/send/send_test.go
+++ b/vendor/github.com/mongodb/grip/send/send_test.go
@@ -51,7 +51,7 @@ func (s *SenderSuite) SetupTest() {
 		},
 	}
 
-	internal := new(InternalSender)
+	internal := MakeInternalLogger()
 	internal.name = "internal"
 	internal.output = make(chan *InternalMessage)
 	s.senders["internal"] = internal


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1150

Files were not being closed because the underlying file send.Senders were not being closed due to WriterSender not closing its underlying sender. This closes the output's `Loggers` but not the `Output` field. It also revendors grip to ensure the buffered sender closes the underlying sender on `Close()`