### PR TITLE
MAKE-1165: create security session for macos

### DIFF
--- a/cli/service.go
+++ b/cli/service.go
@@ -255,7 +255,8 @@ func buildRunCommand(c *cli.Context, serviceType string) []string {
 func serviceOptions(c *cli.Context) service.KeyValue {
 	opts := service.KeyValue{
 		// launchd-specific options
-		"RunAtLoad": true,
+		"RunAtLoad":     true,
+		"SessionCreate": true,
 		// Windows-specific options
 		"Password": c.String(passwordFlagName),
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1165

This is undocumented, but passing `SessionCreate` to launchd creates a user security session to give access to the user keychain.