### PR TITLE
MAKE-1174: specify process type for launchd

### DIFF
--- a/cli/service.go
+++ b/cli/service.go
@@ -257,6 +257,7 @@ func serviceOptions(c *cli.Context) service.KeyValue {
 		// launchd-specific options
 		"RunAtLoad":     true,
 		"SessionCreate": true,
+		"ProcessType":   "Interactive",
 		// Windows-specific options
 		"Password": c.String(passwordFlagName),
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -26,7 +26,7 @@ imports:
   - name: github.com/urfave/cli
     version: 693af58b4d51b8fcc7f9d89576da170765980581
   - name: github.com/evergreen-ci/service
-    version: 6a120a364c348396879d3e3a27df7dce23c9c89a
+    version: d9382e39d76857e2fe92a379d89f3c86fe507c4d
   - name: github.com/cheynewallace/tabby
     version: b7224f6123093cc04ce961170a360e1d22e214a5
   - name: github.com/evergreen-ci/aviation

--- a/vendor/github.com/evergreen-ci/service/service.go
+++ b/vendor/github.com/evergreen-ci/service/service.go
@@ -77,6 +77,7 @@ const (
 	optionSessionCreateDefault = false
 	optionLogOutput            = "LogOutput"
 	optionLogOutputDefault     = false
+	optionProcessType          = "ProcessType"
 
 	optionRunWait      = "RunWait"
 	optionReloadSignal = "ReloadSignal"
@@ -135,6 +136,7 @@ type Config struct {
 	//    - RunAtLoad     bool   (false)
 	//    - UserService   bool   (false) - Install as a current user service.
 	//    - SessionCreate bool   (false) - Create a full user session.
+	//    - ProcessType	  string ()      - Apply resource limits depending kind type.
 	//  * POSIX
 	//    - SystemdScript string ()                 - Use custom systemd script
 	//    - UpstartScript string ()                 - Use custom upstart script

--- a/vendor/github.com/evergreen-ci/service/service_darwin.go
+++ b/vendor/github.com/evergreen-ci/service/service_darwin.go
@@ -160,12 +160,14 @@ func (s *darwinLaunchdService) Install() error {
 
 		KeepAlive, RunAtLoad bool
 		SessionCreate        bool
+		ProcessType          string
 	}{
 		Config:        s.Config,
 		Path:          path,
 		KeepAlive:     s.Option.bool(optionKeepAlive, optionKeepAliveDefault),
 		RunAtLoad:     s.Option.bool(optionRunAtLoad, optionRunAtLoadDefault),
 		SessionCreate: s.Option.bool(optionSessionCreate, optionSessionCreateDefault),
+		ProcessType:   s.Option.string(optionProcessType, ""),
 	}
 
 	return s.template().Execute(f, to)
@@ -279,6 +281,7 @@ var launchdConfig = `<?xml version='1.0' encoding='UTF-8'?>
 <string>{{$value}}</string>
 {{end}}</dict>
 {{end}}
+{{if .ProcessType}}<key>ProcessType</key><string>{{html .ProcessType}}</string>{{end}}
 <key>SessionCreate</key><{{bool .SessionCreate}}/>
 <key>KeepAlive</key><{{bool .KeepAlive}}/>
 <key>RunAtLoad</key><{{bool .RunAtLoad}}/>


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1174

I'm going to try more things to diagnose the problems on the mac hosts and test the hypothesis that maybe the launchctl daemon is excessively limiting the agent's resources. This option tells launchd to not apply resource limits to Jasper (and by extension, the agent). See [the relevant StackExchange post](https://apple.stackexchange.com/questions/322557/why-is-an-application-running-so-slowly-when-started-with-launchctl).