### PR TITLE
MAKE-1179: fix test name

### DIFF
--- a/job_test.go
+++ b/job_test.go
@@ -17,29 +17,25 @@ func TestAmboyJob(t *testing.T) {
 	defer cancel()
 
 	t.Run("Registry", func(t *testing.T) {
-		count := 0
-		for n := range registry.JobTypeNames() {
-			if n == "bond-recall-download-file" {
-				continue
+		numJobs := func() int {
+			count := 0
+			for n := range registry.JobTypeNames() {
+				if n == "bond-recall-download-file" {
+					continue
+				}
+				if n != "" {
+					count++
+				}
 			}
-			if n != "" {
-				count++
-			}
+			return count
 		}
-		require.Equal(t, 0, count)
 
-		RegisterJobs(newBasicProcess)
-
-		for n := range registry.JobTypeNames() {
-			if n == "bond-recall-download-file" {
-				continue
-			}
-			if n != "" {
-				assert.Contains(t, n, "jasper")
-				count++
-			}
+		// We may run this test multiple times, so make it idempotent.
+		if numJobs() == 0 {
+			RegisterJobs(newBasicProcess)
 		}
-		require.Equal(t, 3, count)
+
+		assert.Equal(t, 3, numJobs())
 	})
 	t.Run("RoundTripMarshal", func(t *testing.T) {
 		for _, frm := range []amboy.Format{amboy.BSON2, amboy.JSON} {

--- a/output_test.go
+++ b/output_test.go
@@ -69,7 +69,7 @@ func TestGetInMemoryLogStream(t *testing.T) {
 					assert.NoError(t, err)
 					assert.Contains(t, logs, output)
 				},
-				"MultipleInMemoryoptions.LoggersReturnsLogsFromOnlyOne": func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor, output string) {
+				"MultipleInMemoryLoggersReturnLogsFromOnlyOne": func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor, output string) {
 					opts.Output.Loggers = []options.Logger{
 						{
 							Type: options.LogInMemory,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1179

I ran the logging test on a Windows spawn host many times, but I can't reproduce the hang. I'm going to say it works (or at the very least, the problem is probably something in the agent environment and not due to the test itself) unless the problem appears again.