### PR TITLE
MAKE-1149: update golangci-lint

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -20,7 +20,7 @@ import (
 
 // RunCMD provides a simple user-centered command-line interface for
 // running commands on a remote instance.
-func RunCMD() cli.Command {
+func RunCMD() cli.Command { //nolint: gocognit
 	const (
 		commandFlagName = "command"
 		envFlagName     = "env"

--- a/cli/service.go
+++ b/cli/service.go
@@ -320,7 +320,7 @@ func serviceConfig(serviceType string, c *cli.Context, args []string) *service.C
 // makeUserEnvironment sets up the environment variables for the service. It
 // attempts to reads the common user environment variables from /etc/passwd for
 // upstart and sysv.
-func makeUserEnvironment(user string, vars []string) map[string]string {
+func makeUserEnvironment(user string, vars []string) map[string]string { //nolint: gocognit
 	env := map[string]string{}
 	for _, v := range vars {
 		keyAndValue := strings.Split(v, "=")

--- a/cmd/run-linter/run-linter.go
+++ b/cmd/run-linter/run-linter.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
+
+	"github.com/mongodb/grip"
 )
 
 type result struct {
@@ -45,46 +48,62 @@ func (r *result) fixup(dirname string) {
 	}
 }
 
-// runs the gometalinter on a list of packages; integrating with the "make lint" target.
+// runs the golangci-lint on a list of packages; integrating with the "make lint" target.
 func main() {
 	var (
-		lintArgs       string
-		lintBin        string
-		packageList    string
-		output         string
-		packages       []string
-		results        []*result
-		hasFailingTest bool
-	)
-	gopath := os.Getenv("GOPATH")
+		lintArgs          string
+		lintBin           string
+		customLintersFlag string
+		customLinters     []string
+		packageList       string
+		output            string
+		packages          []string
+		results           []*result
+		hasFailingTest    bool
 
-	flag.StringVar(&lintArgs, "lintArgs", "", "additional args to pass to the linter")
-	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to linter")
-	flag.StringVar(&packageList, "packages", "", "list of space-separated packages")
-	flag.StringVar(&output, "output", "", "output file to write results")
+		gopath = os.Getenv("GOPATH")
+	)
+
+	gopath, _ = filepath.Abs(gopath)
+
+	flag.StringVar(&lintArgs, "lintArgs", "", "args to pass to golangci-lint")
+	flag.StringVar(&lintBin, "lintBin", filepath.Join(gopath, "bin", "golangci-lint"), "path to golangci-lint")
+	flag.StringVar(&packageList, "packages", "", "list of space separated packages")
+	flag.StringVar(&customLintersFlag, "customLinters", "", "list of comma-separated custom linter commands")
+	flag.StringVar(&output, "output", "", "output file for to write results.")
 	flag.Parse()
 
+	if len(customLintersFlag) != 0 {
+		customLinters = strings.Split(customLintersFlag, ",")
+	}
 	packages = strings.Split(strings.Replace(packageList, "-", "/", -1), " ")
 	dirname, _ := os.Getwd()
+	cwd := filepath.Base(dirname)
+	lintArgs += fmt.Sprintf(" --concurrency=%d", runtime.NumCPU()/2)
 
 	for _, pkg := range packages {
-		args := []string{lintBin, "run", lintArgs}
-		if pkg == filepath.Base(dirname) {
-			args = append(args, "./")
-		} else {
-			args = append(args, "./"+pkg)
+		pkgDir := "./"
+		if cwd != pkg {
+			pkgDir += pkg
 		}
+		args := []string{lintBin, "run", lintArgs, pkgDir}
 
 		startAt := time.Now()
 		cmd := strings.Join(args, " ")
 		out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
-
 		r := &result{
 			cmd:      strings.Join(args, " "),
 			name:     "lint-" + strings.Replace(pkg, "/", "-", -1),
 			passed:   err == nil,
 			duration: time.Since(startAt),
 			output:   strings.Split(string(out), "\n"),
+		}
+		for _, linter := range customLinters {
+			customLinterStart := time.Now()
+			out, err = exec.Command("sh", "-c", fmt.Sprintf("%s %s", linter, pkgDir)).CombinedOutput()
+			r.passed = r.passed && err == nil
+			r.duration += time.Since(customLinterStart)
+			r.output = append(r.output, strings.Split(string(out), "\n")...)
 		}
 		r.fixup(dirname)
 
@@ -108,7 +127,10 @@ func main() {
 		}()
 
 		for _, r := range results {
-			f.WriteString(r.String() + "\n")
+			if _, err = f.WriteString(r.String() + "\n"); err != nil {
+				grip.Error(err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/makefile
+++ b/makefile
@@ -44,12 +44,12 @@ lint-%:$(buildDir)/output.%.lint
 	
 # end convienence targets
 
-# lint setup targets
+# start lint setup targets
 lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/.lintSetup:$(buildDir)/golangci-lint
 	@touch $@
 $(buildDir)/golangci-lint:$(buildDir)
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.21.0 >/dev/null 2>&1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
 	@$(goEnv) $(gobin) build -o $@ $<
 # end lint setup targets

--- a/makefile
+++ b/makefile
@@ -26,7 +26,8 @@ endif
 goEnv := GOPATH=$(gopath) GOCACHE=$(gocache)$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)")
 # end environment setup
 
-compile build:
+compile $(buildDir):
+	@mkdir -p $(buildDir)
 	$(goEnv) $(gobin) build $(_compilePackages)
 compile-base:
 	$(goEnv) $(gobin) build  ./
@@ -43,12 +44,15 @@ lint-%:$(buildDir)/output.%.lint
 	
 # end convienence targets
 
-# start linting configuration
-$(buildDir)/.lintSetup:$(lintDeps) $(buildDir)
+# lint setup targets
+lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
+$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
+	@touch $@
+$(buildDir)/golangci-lint:$(buildDir)
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.21.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
 	@$(goEnv) $(gobin) build -o $@ $<
-# end lint configuration
+# end lint setup targets
 
 # benchmark setup targets
 $(buildDir)/run-benchmarks:cmd/run-benchmarks/run_benchmarks.go $(buildDir)
@@ -116,7 +120,7 @@ phony += lint $(buildDir) test coverage coverage-html
 .FORCE:
 
 clean:
-	rm -rf *.pb.go
+	rm -rf $(lintDeps) *.pb.go 
 
 clean-results:
 	rm -rf $(buildDir)/output.*

--- a/makefile
+++ b/makefile
@@ -45,7 +45,7 @@ lint-%:$(buildDir)/output.%.lint
 
 # start linting configuration
 $(buildDir)/.lintSetup:$(lintDeps) $(buildDir)
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/c87c37210f99021721d039a9176fabd25d326843/install.sh | sh -s -- -b $(buildDir) v1.21.0 >/dev/null 2>&1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.21.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
 	@$(goEnv) $(gobin) build -o $@ $<
 # end lint configuration


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1149

I'm moving all MAKE repos to use golangci-lint. This just updates the version since Jasper already uses golangci-lint.