### PR TITLE
MAKE-1311: define basic jasper build syntax structure

### DIFF
--- a/buildsystem/model/build.go
+++ b/buildsystem/model/build.go
@@ -96,9 +96,9 @@ type Output struct {
 type UploadOptions struct {
 	// Format describes the format of the output to upload.
 	Format OutputFormat `yaml:"format,omitempty"`
-	// kim: TODO: no idea what this field means.
+	// Report indicates that the output should be reported as test results.
 	Report bool `yaml:"report,omitempty"`
-	// kim:TODO: isn't this superfluous with archive options?
+	// UploadArchive indicates that the output should be uploaded as an archive.
 	UploadArchive bool `yaml:"upload_archive,omitempty"`
 	// UploadPath is the remote path where the output will be uploaded.
 	UploadPath string `yaml:"upload_path,omitempty"`

--- a/buildsystem/model/build.go
+++ b/buildsystem/model/build.go
@@ -1,0 +1,114 @@
+package model
+
+// Target represents a set of commands that can be executed.
+type Target struct {
+	// Name is the name of the target to execute.
+	Name string `yaml:"name"`
+	// Tags are labels that allow you to logically group related targets.
+	Tags []string `yaml:"tags,omitempty"`
+	// ExcludeTags allows you to specify tags that should not be applied to the
+	// task. This can be useful for excluding a target from the default tags.
+	ExcludeTags []string `yaml:"exclude_tags,omitempty"`
+	// RequiredEnvironment specifies prerequisite environment variables names
+	// that must be defined (in the local process environment? from another
+	// file?) before the target can run.
+	RequiredEnvironment []string         `yaml:"required_environment,omitempty"`
+	DependencyInfo      []DependencyInfo `yaml:"dependency_info,omitempty"`
+	// Commands are the commands that this target will run.
+	Commands []Command `yaml:"commands"`
+	// Options specify target-specific options.
+	Options TargetOptions `yaml:"options,omitempty"`
+	// Output specifies target-specific output.
+	Output Output `yaml:"output,omitempty"`
+}
+
+// DependencyInfo describes a defines necessary prerequisite dependencies and
+// outputs to determine if a target's dependencies are satisfied and if the
+// target is up-to-date.
+type DependencyInfo struct {
+	Dependencies []Dependency `yaml:"dependencies,omitempty"`
+	// ProducesFiles provides a hint to determine if the target is up-to-date.
+	// If all the files exist and are up-to-date with the cached versions, the
+	// target is considered up-to-date. If this is not provided, the target is
+	// assumed to be out of date.
+	ProducesFiles []string `yaml:"produces_files,omitempty"`
+	// OnlyAsDependency determines whether this target can be executed directly or
+	// is only usable as a dependency of other targets. By default, targets are
+	// executable.
+	OnlyAsDependency bool `yaml:"only_as_dependency,omitempty"`
+	// IgnoreDependencies determines whether dependencies are checked or not
+	// before running a target. By default, dependencies are checked before
+	// running a target.
+	IgnoreDependencies bool `yaml:"ignore_dependencies,omitempty"`
+}
+
+// Dependency describes
+type Dependency struct {
+	// Targets are names of other targets that this target depends on.
+	Targets []string `yaml:"targets,omitempty"`
+	// Files are files that this target depends on.
+	// kim: TODO: if a target depends on another file which does not exist, how
+	// will the build system know how to generate said file (same problem as
+	// Make)?
+	Files []string `yaml:"files,omitempty"`
+}
+
+// TargetOptions specify options that modify the behavior of target execution.
+type TargetOptions struct {
+	// ContinueOnError determines whether or not to continue running later
+	// targets when a target fails during execution.
+	ContinueOnError bool
+}
+
+// Command describes a command to run.
+type Command struct {
+	// Command specifies the command in shell syntax. The command is parsed
+	// according to shell syntax rules (although it will not be executed within
+	// a shell).
+	Command string `yaml:"command,omitempty"`
+	// Args are the arguments to the command. The first argument should be the
+	// binary name or path to it.
+	Args    []string       `yaml:"args,omitempty"`
+	Options CommandOptions `yaml:"options,omitempty"`
+}
+
+// CommandOptions allow you to modify a command's execution behavior.
+type CommandOptions struct {
+	// Background indicates that the command should run in the background.
+	Background bool `yaml:"background,omitempty"`
+	// Silent indicates that logs from standard output and standard error should
+	// be suppressed.
+	Silent bool `yaml:"silent,omitempty"`
+}
+
+// Output describes how to process the output of a target.
+type Output struct {
+	// Path is the path to the files created by the target.
+	Path string `yaml:"path"`
+	// ArchiveFormat is the kind of archive that should be created.
+	ArchiveFormat string `yaml:"format"`
+	// ArchivePath specifies where the archive file should be written.
+	ArchivePath   string        `yaml:"output_file"`
+	UploadOptions UploadOptions `yaml:"upload_options,omitempty"`
+}
+
+// UploadOptions describe how the output should be uploaded to a remote store.
+type UploadOptions struct {
+	// Format describes the format of the output to upload.
+	Format OutputFormat `yaml:"format,omitempty"`
+	// kim: TODO: no idea what this field means.
+	Report bool `yaml:"report,omitempty"`
+	// kim:TODO: isn't this superfluous with archive options?
+	UploadArchive bool `yaml:"upload_archive,omitempty"`
+	// UploadPath is the remote path where the output will be uploaded.
+	UploadPath string `yaml:"upload_path,omitempty"`
+}
+
+// OutputFormat is a recognized output format.
+type OutputFormat string
+
+const (
+	XUnitFormat  OutputFormat = "xunit"
+	GotestFormat OutputFormat = "gotest"
+	PoplarFormat OutputFormat = "poplar"
+)

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -84,11 +84,23 @@ tasks:
 
   - <<: *run-build
     tags: ["report"]
+    name: lint-buildsystem-generator
+
+  - <<: *run-build
+    tags: ["report"]
+    name: lint-buildsystem-model
+
+  - <<: *run-build
+    tags: ["report"]
     name: lint-cli
 
   - <<: *run-build
     tags: ["report"]
     name: lint-internal-executor
+
+  - <<: *run-build
+    tags: ["report"]
+    name: lint-jasper
 
   - <<: *run-build
     tags: ["report"]
@@ -109,14 +121,6 @@ tasks:
   - <<: *run-build
     tags: ["report"]
     name: lint-testutil
-
-  - <<: *run-build
-    tags: ["report"]
-    name: lint-buildsystem-generator
-
-  - <<: *run-build
-    tags: ["report"]
-    name: lint-buildsystem-model
 
 task_groups:
   - name: lintGroup

--- a/makefile
+++ b/makefile
@@ -122,7 +122,7 @@ $(buildDir)/:
 proto:
 	@mkdir -p remote/internal
 	protoc --go_out=plugins=grpc:remote/internal *.proto
-lint:$(buildDir) $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+lint:$(buildDir) $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
 
 test:$(buildDir) $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
 

--- a/output_test.go
+++ b/output_test.go
@@ -21,7 +21,6 @@ func TestGetInMemoryLogStream(t *testing.T) {
 		"Blocking": newBlockingProcess,
 	} {
 		t.Run(procType, func(t *testing.T) {
-
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor, output string){
 				"FailsWithNilProcess": func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor, output string) {
 					logs, err := GetInMemoryLogStream(ctx, nil, 1)
@@ -58,7 +57,7 @@ func TestGetInMemoryLogStream(t *testing.T) {
 						},
 					}
 					config := &options.LoggerConfig{}
-					config.Set(loggerProducer)
+					require.NoError(t, config.Set(loggerProducer))
 					opts.Output.Loggers = []*options.LoggerConfig{config}
 					proc, err := makeProc(ctx, opts)
 					require.NoError(t, err)
@@ -72,19 +71,19 @@ func TestGetInMemoryLogStream(t *testing.T) {
 				},
 				"MultipleInMemoryLoggersReturnLogsFromOnlyOne": func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor, output string) {
 					config1 := &options.LoggerConfig{}
-					config1.Set(&options.InMemoryLoggerOptions{
+					require.NoError(t, config1.Set(&options.InMemoryLoggerOptions{
 						InMemoryCap: 100,
 						Base: options.BaseOptions{
 							Format: options.LogFormatPlain,
 						},
-					})
+					}))
 					config2 := &options.LoggerConfig{}
-					config2.Set(&options.InMemoryLoggerOptions{
+					require.NoError(t, config2.Set(&options.InMemoryLoggerOptions{
 						InMemoryCap: 100,
 						Base: options.BaseOptions{
 							Format: options.LogFormatPlain,
 						},
-					})
+					}))
 					opts.Output.Loggers = []*options.LoggerConfig{config1, config2}
 					proc, err := makeProc(ctx, opts)
 					require.NoError(t, err)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1311

* Define jasper build target structure.
    * I left some open questions since some parts of the jasper build example syntax weren't clear on their purpose.
* Add lint-jasper to evergreen tasks.