### PR TITLE
MAKE-1159: enforce non-interactive options in SSH client

### DIFF
--- a/cli/ssh_client.go
+++ b/cli/ssh_client.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
@@ -27,10 +29,13 @@ func NewSSHClient(remoteOpts options.Remote, clientOpts ClientOptions, trackProc
 	if err := remoteOpts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "problem validating remote options")
 	}
-	// We have to suppress logs from SSH, because it will prevent the JSON
+	// We have to run SSH without output, because it will prevent the JSON
 	// output from the Jasper CLI from being parsed correctly (e.g. adding a
 	// host to the known hosts file generates a warning).
-	remoteOpts.Args = append([]string{"-o", "LogLevel=QUIET"}, remoteOpts.Args...)
+	remoteOpts.Args = append(remoteOpts.Args...
+		"-T",
+		"-o", "LogLevel=QUIET",
+	)
 
 	if err := clientOpts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "problem validating client options")

--- a/cli/ssh_client.go
+++ b/cli/ssh_client.go
@@ -5,9 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
@@ -37,7 +36,7 @@ func NewSSHClient(remoteOpts options.Remote, clientOpts ClientOptions, trackProc
 	// We have to run SSH without output, because it will prevent the JSON
 	// output from the Jasper CLI from being parsed correctly (e.g. adding a
 	// host to the known hosts file generates a warning).
-	remoteOpts.Args = append(remoteOpts.Args...
+	remoteOpts.Args = append(remoteOpts.Args,
 		"-T",
 		"-o", "LogLevel=QUIET",
 	)

--- a/cli/ssh_client.go
+++ b/cli/ssh_client.go
@@ -29,6 +29,11 @@ func NewSSHClient(remoteOpts options.Remote, clientOpts ClientOptions, trackProc
 	if err := remoteOpts.Validate(); err != nil {
 		return nil, errors.Wrap(err, "problem validating remote options")
 	}
+	for _, arg := range remoteOpts.Args {
+		if strings.HasPrefix(arg, "-v") {
+			return nil, errors.New("cannot use verbose arguments in non-interactive SSH client")
+		}
+	}
 	// We have to run SSH without output, because it will prevent the JSON
 	// output from the Jasper CLI from being parsed correctly (e.g. adding a
 	// host to the known hosts file generates a warning).

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,19 +3,28 @@ import:
   - package: github.com/pkg/errors
   - package: github.com/golang/uuid
   - package: github.com/stretchr/testify
+  - package: github.com/mongodb/amboy
+  - package: github.com/mongodb/ftdc
   - package: github.com/mongodb/grip
+  - package: github.com/evergreen-ci/aviation
+  - package: github.com/evergreen-ci/birch
   - package: github.com/evergreen-ci/gimlet
+  - package: github.com/evergreen-ci/mrpc
+  - package: github.com/evergreen-ci/poplar
+  - package: github.com/evergreen-ci/service
+  - package: github.com/evergreen-ci/timber
   - package: github.com/tychoish/bond
   - package: github.com/tychoish/lru
   - package: github.com/mholt/archiver
   - package: github.com/montanaflynn/stats
-  - package: github.com/mongodb/amboy
   - package: github.com/containerd/cgroups
+  - package: github.com/opencontainers/runtime-spec
+  - package: github.com/docker/go-units
+  - package: github.com/coreos/go-systemd
+  - package: github.com/godbus/dbus
+  - package: github.com/gogo/protobuf
   - package: github.com/urfave/cli
-  - package: github.com/evergreen-ci/aviation
   - package: github.com/tychoish/mongorpc
-  - package: github.com/mongodb/ftdc
-  - package: github.com/evergreen-ci/timber
   - package: golang.org/x/crypto
   - package: golang.org/x/net
   - package: golang.org/x/sys
@@ -23,4 +32,4 @@ import:
   - package: google.golang.org/genproto
   - package: github.com/golang/protobuf
   - package: go.mongodb.org/go-driver
-  - package: github.com/evergreen-ci/poplar
+  - package: github.com/cheynewallce/tabby


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1159

This disables pty allocation since we're running in non-interactive mode anyways and prevent user from running in verbose mode.

Unrelated, but also cleans up some of the glide yaml packages.