### PR TITLE
MAKE-1150: close logger's underlying senders

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   - name: github.com/stretchr/testify
     version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   - name: github.com/mongodb/grip
-    version: 9b7e20ecfeb5ee307f792b2e339f89d3bbbd6ecc
+    version: 505d1051058d81836ddb3cb839ba06009588a14e
   - name: github.com/evergreen-ci/gimlet
     version: 8a317d725d0315a97c5d0c08ec04921f3ba498d5
   - name: github.com/tychoish/bond

--- a/glide.lock
+++ b/glide.lock
@@ -8,7 +8,7 @@ imports:
   - name: github.com/stretchr/testify
     version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   - name: github.com/mongodb/grip
-    version: c55591ce17342e8b8dc5ce7cded6de3837ab025a
+    version: 9b7e20ecfeb5ee307f792b2e339f89d3bbbd6ecc
   - name: github.com/evergreen-ci/gimlet
     version: 8a317d725d0315a97c5d0c08ec04921f3ba498d5
   - name: github.com/tychoish/bond

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -20,7 +20,7 @@ func TestBasicManagerWithTrackedProcesses(t *testing.T) {
 
 	for managerName, makeManager := range map[string]func(ctx context.Context, t *testing.T) *basicProcessManager{
 		"Basic": func(ctx context.Context, t *testing.T) *basicProcessManager {
-			basicManager, err := newBasicProcessManager(map[string]Process{}, false, false)
+			basicManager, err := newBasicProcessManager(map[string]Process{}, true, false)
 			require.NoError(t, err)
 			return basicManager.(*basicProcessManager)
 		},

--- a/options/log.go
+++ b/options/log.go
@@ -134,7 +134,13 @@ type Logger struct {
 	Type    LogType `bson:"log_type" json:"log_type" yaml:"log_type"`
 	Options Log     `bson:"log_options" json:"log_options" yaml:"log_options"`
 
+	// sender may be the actual send.Sender or the wrapping send.Sender.
 	sender send.Sender
+	// baseSender stores the underlying send.Senders. It must be stored to work
+	// around the fact that wrapping Senders do not necessarily close their
+	// underlying send.Sender, but we have to clean up the resources when the
+	// Logger is finished.
+	baseSender send.Sender
 }
 
 // Validate ensures that LogOptions is valid.
@@ -235,6 +241,8 @@ func (l *Logger) Configure() (send.Sender, error) { //nolint: gocognit
 		return nil, errors.New("failed to set log format")
 	}
 
+	baseSender := sender
+
 	if l.Type != LogBuildloggerV3 && l.Options.BufferOptions.Buffered {
 		if l.Options.BufferOptions.Duration < 0 || l.Options.BufferOptions.MaxSize < 0 {
 			return nil, errors.New("buffer options cannot be negative")
@@ -243,15 +251,21 @@ func (l *Logger) Configure() (send.Sender, error) { //nolint: gocognit
 	}
 
 	l.sender = sender
+	l.baseSender = baseSender
 
 	return l.sender, nil
 }
 
-// Close closes the underlying sender. This should be called once the logger is
+// Close closes its send.Senders, closing the wrapper send.Sender and then the
+// underlying base send.Sender. This should be called once the Logger is
 // finished logging.
 func (l *Logger) Close() error {
+	catcher := grip.NewBasicCatcher()
 	if l.sender != nil {
-		l.sender.Close()
+		catcher.Wrap(l.sender.Close(), "could not close sender")
 	}
-	return nil
+	if l.baseSender != nil && l.sender != l.baseSender {
+		catcher.Wrap(l.baseSender.Close(), "could not close underlying sender")
+	}
+	return catcher.Resolve()
 }

--- a/options/output.go
+++ b/options/output.go
@@ -235,8 +235,8 @@ func (o *Output) Close() error {
 	if o.errorSender != nil && (o.SuppressOutput || o.SendOutputToError) {
 		catcher.Add(o.errorSender.Sender.Close())
 	}
-	// Since loggers are not shared outside of this process, we close the
-	// loggers to clean up their underlying send.Senders.
+	// Since loggers are owned by this process, we close the loggers to clean up
+	// their underlying send.Senders.
 	for _, logger := range o.Loggers {
 		catcher.Add(logger.Close())
 	}

--- a/vendor/github.com/mongodb/grip/send/annotating.go
+++ b/vendor/github.com/mongodb/grip/send/annotating.go
@@ -17,7 +17,8 @@ type annotatingSender struct {
 //
 // Calling code should assume that the sender owns the annotations map
 // and it should not attempt to modify that data after calling the
-// sender constructor.
+// sender constructor. Furthermore, since it owns the sender, callin Close on
+// this sender will close the underlying sender.
 //
 // While you can wrap an existing sender with the annotator, changes
 // to the annotating sender (e.g. level, formater, error handler) will

--- a/vendor/github.com/mongodb/grip/send/async_group.go
+++ b/vendor/github.com/mongodb/grip/send/async_group.go
@@ -22,6 +22,9 @@ type asyncGroupSender struct {
 //
 // This sender does not guarantee ordering of messages, and Send operations may
 // if the underlying senders fall behind the buffer size.
+//
+// The sender takes ownership of the underlying Senders, so closing this sender
+// closes all underlying Senders.
 func NewAsyncGroupSender(ctx context.Context, bufferSize int, senders ...Sender) Sender {
 	s := &asyncGroupSender{
 		senders: senders,
@@ -48,7 +51,7 @@ func NewAsyncGroupSender(ctx context.Context, bufferSize int, senders ...Sender)
 	}
 
 	s.closer = func() error {
-		//s.cancel()
+		s.cancel()
 
 		errs := []string{}
 		for _, sender := range s.senders {

--- a/vendor/github.com/mongodb/grip/send/buffered_test.go
+++ b/vendor/github.com/mongodb/grip/send/buffered_test.go
@@ -101,41 +101,40 @@ func TestFlush(t *testing.T) {
 }
 
 func TestBufferedClose(t *testing.T) {
-	for testName, testCase := range map[string]func(t *testing.T, s *InternalSender, bs *bufferedSender){
-		"EmptyBuffer": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			assert.Nil(t, bs.Close())
-			assert.True(t, bs.closed)
-			_, ok := s.GetMessageSafe()
-			assert.False(t, ok)
-		},
-		"NonEmptyBuffer": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			bs.buffer = append(
-				bs.buffer,
-				message.ConvertToComposer(level.Debug, "message1"),
-				message.ConvertToComposer(level.Debug, "message2"),
-				message.ConvertToComposer(level.Debug, "message3"),
-			)
+	s, err := NewInternalLogger("buffs", LevelInfo{level.Debug, level.Debug})
+	require.NoError(t, err)
 
-			assert.Nil(t, bs.Close())
-			assert.True(t, bs.closed)
-			assert.Empty(t, bs.buffer)
-			msgs, ok := s.GetMessageSafe()
-			require.True(t, ok)
-			assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
-		},
-		"NoopWhenClosed": func(t *testing.T, s *InternalSender, bs *bufferedSender) {
-			assert.NoError(t, bs.Close())
-			assert.True(t, bs.closed)
-			assert.NoError(t, bs.Close())
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			s, err := NewInternalLogger("buffs", LevelInfo{Default: level.Debug, Threshold: level.Debug})
-			require.NoError(t, err)
-			bs := newBufferedSender(s, time.Minute, 10)
-			testCase(t, s, bs)
-		})
-	}
+	t.Run("EmptyBuffer", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		_, ok := s.GetMessageSafe()
+		assert.False(t, ok)
+	})
+	t.Run("NonEmptyBuffer", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+		bs.buffer = append(
+			bs.buffer,
+			message.ConvertToComposer(level.Debug, "message1"),
+			message.ConvertToComposer(level.Debug, "message2"),
+			message.ConvertToComposer(level.Debug, "message3"),
+		)
+
+		assert.Nil(t, bs.Close())
+		assert.True(t, bs.closed)
+		assert.Empty(t, bs.buffer)
+		msgs, ok := s.GetMessageSafe()
+		require.True(t, ok)
+		assert.Equal(t, "message1\nmessage2\nmessage3", msgs.Message.String())
+	})
+	t.Run("NoopWhenClosed", func(t *testing.T) {
+		bs := newBufferedSender(s, time.Minute, 10)
+
+		assert.NoError(t, bs.Close())
+		assert.True(t, bs.closed)
+		assert.NoError(t, bs.Close())
+	})
 }
 
 func TestIntervalFlush(t *testing.T) {

--- a/vendor/github.com/mongodb/grip/send/error_handler.go
+++ b/vendor/github.com/mongodb/grip/send/error_handler.go
@@ -22,7 +22,7 @@ func ErrorHandlerFromLogger(l *log.Logger) ErrorHandler {
 	}
 }
 
-// ErrorHandler wraps an existing Sender for sending error messages.
+// ErrorHandlerFromSender wraps an existing Sender for sending error messages.
 func ErrorHandlerFromSender(s Sender) ErrorHandler {
 	return func(err error, m message.Composer) {
 		if err == nil {

--- a/vendor/github.com/mongodb/grip/send/error_handler.go
+++ b/vendor/github.com/mongodb/grip/send/error_handler.go
@@ -22,6 +22,7 @@ func ErrorHandlerFromLogger(l *log.Logger) ErrorHandler {
 	}
 }
 
+// ErrorHandler wraps an existing Sender for sending error messages.
 func ErrorHandlerFromSender(s Sender) ErrorHandler {
 	return func(err error, m message.Composer) {
 		if err == nil {

--- a/vendor/github.com/mongodb/grip/send/interface.go
+++ b/vendor/github.com/mongodb/grip/send/interface.go
@@ -57,7 +57,8 @@ type Sender interface {
 
 	// If the logging sender holds any resources that require desecration
 	// they should be cleaned up in the Close() method. Close() is called
-	// by the SetSender() method before changing loggers.
+	// by the SetSender() method before changing loggers. Sender implementations
+	// that wrap other Senders may or may not close their underlying Senders.
 	Close() error
 }
 

--- a/vendor/github.com/mongodb/grip/send/multi.go
+++ b/vendor/github.com/mongodb/grip/send/multi.go
@@ -23,6 +23,9 @@ type multiSender struct {
 //
 // Use the AddToMulti helper to add additioanl senders to one of these
 // multi Sender implementations after construction.
+//
+// The Sender takes ownership of the underlying Senders, so closing this Sender
+// closes all underlying Senders.
 func NewMultiSender(name string, l LevelInfo, senders []Sender) (Sender, error) {
 	if !l.Valid() {
 		return nil, fmt.Errorf("invalid level specification: %+v", l)
@@ -53,6 +56,9 @@ func NewMultiSender(name string, l LevelInfo, senders []Sender) (Sender, error) 
 //
 // Use the AddToMulti helper to add additioanl senders to one of these
 // multi Sender implementations after construction.
+//
+// The Sender takes ownership of the underlying Senders, so closing this Sender
+// closes all underlying Senders.
 func NewConfiguredMultiSender(senders ...Sender) Sender {
 	s := &multiSender{senders: senders, Base: NewBase("")}
 	_ = s.Base.SetLevel(LevelInfo{Default: level.Invalid, Threshold: level.Invalid})

--- a/vendor/github.com/mongodb/grip/send/writer.go
+++ b/vendor/github.com/mongodb/grip/send/writer.go
@@ -36,7 +36,9 @@ type WriterSender struct {
 // buffered messages) is only whitespace, then it is not sent.
 //
 // If there are any bytes in the buffer when the Close method is
-// called, this sender flushes the buffer.
+// called, this sender flushes the buffer. WriterSender does not own the
+// underlying Sender, so users are responsible for closing the underlying Sender
+// if/when it is appropriate to release its resources.
 func NewWriterSender(s Sender) *WriterSender { return MakeWriterSender(s, s.Level().Default) }
 
 // MakeWriterSender returns an sender interface that also implements
@@ -90,7 +92,7 @@ func (s *WriterSender) doSend() error {
 	}
 }
 
-// Close writes any buffered messages to the underlying Sender. Does
+// Close writes any buffered messages to the underlying Sender. This does
 // not close the underlying sender.
 func (s *WriterSender) Close() error {
 	s.mu.Lock()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1150

Since we have no guarantees on who owns the sender after you wrap it, this both closes the wrapper sender and the base sender. This assumes that potentially closing senders multiple times is acceptable.