### PR TITLE
MAKE-1347, MAKE-1373:

### DIFF
--- a/cli/generate.go
+++ b/cli/generate.go
@@ -59,7 +59,7 @@ func generateGolang() cli.Command {
 		Action: func(c *cli.Context) error {
 			workingDir := c.String(workingDirFlagName)
 			genFile := c.String(generatorFileFlagName)
-			ctrlFile := c.String(generatorFileFlagName)
+			ctrlFile := c.String(controlFileFlagName)
 			outputFile := c.String(outputFileFlagName)
 			var err error
 			if !filepath.IsAbs(workingDir) {

--- a/makefile
+++ b/makefile
@@ -1,13 +1,13 @@
 name := jasper
 buildDir := build
-srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
+srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*" -not -path "./vendor/*")
 testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-packages := $(name) cli remote remote-internal options mock testutil internal-executor metabuild-generator metabuild-model
-lintPackages := $(packages) mock testutil
-testPackages := $(packages) mock
+testPackages := $(name) cli remote options mock metabuild-generator metabuild-model
+allPackages := $(testPackages) internal-executor remote-internal testutil
+lintPackages := $(allPackages)
 projectPath := github.com/mongodb/jasper
 
-_compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(testPackages),./$(target))))
+_compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(lintPackages),./$(target))))
 coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
 coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
 
@@ -26,44 +26,42 @@ endif
 goEnv := GOPATH=$(gopath) GOCACHE=$(gocache)$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)")
 # end environment setup
 
-compile $(buildDir):
+compile $(buildDir): $(srcFiles)
 	@mkdir -p $(buildDir)
+	@touch $(buildDir)
 	$(goEnv) $(gobin) build $(_compilePackages)
 compile-base:
-	$(goEnv) $(gobin) build  ./
+	$(goEnv) $(gobin) build ./
 
 # convenience targets for runing tests and coverage tasks on a
 # specific package.
-test-%:$(buildDir)/output.%.test
+test-%: $(buildDir)/output.%.test
 	
-coverage-%:$(buildDir)/output.%.coverage
+coverage-%: $(buildDir)/output.%.coverage
 	
-html-coverage-%:$(buildDir)/output.%.coverage.html
+html-coverage-%: $(buildDir)/output.%.coverage.html
 	
-lint-%:$(buildDir)/output.%.lint
+lint-%: $(buildDir)/output.%.lint
 	
 # end convienence targets
 
 # start lint setup targets
-lintDeps := $(buildDir)/.lintSetup $(buildDir)/run-linter $(buildDir)/golangci-lint
-$(buildDir)/.lintSetup:$(buildDir)/golangci-lint
-	@touch $@
-$(buildDir)/golangci-lint:$(buildDir)
+lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
+$(buildDir)/golangci-lint: $(buildDir)
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.23.8 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/.lintSetup $(buildDir)
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)
 	@$(goEnv) $(gobin) build -o $@ $<
 # end lint setup targets
 
 # benchmark setup targets
-$(buildDir)/run-benchmarks:cmd/run-benchmarks/run_benchmarks.go $(buildDir)
+$(buildDir)/run-benchmarks: cmd/run-benchmarks/run_benchmarks.go $(buildDir)
 	$(goEnv) $(gobin) build -o $@ $<
 # end benchmark setup targets
 
 # cli targets
-cli: $(name)
-$(name): $(buildDir)/$(name)
-$(buildDir)/$(name): cmd/$(name)/$(name).go
-	@$(goEnv) $(gobin) build -o $@ $<
+$(name) cli: $(buildDir)/$(name)
+$(buildDir)/$(name): cmd/$(name)/$(name).go $(buildDir)
+	$(goEnv) $(gobin) build -o $@ $<
 # end cli targets
 
 # start test and coverage artifacts
@@ -87,17 +85,17 @@ ifneq (,$(SKIP_LONG))
 testArgs += -short
 endif
 # test execution and output handlers
-$(buildDir)/output.%.test:$(buildDir) .FORCE
+$(buildDir)/output.%.test: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@!( grep -s -q "^FAIL" $@ && grep -s -q "^WARNING: DATA RACE" $@)
 	@(grep -s -q "^PASS" $@ || grep -s -q "no test files" $@)
-$(buildDir)/output.%.coverage:$(buildDir) .FORCE
+$(buildDir)/output.%.coverage: $(buildDir) .FORCE
 	$(goEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage .FORCE
 	$(goEnv) $(gobin) tool cover -html=$< -o $@
 #  targets to generate gotest output from the linter.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir) .FORCE
+$(buildDir)/output.%.lint: $(buildDir)/run-linter $(buildDir) .FORCE
 	@$(goEnv) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 #  targets to process and generate coverage reports
 # end test and coverage artifacts
@@ -117,24 +115,21 @@ docker-cleanup:
 # end Docker
 
 # user-facing targets for basic build and development operations
-$(buildDir)/:
-	@mkdir -p $@
 proto:
 	@mkdir -p remote/internal
 	protoc --go_out=plugins=grpc:remote/internal *.proto
-lint:$(buildDir) $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
-
-test:$(buildDir) $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
-
-benchmarks:$(buildDir)/run-benchmarks $(buildDir) .FORCE
+lint: $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
+test: $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
+benchmarks: $(buildDir)/run-benchmarks .FORCE
+	@mkdir -p $(buildDir)
 	$(goEnv) ./$(buildDir)/run-benchmarks $(run-benchmark)
-coverage:$(buildDir) $(coverageOutput)
-coverage-html:$(buildDir) $(coverageHtmlOutput)
-phony += build lint $(buildDir) test coverage coverage-html docker-setup docker-cleanup $(buildDir)/$(name)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony += compile lint test coverage coverage-html docker-setup docker-cleanup
 .PHONY: $(phony) .FORCE
-.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput)
-.PRECIOUS:$(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput)
+.PRECIOUS: $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
+.PRECIOUS: $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
 # end front-ends
 
 .FORCE:

--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -61,7 +61,7 @@ func (g *Golang) Generate() (*shrub.Configuration, error) {
 			// variant.
 			if len(tasksForVariant) >= minTasksForTaskGroup {
 				tg := c.TaskGroup(getTaskGroupName(gv.Name)).SetMaxHosts(len(tasksForVariant) / 2)
-				tg.SetupTask = shrub.CommandSequence{getProjectCmd.Resolve()}
+				tg.SetupGroup = shrub.CommandSequence{getProjectCmd.Resolve()}
 
 				for _, task := range tasksForVariant {
 					_ = tg.Task(task.Name)

--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -31,7 +31,7 @@ func (g *Golang) Generate() (*shrub.Configuration, error) {
 			var tasksForVariant []*shrub.Task
 			// Make one task per package in this variant. We cannot make one
 			// task per package, because we have to account for variant-level
-			// options possibly overriding package-level options, which requires
+			// flags possibly overriding package-level flags, which requires
 			// making separate tasks with different commands.
 			for _, gvp := range gv.Packages {
 				var gps []model.GolangPackage
@@ -117,9 +117,9 @@ func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangP
 		return nil, errors.Wrap(err, "getting project path as a relative path")
 	}
 
-	testOpts := gp.Options
-	if gv.Options != nil {
-		testOpts = testOpts.Merge(*gv.Options)
+	testOpts := gp.Flags
+	if gv.Flags != nil {
+		testOpts = testOpts.Merge(*gv.Flags)
 	}
 
 	relPath := gp.Path

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -107,10 +107,8 @@ func TestGolangGenerate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: model.GolangVariantParameters{
-						Packages: []model.GolangVariantPackage{
-							{Tag: "tag"},
-						},
+					Packages: []model.GolangVariantPackage{
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -159,10 +157,8 @@ func TestGolangGenerate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: model.GolangVariantParameters{
-						Packages: []model.GolangVariantPackage{
-							{Tag: "tag"},
-						},
+					Packages: []model.GolangVariantPackage{
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -186,10 +182,8 @@ func TestGolangGenerate(t *testing.T) {
 				VariantDistro: model.VariantDistro{
 					Name: "newVariant",
 				},
-				GolangVariantParameters: model.GolangVariantParameters{
-					Packages: []model.GolangVariantPackage{
-						{Name: "nonexistent"},
-					},
+				Packages: []model.GolangVariantPackage{
+					{Name: "nonexistent"},
 				},
 			})
 			conf, err := g.Generate()
@@ -201,10 +195,8 @@ func TestGolangGenerate(t *testing.T) {
 				VariantDistro: model.VariantDistro{
 					Name: "newVariant",
 				},
-				GolangVariantParameters: model.GolangVariantParameters{
-					Packages: []model.GolangVariantPackage{
-						{Path: "nonexistent"},
-					},
+				Packages: []model.GolangVariantPackage{
+					{Path: "nonexistent"},
 				},
 			})
 			conf, err := g.Generate()
@@ -216,10 +208,8 @@ func TestGolangGenerate(t *testing.T) {
 				VariantDistro: model.VariantDistro{
 					Name: "newVariant",
 				},
-				GolangVariantParameters: model.GolangVariantParameters{
-					Packages: []model.GolangVariantPackage{
-						{Tag: "nonexistent"},
-					},
+				Packages: []model.GolangVariantPackage{
+					{Tag: "nonexistent"},
 				},
 			})
 			conf, err := g.Generate()
@@ -240,11 +230,16 @@ func TestGolangGenerate(t *testing.T) {
 			gopath := "gopath"
 
 			mg := model.Golang{
-				Environment: map[string]string{
-					"GOPATH": gopath,
-					"GOROOT": "some_goroot",
+				GolangGeneralConfig: model.GolangGeneralConfig{
+					GeneralConfig: model.GeneralConfig{
+						Environment: map[string]string{
+							"GOPATH": gopath,
+							"GOROOT": "some_goroot",
+						},
+					},
+					RootPackage:      rootPackage,
+					WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
 				},
-				RootPackage: rootPackage,
 				Packages: []model.GolangPackage{
 					{
 						Path: "path1",
@@ -260,11 +255,9 @@ func TestGolangGenerate(t *testing.T) {
 							Name:    "variant1",
 							Distros: []string{"distro1"},
 						},
-						GolangVariantParameters: model.GolangVariantParameters{
-							Packages: []model.GolangVariantPackage{
-								{Path: "path1"},
-								{Name: "name2"},
-							},
+						Packages: []model.GolangVariantPackage{
+							{Path: "path1"},
+							{Name: "name2"},
 						},
 					},
 					{
@@ -272,14 +265,11 @@ func TestGolangGenerate(t *testing.T) {
 							Name:    "variant2",
 							Distros: []string{"distro2"},
 						},
-						GolangVariantParameters: model.GolangVariantParameters{
-							Packages: []model.GolangVariantPackage{
-								{Name: "name2"},
-							},
+						Packages: []model.GolangVariantPackage{
+							{Name: "name2"},
 						},
 					},
 				},
-				WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
 			}
 
 			g := NewGolang(mg)

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -236,9 +236,9 @@ func TestGolangGenerate(t *testing.T) {
 							"GOPATH": gopath,
 							"GOROOT": "some_goroot",
 						},
+						WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
 					},
-					RootPackage:      rootPackage,
-					WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
+					RootPackage: rootPackage,
 				},
 				Packages: []model.GolangPackage{
 					{

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -130,8 +130,8 @@ func TestGolangGenerate(t *testing.T) {
 
 			assert.Equal(t, numTasks/2, taskGroup.MaxHosts)
 			assert.Len(t, taskGroup.Tasks, numTasks)
-			require.Len(t, taskGroup.SetupTask, 1)
-			getProjectCmd := taskGroup.SetupTask[0]
+			require.Len(t, taskGroup.SetupGroup, 1)
+			getProjectCmd := taskGroup.SetupGroup[0]
 			assert.Equal(t, shrub.CmdGetProject{}.Name(), getProjectCmd.CommandName)
 			projectPath, err := g.RelProjectPath()
 			require.NoError(t, err)

--- a/metabuild/generator/make.go
+++ b/metabuild/generator/make.go
@@ -88,11 +88,11 @@ func (m *Make) taskCmds(mv model.MakeVariant, mt model.MakeTask) ([]shrub.Comman
 		if err != nil {
 			return nil, errors.Wrap(err, "resolving commands for targets")
 		}
-		opts := target.Options.Merge(mt.Options, mv.Options)
+		flags := target.Flags.Merge(mt.Flags, mv.Flags)
 		for _, targetName := range targetNames {
 			cmds = append(cmds, &shrub.CmdExec{
 				Binary:           "make",
-				Args:             append(opts, targetName),
+				Args:             append(flags, targetName),
 				Env:              env,
 				WorkingDirectory: m.WorkingDirectory,
 			})

--- a/metabuild/generator/make.go
+++ b/metabuild/generator/make.go
@@ -43,7 +43,7 @@ func (m *Make) Generate() (*shrub.Configuration, error) {
 
 			if len(tasksForVariant) >= minTasksForTaskGroup {
 				tg := c.TaskGroup(getTaskGroupName(mv.Name)).SetMaxHosts(len(tasksForVariant) / 2)
-				tg.SetupTask = shrub.CommandSequence{getProjectCmd.Resolve()}
+				tg.SetupGroup = shrub.CommandSequence{getProjectCmd.Resolve()}
 
 				for _, task := range tasksForVariant {
 					_ = tg.Task(task.Name)

--- a/metabuild/generator/make_test.go
+++ b/metabuild/generator/make_test.go
@@ -95,10 +95,8 @@ func TestMakeGenerate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					MakeVariantParameters: model.MakeVariantParameters{
-						Tasks: []model.MakeVariantTask{
-							{Tag: "tag"},
-						},
+					Tasks: []model.MakeVariantTask{
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -149,10 +147,8 @@ func TestMakeGenerate(t *testing.T) {
 						Name:    "variant1",
 						Distros: []string{"distro1"},
 					},
-					MakeVariantParameters: model.MakeVariantParameters{
-						Tasks: []model.MakeVariantTask{
-							{Tag: "tag"},
-						},
+					Tasks: []model.MakeVariantTask{
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -184,10 +180,8 @@ func TestMakeGenerate(t *testing.T) {
 					Name:    "newVariant",
 					Distros: []string{"newDistro"},
 				},
-				MakeVariantParameters: model.MakeVariantParameters{
-					Tasks: []model.MakeVariantTask{
-						{Name: "newTask"},
-					},
+				Tasks: []model.MakeVariantTask{
+					{Name: "newTask"},
 				},
 			})
 			conf, err := m.Generate()
@@ -200,10 +194,8 @@ func TestMakeGenerate(t *testing.T) {
 					Name:    "newVariant",
 					Distros: []string{"newDistro"},
 				},
-				MakeVariantParameters: model.MakeVariantParameters{
-					Tasks: []model.MakeVariantTask{
-						{Name: "nonexistent"},
-					},
+				Tasks: []model.MakeVariantTask{
+					{Name: "nonexistent"},
 				},
 			})
 			conf, err := m.Generate()
@@ -216,10 +208,8 @@ func TestMakeGenerate(t *testing.T) {
 					Name:    "newVariant",
 					Distros: []string{"newDistro"},
 				},
-				MakeVariantParameters: model.MakeVariantParameters{
-					Tasks: []model.MakeVariantTask{
-						{Tag: "nonexistent"},
-					},
+				Tasks: []model.MakeVariantTask{
+					{Tag: "nonexistent"},
 				},
 			})
 			conf, err := m.Generate()
@@ -229,6 +219,9 @@ func TestMakeGenerate(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			mm := model.Make{
+				GeneralConfig: model.GeneralConfig{
+					WorkingDirectory: "working_dir",
+				},
 				TargetSequences: []model.MakeTargetSequence{
 					{
 						Name:    "sequence1",
@@ -257,10 +250,8 @@ func TestMakeGenerate(t *testing.T) {
 							Name:    "variant1",
 							Distros: []string{"distro1"},
 						},
-						MakeVariantParameters: model.MakeVariantParameters{
-							Tasks: []model.MakeVariantTask{
-								{Name: "task1"},
-							},
+						Tasks: []model.MakeVariantTask{
+							{Name: "task1"},
 						},
 					},
 					{
@@ -268,14 +259,11 @@ func TestMakeGenerate(t *testing.T) {
 							Name:    "variant2",
 							Distros: []string{"distro2"},
 						},
-						MakeVariantParameters: model.MakeVariantParameters{
-							Tasks: []model.MakeVariantTask{
-								{Name: "task2"},
-							},
+						Tasks: []model.MakeVariantTask{
+							{Name: "task2"},
 						},
 					},
 				},
-				WorkingDirectory: "working_dir",
 			}
 
 			m := NewMake(mm)

--- a/metabuild/generator/make_test.go
+++ b/metabuild/generator/make_test.go
@@ -115,8 +115,8 @@ func TestMakeGenerate(t *testing.T) {
 			}
 
 			taskGroup := conf.TaskGroup(getTaskGroupName(m.Variants[0].Name))
-			require.Len(t, taskGroup.SetupTask, 1)
-			getProjectCmd := taskGroup.SetupTask[0]
+			require.Len(t, taskGroup.SetupGroup, 1)
+			getProjectCmd := taskGroup.SetupGroup[0]
 			assert.Equal(t, shrub.CmdGetProject{}.Name(), getProjectCmd.CommandName)
 			assert.Equal(t, m.WorkingDirectory, getProjectCmd.Params["directory"])
 			assert.Equal(t, numTasks/2, taskGroup.MaxHosts)

--- a/metabuild/model/common.go
+++ b/metabuild/model/common.go
@@ -14,7 +14,8 @@ type GeneralConfig struct {
 	// Environment defines global environment variables.
 	Environment map[string]string `yaml:"env,omitempty"`
 	// DefaultTags are tags that apply to all units of work.
-	DefaultTags []string `yaml:"default_tags,omitempty"`
+	DefaultTags      []string `yaml:"default_tags,omitempty"`
+	WorkingDirectory string   `yaml:"-"`
 }
 
 // VariantDistro represents a mapping between a variant name and the distros

--- a/metabuild/model/common.go
+++ b/metabuild/model/common.go
@@ -2,6 +2,21 @@ package model
 
 import "github.com/mongodb/grip"
 
+// VariablesSection defines an optional variables section that can be used
+// within YAML files to define additional structures (e.g. anchors).
+type VariablesSection struct {
+	Variables interface{} `yaml:"variables,omitempty"`
+}
+
+// GeneralConfig defines common top-level configuration between different
+// generator types.
+type GeneralConfig struct {
+	// Environment defines global environment variables.
+	Environment map[string]string `yaml:"env,omitempty"`
+	// DefaultTags are tags that apply to all units of work.
+	DefaultTags []string `yaml:"default_tags,omitempty"`
+}
+
 // VariantDistro represents a mapping between a variant name and the distros
 // that it runs on.
 type VariantDistro struct {

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -37,12 +37,15 @@ type Golang struct {
 // NewGolang returns a model of a Golang build configuration from a single file
 // and working directory where the GOPATH directory is located.
 func NewGolang(file, workingDir string) (*Golang, error) {
-	g := Golang{
-		WorkingDirectory: workingDir,
-	}
-	if err := utility.ReadYAMLFileStrict(file, &g); err != nil {
+	gv := struct {
+		Golang    `yaml:",inline"`
+		Variables interface{} `yaml:"variables,omitempty"`
+	}{}
+	if err := utility.ReadYAMLFileStrict(file, &gv); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
+	g := gv.Golang
+	g.WorkingDirectory = workingDir
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -14,32 +14,124 @@ import (
 // Golang represents a configuration for generating an evergreen configuration
 // from a project that uses golang.
 type Golang struct {
-	// RootPackage is the name of the root package for the project (e.g.
-	// github.com/mongodb/jasper).
-	RootPackage string `yaml:"root_package"`
+	GolangGeneralConfig `yaml:"general,inline"`
 	// Packages define packages that should be tested. They can be either
 	// explicitly defined via configuration or automatically discovered.
 	Packages []GolangPackage `yaml:"packages,omitempty"`
 	// Variants describe the mapping between packages and distros to run them
 	// on.
 	Variants []GolangVariant `yaml:"variants"`
-	// Environment defines any environment variables. GOPATH and GOROOT are
-	// required. If the working directory is specified, GOPATH must be specified
-	// as a subdirectory of the working directory.
-	Environment map[string]string `yaml:"environment"`
-	DefaultTags []string          `yaml:"default_tags,omitempty"`
+}
+
+// GolangGeneralConfig defines general top-level configuration for Golang.
+type GolangGeneralConfig struct {
+	// GeneralConfig requires that GOPATH and GOROOT be defined in the
+	// environment. If the working directory is specified, GOPATH must be
+	// specified as a subdirectory of the working directory. DefaultTags are
+	// applied to all packages (discovered or explicitly defined).
+	GeneralConfig `yaml:",inline"`
+	// RootPackage is the name of the root package for the project (e.g.
+	// github.com/mongodb/jasper).
+	RootPackage string `yaml:"root_package"`
 
 	// WorkingDirectory is the absolute path to the base directory where the
 	// GOPATH directory is located.
 	WorkingDirectory string `yaml:"-"`
 }
 
+func (ggc *GolangGeneralConfig) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(ggc.RootPackage == "", "must specify the import path of the root package of the project")
+	catcher.Wrap(ggc.validateEnvVars(), "invalid environment variables")
+	return catcher.Resolve()
+}
+
+func (ggc *GolangGeneralConfig) validateEnvVars() error {
+	catcher := grip.NewBasicCatcher()
+	for _, name := range []string{"GOPATH", "GOROOT"} {
+		if val, ok := ggc.Environment[name]; ok && val != "" {
+			ggc.Environment[name] = util.ConsistentFilepath(val)
+			continue
+		}
+		if val := os.Getenv(name); val != "" {
+			ggc.Environment[name] = util.ConsistentFilepath(val)
+			continue
+		}
+		catcher.Errorf("environment variable '%s' must be explicitly defined or already present in the environment", name)
+	}
+	if catcher.HasErrors() {
+		return catcher.Resolve()
+	}
+
+	// According to the semantics of the generator's GOPATH, it must be relative
+	// to the working directory (if specified).
+	relGopath, err := ggc.RelGopath()
+	if err != nil {
+		catcher.Wrap(err, "converting GOPATH to relative path")
+	} else {
+		ggc.Environment["GOPATH"] = relGopath
+	}
+
+	return catcher.Resolve()
+}
+
+// AbsGopath converts the relative GOPATH in the environment into an absolute
+// path based on the working directory.
+func (ggc *GolangGeneralConfig) AbsGopath() (string, error) {
+	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
+	workingDir := util.ConsistentFilepath(ggc.WorkingDirectory)
+	if workingDir != "" && !strings.HasPrefix(gopath, workingDir) {
+		return util.ConsistentFilepath(workingDir, gopath), nil
+	}
+	if !filepath.IsAbs(gopath) {
+		return "", errors.New("GOPATH is relative path, but needs to be absolute path")
+	}
+	return gopath, nil
+}
+
+// RelGopath returns the GOPATH in the environment relative to the working
+// directory (if it is defined).
+func (ggc *GolangGeneralConfig) RelGopath() (string, error) {
+	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
+	workingDir := util.ConsistentFilepath(ggc.WorkingDirectory)
+	if workingDir != "" && strings.HasPrefix(gopath, workingDir) {
+		relGopath, err := filepath.Rel(workingDir, gopath)
+		if err != nil {
+			return "", errors.Wrap(err, "making GOPATH relative")
+		}
+		return util.ConsistentFilepath(relGopath), nil
+	}
+	if filepath.IsAbs(gopath) {
+		return "", errors.New("GOPATH is absolute path, but needs to be relative path")
+	}
+	return gopath, nil
+}
+
+// AbsProjectPath returns the absolute path to the project.
+func (ggc *GolangGeneralConfig) AbsProjectPath() (string, error) {
+	gopath, err := ggc.AbsGopath()
+	if err != nil {
+		return "", errors.Wrap(err, "getting GOPATH as an absolute path")
+	}
+	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage), nil
+}
+
+// RelProjectPath returns the path to the project relative to the working
+// directory.
+func (ggc *Golang) RelProjectPath() (string, error) {
+	gopath, err := ggc.RelGopath()
+	if err != nil {
+		return "", errors.Wrap(err, "getting GOPATH as a relative path")
+	}
+	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage), nil
+}
+
 // NewGolang returns a model of a Golang build configuration from a single file
 // and working directory where the GOPATH directory is located.
 func NewGolang(file, workingDir string) (*Golang, error) {
 	gv := struct {
-		Golang    `yaml:",inline"`
-		Variables interface{} `yaml:"variables,omitempty"`
+		Golang           `yaml:",inline"`
+		VariablesSection `yaml:",inline"`
 	}{}
 	if err := utility.ReadYAMLFileStrict(file, &gv); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
@@ -75,7 +167,7 @@ func (g *Golang) ApplyDefaultTags() {
 // MergeTasks merges task definitions with the existing ones by either package
 // name or package path. For a given package name or path, existing tasks are
 // overwritten if they are already defined.
-func (g *Golang) MergePackages(gps ...GolangPackage) *Golang {
+func (g *Golang) MergePackages(gps ...GolangPackage) {
 	for _, gp := range gps {
 		if gp.Name != "" {
 			if _, i, err := g.GetPackageIndexByName(gp.Name); err == nil {
@@ -91,70 +183,27 @@ func (g *Golang) MergePackages(gps ...GolangPackage) *Golang {
 			}
 		}
 	}
-	return g
 }
 
-// MergeVariantDistros merges variant-distro mappings with the existing ones by
-// variant name. For a given variant name, existing variant-distro mappings are
-// overwritten if they are already defined.
-func (g *Golang) MergeVariantDistros(vds ...VariantDistro) *Golang {
-	for _, vd := range vds {
-		if mv, i, err := g.GetVariantIndexByName(vd.Name); err == nil {
-			mv.VariantDistro = vd
-			g.Variants[i] = *mv
+// MergeVariants merges variants with the existing ones by variant name. For a
+// given variant name, existing variants are overwritten if they are already
+// defined.
+func (g *Golang) MergeVariants(vs ...GolangVariant) {
+	for _, v := range vs {
+		if _, i, err := g.GetVariantIndexByName(v.Name); err == nil {
+			g.Variants[i] = v
 		} else {
-			g.Variants = append(g.Variants, GolangVariant{
-				VariantDistro: vd,
-			})
+			g.Variants = append(g.Variants, v)
 		}
 	}
-	return g
-}
-
-// MergeVariantParameters merges variant parameters with the existing ones by
-// name. For a given variant name, existing variant options are overwritten if
-// they are already defined.
-func (g *Golang) MergeVariantParameters(ngvps ...NamedGolangVariantParameters) *Golang {
-	for _, ngvp := range ngvps {
-		if gv, i, err := g.GetVariantIndexByName(ngvp.Name); err == nil {
-			gv.GolangVariantParameters = ngvp.GolangVariantParameters
-			g.Variants[i] = *gv
-		} else {
-			g.Variants = append(g.Variants, GolangVariant{
-				VariantDistro:           VariantDistro{Name: ngvp.Name},
-				GolangVariantParameters: ngvp.GolangVariantParameters,
-			})
-		}
-	}
-	return g
-}
-
-// MergeEnvironments merges the given environments with the existing environment
-// variables. Duplicates are overwritten in the order in which environments are
-// passed into the function.
-func (g *Golang) MergeEnvironments(envs ...map[string]string) *Golang {
-	g.Environment = MergeEnvironments(append([]map[string]string{g.Environment}, envs...)...)
-	return g
-}
-
-// MergeDefaultTags merges the given tags with the existing default tags.
-// Duplicates are ignored.
-func (g *Golang) MergeDefaultTags(tags ...string) *Golang {
-	for _, tag := range tags {
-		if !utility.StringSliceContains(g.DefaultTags, tag) {
-			g.DefaultTags = append(g.DefaultTags, tag)
-		}
-	}
-	return g
 }
 
 // Validate checks that the entire Golang build configuration is valid.
 func (g *Golang) Validate() error {
 	catcher := grip.NewBasicCatcher()
 
-	catcher.NewWhen(g.RootPackage == "", "must specify the import path of the root package of the project")
+	catcher.Wrap(g.GolangGeneralConfig.Validate(), "invalid top-level configuration")
 	catcher.Wrap(g.validatePackages(), "invalid package definitions")
-	catcher.Wrap(g.validateEnvVars(), "invalid environment variables")
 	catcher.Wrap(g.validateVariants(), "invalid variant definitions")
 
 	return catcher.Resolve()
@@ -203,35 +252,6 @@ func (g *Golang) validatePackages() error {
 // - GOROOT is defined.
 // - GOPATH is defined and can be converted to a path relative to the working
 //   directory.
-func (g *Golang) validateEnvVars() error {
-	catcher := grip.NewBasicCatcher()
-	for _, name := range []string{"GOPATH", "GOROOT"} {
-		if val, ok := g.Environment[name]; ok && val != "" {
-			g.Environment[name] = util.ConsistentFilepath(val)
-			continue
-		}
-		if val := os.Getenv(name); val != "" {
-			g.Environment[name] = util.ConsistentFilepath(val)
-			continue
-		}
-		catcher.Errorf("environment variable '%s' must be explicitly defined or already present in the environment", name)
-	}
-	if catcher.HasErrors() {
-		return catcher.Resolve()
-	}
-
-	// According to the semantics of the generator's GOPATH, it must be relative
-	// to the working directory (if specified).
-	relGopath, err := g.RelGopath()
-	if err != nil {
-		catcher.Wrap(err, "converting GOPATH to relative path")
-	} else {
-		g.Environment["GOPATH"] = relGopath
-	}
-
-	return catcher.Resolve()
-}
-
 // validateVariants checks that:
 // - Variants are defined.
 // - Each variant name is unique.
@@ -373,57 +393,6 @@ func (g *Golang) GetPackagesAndRef(gvp GolangVariantPackage) ([]GolangPackage, s
 	return nil, "", errors.New("empty package reference")
 }
 
-// AbsGopath converts the relative GOPATH in the environment into an absolute
-// path based on the working directory.
-func (g *Golang) AbsGopath() (string, error) {
-	gopath := util.ConsistentFilepath(g.Environment["GOPATH"])
-	workingDir := util.ConsistentFilepath(g.WorkingDirectory)
-	if workingDir != "" && !strings.HasPrefix(gopath, workingDir) {
-		return util.ConsistentFilepath(workingDir, gopath), nil
-	}
-	if !filepath.IsAbs(gopath) {
-		return "", errors.New("GOPATH is relative path, but needs to be absolute path")
-	}
-	return gopath, nil
-}
-
-// RelGopath returns the GOPATH in the environment relative to the working
-// directory (if it is defined).
-func (g *Golang) RelGopath() (string, error) {
-	gopath := util.ConsistentFilepath(g.Environment["GOPATH"])
-	workingDir := util.ConsistentFilepath(g.WorkingDirectory)
-	if workingDir != "" && strings.HasPrefix(gopath, workingDir) {
-		relGopath, err := filepath.Rel(workingDir, gopath)
-		if err != nil {
-			return "", errors.Wrap(err, "making GOPATH relative")
-		}
-		return util.ConsistentFilepath(relGopath), nil
-	}
-	if filepath.IsAbs(gopath) {
-		return "", errors.New("GOPATH is absolute path, but needs to be relative path")
-	}
-	return gopath, nil
-}
-
-// AbsProjectPath returns the absolute path to the project.
-func (g *Golang) AbsProjectPath() (string, error) {
-	gopath, err := g.AbsGopath()
-	if err != nil {
-		return "", errors.Wrap(err, "getting GOPATH as an absolute path")
-	}
-	return util.ConsistentFilepath(gopath, "src", g.RootPackage), nil
-}
-
-// RelProjectPath returns the path to the project relative to the working
-// directory.
-func (g *Golang) RelProjectPath() (string, error) {
-	gopath, err := g.RelGopath()
-	if err != nil {
-		return "", errors.Wrap(err, "getting GOPATH as a relative path")
-	}
-	return util.ConsistentFilepath(gopath, "src", g.RootPackage), nil
-}
-
 // GetPackageIndexByName finds the package by name and returns the task
 // definition and its index.
 func (g *Golang) GetPackageIndexByName(name string) (gp *GolangPackage, index int, err error) {
@@ -501,21 +470,7 @@ func (gp *GolangPackage) Validate() error {
 // GolangVariant defines a mapping between distros that run packages and the
 // golang packages to run.
 type GolangVariant struct {
-	VariantDistro           `yaml:",inline"`
-	GolangVariantParameters `yaml:",inline"`
-}
-
-// Validate checks that the variant-distro mapping and the Golang-specific
-// parameters are valid.
-func (gv *GolangVariant) Validate() error {
-	catcher := grip.NewBasicCatcher()
-	catcher.Add(gv.VariantDistro.Validate())
-	catcher.Add(gv.GolangVariantParameters.Validate())
-	return catcher.Resolve()
-}
-
-// GolangVariantParameters describe Golang-specific variant configuration.
-type GolangVariantParameters struct {
+	VariantDistro `yaml:",inline"`
 	// Packages lists a package name, path or or tagged group of packages
 	// relative to the root package.
 	Packages []GolangVariantPackage `yaml:"packages"`
@@ -525,28 +480,41 @@ type GolangVariantParameters struct {
 	Options *GolangRuntimeOptions `yaml:"options,omitempty"`
 }
 
-// Validate checks that the Golang-specific variant parameters are valid.
-func (gvp *GolangVariantParameters) Validate() error {
+// Validate checks that the variant-distro mapping and the Golang-specific
+// parameters are valid.
+func (gv *GolangVariant) Validate() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(len(gvp.Packages) == 0, "need to specify at least one package")
+	catcher.Add(gv.VariantDistro.Validate())
+	catcher.Wrap(gv.validatePackages(), "invalid package references")
+
+	if gv.Options != nil {
+		catcher.Wrap(gv.Options.Validate(), "invalid runtime options")
+	}
+
+	return catcher.Resolve()
+}
+
+func (gv *GolangVariant) validatePackages() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(len(gv.Packages) == 0, "need to specify at least one package")
 	pkgPaths := map[string]struct{}{}
 	pkgNames := map[string]struct{}{}
 	pkgTags := map[string]struct{}{}
-	for _, pkg := range gvp.Packages {
-		catcher.Wrap(pkg.Validate(), "invalid package reference")
-		if path := pkg.Path; path != "" {
+	for _, gvp := range gv.Packages {
+		catcher.Wrap(gvp.Validate(), "invalid package reference")
+		if path := gvp.Path; path != "" {
 			if _, ok := pkgPaths[path]; ok {
 				catcher.Errorf("duplicate reference to package path '%s'", path)
 			}
 			pkgPaths[path] = struct{}{}
 		}
-		if name := pkg.Name; name != "" {
+		if name := gvp.Name; name != "" {
 			if _, ok := pkgNames[name]; ok {
 				catcher.Errorf("duplicate reference to package name '%s'", name)
 			}
 			pkgNames[name] = struct{}{}
 		}
-		if tag := pkg.Tag; tag != "" {
+		if tag := gvp.Tag; tag != "" {
 			if _, ok := pkgTags[tag]; ok {
 				catcher.Errorf("duplicate reference to package tag '%s'", tag)
 			}
@@ -554,25 +522,6 @@ func (gvp *GolangVariantParameters) Validate() error {
 
 		}
 	}
-	if gvp.Options != nil {
-		catcher.Wrap(gvp.Options.Validate(), "invalid runtime options")
-	}
-	return catcher.Resolve()
-}
-
-// NamedGolangVariantParameters describes Golang-specific variant configuration
-// associated with a particular variant name.
-type NamedGolangVariantParameters struct {
-	// Name is the variant name.
-	Name                    string `yaml:"name"`
-	GolangVariantParameters `yaml:",inline"`
-}
-
-// Validate checks that there is a variant name and valid parameters.
-func (ngvp *NamedGolangVariantParameters) Validate() error {
-	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(ngvp.Name == "", "must specify variant name")
-	catcher.Add(ngvp.GolangVariantParameters.Validate())
 	return catcher.Resolve()
 }
 

--- a/metabuild/model/golang_control.go
+++ b/metabuild/model/golang_control.go
@@ -38,7 +38,6 @@ func NewGolangControl(file, workingDir string) (*GolangControl, error) {
 }
 
 // Build creates a Golang model from the files referenced in the GolangControl.
-// kim: TODO: refactor Make in equivalent way
 func (gc *GolangControl) Build() (*Golang, error) {
 	g := Golang{}
 

--- a/metabuild/model/golang_control.go
+++ b/metabuild/model/golang_control.go
@@ -12,72 +12,60 @@ import (
 // GolangControl represents a control file which can be used to build a Golang
 // generator from multiple files containing the necessary build configuration.
 type GolangControl struct {
-	// TODO (MAKE-1347): this configuration is required to know the full go package name but
-	// doesn't have a designated config file where it can be placed.
-	RootPackage string `yaml:"root_package"`
-
-	VariantDistroFiles    []string `yaml:"variant_distro_files"`
-	VariantParameterFiles []string `yaml:"variant_parameter_files"`
-	PackageFiles          []string `yaml:"package_files"`
-	EnvironmentFiles      []string `yaml:"environment_files"`
-	DefaultTagFiles       []string `yaml:"default_tag_files"`
+	GeneralFile  string   `yaml:"general,omitempty"`
+	VariantFiles []string `yaml:"variants"`
+	PackageFiles []string `yaml:"packages,omitempty"`
 
 	ControlDirectory string `yaml:"-"`
 	WorkingDirectory string `yaml:"-"`
 }
 
 // NewGolangControl creates a new representation of a Golang control file from
-// the given file. The working directory is the
+// the given file. The working directory is the directory where the project
+// will be cloned.
 func NewGolangControl(file, workingDir string) (*GolangControl, error) {
-	gc := GolangControl{
-		ControlDirectory: util.ConsistentFilepath(filepath.Dir(file)),
-		WorkingDirectory: workingDir,
-	}
-	if err := utility.ReadYAMLFileStrict(file, &gc); err != nil {
+	gcv := struct {
+		GolangControl    `yaml:",inline"`
+		VariablesSection `yaml:",inline"`
+	}{}
+	if err := utility.ReadYAMLFileStrict(file, &gcv); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
+	gc := gcv.GolangControl
+	gc.ControlDirectory = util.ConsistentFilepath(filepath.Dir(file))
+	gc.WorkingDirectory = workingDir
 	return &gc, nil
 }
 
 // Build creates a Golang model from the files referenced in the GolangControl.
+// kim: TODO: refactor Make in equivalent way
 func (gc *GolangControl) Build() (*Golang, error) {
-	g := Golang{RootPackage: gc.RootPackage}
+	g := Golang{}
 
 	gps, err := gc.buildPackages()
 	if err != nil {
 		return nil, errors.Wrap(err, "building package definitions")
 	}
-	_ = g.MergePackages(gps...)
+	g.MergePackages(gps...)
 
-	vds, err := gc.buildVariantDistros()
+	vs, err := gc.buildVariants()
 	if err != nil {
-		return nil, errors.Wrap(err, "building variant-distro mappings")
+		return nil, errors.Wrap(err, "building variant definitions")
 	}
-	_ = g.MergeVariantDistros(vds...)
+	g.MergeVariants(vs...)
 
-	ngvps, err := gc.buildVariantParameters()
+	ggc, err := gc.buildGeneral()
 	if err != nil {
-		return nil, errors.Wrap(err, "building variant parameters")
+		return nil, errors.Wrap(err, "building top-level configuration")
 	}
-	_ = g.MergeVariantParameters(ngvps...)
-
-	envs, err := gc.buildEnvironments()
-	if err != nil {
-		return nil, errors.Wrap(err, "building environment variables")
-	}
-	_ = g.MergeEnvironments(envs...)
-
-	tags, err := gc.buildDefaultTags()
-	if err != nil {
-		return nil, errors.Wrap(err, "building default tags")
-	}
-	_ = g.MergeDefaultTags(tags...)
+	g.GolangGeneralConfig = ggc
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")
 	}
 
 	g.WorkingDirectory = gc.WorkingDirectory
+
 	g.ApplyDefaultTags()
 
 	if err := g.Validate(); err != nil {
@@ -90,10 +78,14 @@ func (gc *GolangControl) Build() (*Golang, error) {
 func (gc *GolangControl) buildPackages() ([]GolangPackage, error) {
 	var all []GolangPackage
 	if err := withMatchingFiles(gc.ControlDirectory, gc.PackageFiles, func(file string) error {
-		gps := []GolangPackage{}
-		if err := utility.ReadYAMLFileStrict(file, &gps); err != nil {
+		gpsv := struct {
+			Packages         []GolangPackage `yaml:"packages"`
+			VariablesSection `yaml:",inline"`
+		}{}
+		if err := utility.ReadYAMLFileStrict(file, &gpsv); err != nil {
 			return errors.Wrap(err, "unmarshalling from YAML file")
 		}
+		gps := gpsv.Packages
 
 		catcher := grip.NewBasicCatcher()
 		for _, gp := range gps {
@@ -113,23 +105,27 @@ func (gc *GolangControl) buildPackages() ([]GolangPackage, error) {
 	return all, nil
 }
 
-func (gc *GolangControl) buildVariantDistros() ([]VariantDistro, error) {
-	var all []VariantDistro
-	if err := withMatchingFiles(gc.ControlDirectory, gc.VariantDistroFiles, func(file string) error {
-		vds := []VariantDistro{}
-		if err := utility.ReadYAMLFileStrict(file, &vds); err != nil {
+func (gc *GolangControl) buildVariants() ([]GolangVariant, error) {
+	var all []GolangVariant
+	if err := withMatchingFiles(gc.ControlDirectory, gc.VariantFiles, func(file string) error {
+		vsv := struct {
+			Variants         []GolangVariant `yaml:"variants"`
+			VariablesSection `yaml:",inline"`
+		}{}
+		if err := utility.ReadYAMLFileStrict(file, &vsv); err != nil {
 			return errors.Wrap(err, "unmarshalling from YAML file")
 		}
+		vs := vsv.Variants
 
 		catcher := grip.NewBasicCatcher()
-		for _, vd := range vds {
-			catcher.Wrapf(vd.Validate(), "variant '%s'", vd.Name)
+		for _, v := range vs {
+			catcher.Wrapf(v.Validate(), "variant '%s'", v.Name)
 		}
 		if catcher.HasErrors() {
-			return errors.Wrap(catcher.Resolve(), "invalid variant-distro mappings")
+			return errors.Wrap(catcher.Resolve(), "invalid variant definition(s)")
 		}
 
-		all = append(all, vds...)
+		all = append(all, vs...)
 
 		return nil
 	}); err != nil {
@@ -139,66 +135,18 @@ func (gc *GolangControl) buildVariantDistros() ([]VariantDistro, error) {
 	return all, nil
 }
 
-func (gc *GolangControl) buildVariantParameters() ([]NamedGolangVariantParameters, error) {
-	var all []NamedGolangVariantParameters
-
-	if err := withMatchingFiles(gc.ControlDirectory, gc.VariantParameterFiles, func(file string) error {
-		ngvps := []NamedGolangVariantParameters{}
-		if err := utility.ReadYAMLFileStrict(file, &ngvps); err != nil {
-			return errors.Wrap(err, "unmarshalling from YAML file")
-		}
-
-		catcher := grip.NewBasicCatcher()
-		for _, ngvp := range ngvps {
-			catcher.Wrapf(ngvp.Validate(), "variant '%s'", ngvp.Name)
-		}
-		if catcher.HasErrors() {
-			return errors.Wrap(catcher.Resolve(), "invalid variant parameters")
-		}
-
-		all = append(all, ngvps...)
-
-		return nil
-	}); err != nil {
-		return nil, errors.WithStack(err)
+func (gc *GolangControl) buildGeneral() (GolangGeneralConfig, error) {
+	ggcv := struct {
+		GolangGeneralConfig `yaml:"general"`
+		VariablesSection    `yaml:",inline"`
+	}{}
+	if err := utility.ReadYAMLFileStrict(gc.GeneralFile, &ggcv); err != nil {
+		return GolangGeneralConfig{}, errors.Wrap(err, "unmarshalling from YAML file")
+	}
+	ggc := ggcv.GolangGeneralConfig
+	if err := ggc.Validate(); err != nil {
+		return GolangGeneralConfig{}, errors.Wrap(err, "invalid top-level configuration")
 	}
 
-	return all, nil
-}
-
-func (gc *GolangControl) buildEnvironments() ([]map[string]string, error) {
-	var all []map[string]string
-
-	if err := withMatchingFiles(gc.ControlDirectory, gc.EnvironmentFiles, func(file string) error {
-		env := map[string]string{}
-		if err := utility.ReadYAMLFileStrict(file, &env); err != nil {
-			return errors.Wrap(err, "unmarshalling from YAML file")
-		}
-
-		all = append(all, env)
-
-		return nil
-	}); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return all, nil
-}
-
-func (gc *GolangControl) buildDefaultTags() ([]string, error) {
-	var all []string
-	if err := withMatchingFiles(gc.ControlDirectory, gc.DefaultTagFiles, func(file string) error {
-		tags := []string{}
-		if err := utility.ReadYAMLFileStrict(file, &tags); err != nil {
-			return errors.Wrap(err, "unmarshalling from YAML file")
-		}
-
-		all = append(all, tags...)
-
-		return nil
-	}); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return all, nil
+	return ggc, nil
 }

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -106,134 +106,60 @@ func TestGolangVariant(t *testing.T) {
 				}
 				assert.Error(t, gv.Validate())
 			},
-		} {
-			t.Run(testName, func(t *testing.T) {
-				gv := GolangVariant{
-					VariantDistro: VariantDistro{
-						Name:    "var_name",
-						Distros: []string{"distro1", "distro2"},
-					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Name: "name"},
-							{Path: "path"},
-							{Tag: "tag"},
-						},
-					},
-				}
-				testCase(t, &gv)
-			})
-		}
-	})
-}
-
-func TestGolangVariantParameters(t *testing.T) {
-	t.Run("Validate", func(t *testing.T) {
-		t.Run("SucceedsWithName", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
+			"SucceedsWithPackageName": func(t *testing.T, gv *GolangVariant) {
+				gv.Packages = []GolangVariantPackage{
 					{Name: "name"},
-				},
-			}
-			assert.NoError(t, gvp.Validate())
-		})
-		t.Run("SucceedsWithPath", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
+				}
+				assert.NoError(t, gv.Validate())
+			},
+			"SucceedsWithPackagePath": func(t *testing.T, gv *GolangVariant) {
+				gv.Packages = []GolangVariantPackage{
 					{Path: "path"},
-				},
-			}
-			assert.NoError(t, gvp.Validate())
-		})
-		t.Run("SucceedsWithTag", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
+				}
+				assert.NoError(t, gv.Validate())
+			},
+			"SucceedsWithPackageTag": func(t *testing.T, gv *GolangVariant) {
+				gv.Packages = []GolangVariantPackage{
 					{Tag: "tag"},
-				},
-			}
-			assert.NoError(t, gvp.Validate())
-		})
-		t.Run("SucceedsWithMultiple", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
+				}
+				assert.NoError(t, gv.Validate())
+			},
+			"SucceedsWithMultiplePackages": func(t *testing.T, gv *GolangVariant) {
+				gv.Packages = []GolangVariantPackage{
 					{Name: "name1"},
 					{Name: "name2"},
 					{Path: "path1"},
 					{Path: "path2"},
 					{Tag: "tag1"},
 					{Tag: "tag2"},
-				},
-			}
-			assert.NoError(t, gvp.Validate())
-		})
-		t.Run("FailsWithEmpty", func(t *testing.T) {
-			gvp := GolangVariantParameters{}
-			assert.Error(t, gvp.Validate())
-		})
-		t.Run("FailsWithDuplicateName", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
-					{Name: "name"},
-					{Name: "name"},
-				},
-			}
-			assert.Error(t, gvp.Validate())
-		})
-		t.Run("FailsWithDuplicatePath", func(t *testing.T) {
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
-					{Path: "path"},
-					{Path: "path"},
-				},
-			}
-			assert.Error(t, gvp.Validate())
-		})
-		t.Run("FailsWithInvalidOptions", func(t *testing.T) {
-			opts := GolangRuntimeOptions([]string{"-v"})
-			gvp := GolangVariantParameters{
-				Packages: []GolangVariantPackage{
-					{Name: "name"},
-				},
-				Options: &opts,
-			}
-			assert.Error(t, gvp.Validate())
-		})
-	})
-}
-
-func TestNamedGolangVariantParameters(t *testing.T) {
-	t.Run("Validate", func(t *testing.T) {
-		t.Run("Succeeds", func(t *testing.T) {
-			ngvp := NamedGolangVariantParameters{
-				Name: "variant",
-				GolangVariantParameters: GolangVariantParameters{
-					Packages: []GolangVariantPackage{
-						{Name: "package"},
+				}
+				assert.NoError(t, gv.Validate())
+			},
+			"FailsWithEmpty": func(t *testing.T, gv *GolangVariant) {
+				gv = &GolangVariant{}
+				assert.Error(t, gv.Validate())
+			},
+			"FailsWithInvalidOptions": func(t *testing.T, gv *GolangVariant) {
+				opts := GolangRuntimeOptions([]string{"-v"})
+				gv.Options = &opts
+				assert.Error(t, gv.Validate())
+			},
+		} {
+			t.Run(testName, func(t *testing.T) {
+				gv := GolangVariant{
+					VariantDistro: VariantDistro{
+						Name:    "variant",
+						Distros: []string{"distro1", "distro2"},
 					},
-				},
-			}
-			assert.NoError(t, ngvp.Validate())
-		})
-		t.Run("FailsWithEmpty", func(t *testing.T) {
-			ngvp := NamedGolangVariantParameters{}
-			assert.Error(t, ngvp.Validate())
-		})
-		t.Run("FailsWithoutName", func(t *testing.T) {
-			ngvp := NamedGolangVariantParameters{
-				GolangVariantParameters: GolangVariantParameters{
 					Packages: []GolangVariantPackage{
-						{Name: "package"},
+						{Name: "name"},
+						{Path: "path"},
+						{Tag: "tag"},
 					},
-				},
-			}
-			assert.Error(t, ngvp.Validate())
-		})
-		t.Run("FailsWithInvalidParameters", func(t *testing.T) {
-			ngvp := NamedGolangVariantParameters{
-				Name: "variant",
-			}
-			assert.Error(t, ngvp.Validate())
-		})
+				}
+				testCase(t, &gv)
+			})
+		}
 	})
 }
 
@@ -525,11 +451,9 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Name: "name1"},
-							{Name: "name2"},
-						},
+					Packages: []GolangVariantPackage{
+						{Name: "name1"},
+						{Name: "name2"},
 					},
 				},
 			}
@@ -564,10 +488,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Path: "path1"},
-						},
+					Packages: []GolangVariantPackage{
+						{Path: "path1"},
 					},
 				},
 				{
@@ -575,10 +497,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Path: "path1"},
-						},
+					Packages: []GolangVariantPackage{
+						{Path: "path1"},
 					},
 				},
 			}
@@ -594,10 +514,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Name: "name"},
-						},
+					Packages: []GolangVariantPackage{
+						{Name: "name"},
 					},
 				},
 			}
@@ -610,10 +528,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Name: "nonexistent"},
-						},
+					Packages: []GolangVariantPackage{
+						{Name: "nonexistent"},
 					},
 				},
 			}
@@ -629,10 +545,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Path: "path"},
-						},
+					Packages: []GolangVariantPackage{
+						{Path: "path"},
 					},
 				},
 			}
@@ -648,11 +562,9 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Path: "path"},
-							{Tag: "tag"},
-						},
+					Packages: []GolangVariantPackage{
+						{Path: "path"},
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -665,10 +577,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Path: "nonexistent"},
-						},
+					Packages: []GolangVariantPackage{
+						{Path: "nonexistent"},
 					},
 				},
 			}
@@ -684,10 +594,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Tag: "tag"},
-						},
+					Packages: []GolangVariantPackage{
+						{Tag: "tag"},
 					},
 				},
 			}
@@ -700,10 +608,8 @@ func TestGolangValidate(t *testing.T) {
 						Name:    "variant",
 						Distros: []string{"distro"},
 					},
-					GolangVariantParameters: GolangVariantParameters{
-						Packages: []GolangVariantPackage{
-							{Tag: "nonexistent"},
-						},
+					Packages: []GolangVariantPackage{
+						{Tag: "nonexistent"},
 					},
 				},
 			}
@@ -712,10 +618,14 @@ func TestGolangValidate(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			g := Golang{
-				RootPackage: "root_package",
-				Environment: map[string]string{
-					"GOPATH": "gopath",
-					"GOROOT": "goroot",
+				GolangGeneralConfig: GolangGeneralConfig{
+					GeneralConfig: GeneralConfig{
+						Environment: map[string]string{
+							"GOPATH": "gopath",
+							"GOROOT": "goroot",
+						},
+					},
+					RootPackage: "root_package",
 				},
 				Packages: []GolangPackage{
 					{Path: "path1"},
@@ -727,10 +637,8 @@ func TestGolangValidate(t *testing.T) {
 							Name:    "variant",
 							Distros: []string{"distro"},
 						},
-						GolangVariantParameters: GolangVariantParameters{
-							Packages: []GolangVariantPackage{
-								{Path: "path1"},
-							},
+						Packages: []GolangVariantPackage{
+							{Path: "path1"},
 						},
 					},
 				},
@@ -800,12 +708,16 @@ func TestDiscoverPackages(t *testing.T) {
 			require.NoError(t, os.MkdirAll(rootPath, 0777))
 
 			g := Golang{
-				Environment: map[string]string{
-					"GOPATH": gopath,
-					"GOROOT": "some_goroot",
+				GolangGeneralConfig: GolangGeneralConfig{
+					GeneralConfig: GeneralConfig{
+						Environment: map[string]string{
+							"GOPATH": gopath,
+							"GOROOT": "some_goroot",
+						},
+					},
+					RootPackage:      rootPackage,
+					WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
 				},
-				RootPackage:      rootPackage,
-				WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
 			}
 			testCase(t, &g, rootPath)
 		})
@@ -921,7 +833,7 @@ func TestGolangMergePackages(t *testing.T) {
 				Path: "path2",
 				Tags: []string{"tag1"},
 			}
-			_ = g.MergePackages(gp)
+			g.MergePackages(gp)
 			require.Len(t, g.Packages, 2)
 			assert.Equal(t, gp, g.Packages[0])
 			assert.Equal(t, gps[1], g.Packages[1])
@@ -931,7 +843,7 @@ func TestGolangMergePackages(t *testing.T) {
 				Path: "path1",
 				Tags: []string{"tag1"},
 			}
-			_ = g.MergePackages(gp)
+			g.MergePackages(gp)
 			require.Len(t, g.Packages, 2)
 			assert.Equal(t, gps[0], g.Packages[0])
 			assert.Equal(t, gp, g.Packages[1])
@@ -942,7 +854,7 @@ func TestGolangMergePackages(t *testing.T) {
 				Path: "path1",
 				Tags: []string{"tag1"},
 			}
-			_ = g.MergePackages(gp)
+			g.MergePackages(gp)
 			require.Len(t, g.Packages, 3)
 			assert.Equal(t, gps[0:2], g.Packages[0:2])
 			assert.Equal(t, gp, g.Packages[2])
@@ -953,7 +865,7 @@ func TestGolangMergePackages(t *testing.T) {
 				Path: "path2",
 				Tags: []string{"tag1"},
 			}
-			_ = g.MergePackages(gp)
+			g.MergePackages(gp)
 			require.Len(t, g.Packages, 3)
 			assert.Equal(t, gps[0:2], g.Packages[0:2])
 			assert.Equal(t, gp, g.Packages[2])
@@ -968,12 +880,15 @@ func TestGolangMergePackages(t *testing.T) {
 	}
 }
 
-func TestGolangMergeVariantDistros(t *testing.T) {
+func TestGolangMergeVariants(t *testing.T) {
 	gvs := []GolangVariant{
 		{
 			VariantDistro: VariantDistro{
 				Name:    "variant1",
 				Distros: []string{"distro1"},
+			},
+			Packages: []GolangVariantPackage{
+				{Name: "package1"},
 			},
 		},
 		{
@@ -986,87 +901,34 @@ func TestGolangMergeVariantDistros(t *testing.T) {
 
 	for testName, testCase := range map[string]func(t *testing.T, g *Golang){
 		"OverwritesExistingWithMatchingName": func(t *testing.T, g *Golang) {
-			vd := VariantDistro{
-				Name:    "variant1",
-				Distros: []string{"distro3"},
-			}
-			_ = g.MergeVariantDistros(vd)
-			require.Len(t, g.Variants, 2)
-			assert.Equal(t, vd, g.Variants[0].VariantDistro)
-			assert.Equal(t, gvs[1], g.Variants[1])
-		},
-		"AddsNewVariant": func(t *testing.T, g *Golang) {
-			vd := VariantDistro{
-				Name:    "variant3",
-				Distros: []string{"distro3"},
-			}
-			_ = g.MergeVariantDistros(vd)
-			require.Len(t, g.Variants, 3)
-			assert.Equal(t, gvs[0:2], g.Variants[0:2])
-			assert.Equal(t, vd, g.Variants[2].VariantDistro)
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			g := Golang{
-				Variants: gvs,
-			}
-			testCase(t, &g)
-		})
-	}
-}
-
-func TestGolangMergeVariantParameters(t *testing.T) {
-	gvs := []GolangVariant{
-		{
-			VariantDistro: VariantDistro{
-				Name: "variant1",
-			},
-			GolangVariantParameters: GolangVariantParameters{
-				Packages: []GolangVariantPackage{
-					{Name: "package1"},
+			gv := GolangVariant{
+				VariantDistro: VariantDistro{
+					Name:    "variant1",
+					Distros: []string{"distro3"},
 				},
-			},
-		},
-		{
-			VariantDistro: VariantDistro{
-				Name: "variant2",
-			},
-			GolangVariantParameters: GolangVariantParameters{
 				Packages: []GolangVariantPackage{
 					{Name: "package2"},
 				},
-			},
-		},
-	}
-
-	for testName, testCase := range map[string]func(t *testing.T, g *Golang){
-		"OverwritesExistingWithMatchingName": func(t *testing.T, g *Golang) {
-			ngvp := NamedGolangVariantParameters{
-				Name: "variant1",
-				GolangVariantParameters: GolangVariantParameters{
-					Packages: []GolangVariantPackage{
-						{Name: "package3"},
-					},
-				},
 			}
-			_ = g.MergeVariantParameters(ngvp)
+			g.MergeVariants(gv)
 			require.Len(t, g.Variants, 2)
-			assert.Equal(t, ngvp.GolangVariantParameters, g.Variants[0].GolangVariantParameters)
+			assert.Equal(t, gv, g.Variants[0])
 			assert.Equal(t, gvs[1], g.Variants[1])
 		},
 		"AddsNewVariant": func(t *testing.T, g *Golang) {
-			ngvp := NamedGolangVariantParameters{
-				Name: "variant3",
-				GolangVariantParameters: GolangVariantParameters{
-					Packages: []GolangVariantPackage{
-						{Name: "package3"},
-					},
+			gv := GolangVariant{
+				VariantDistro: VariantDistro{
+					Name:    "variant3",
+					Distros: []string{"distro3"},
+				},
+				Packages: []GolangVariantPackage{
+					{Name: "distro3"},
 				},
 			}
-			_ = g.MergeVariantParameters(ngvp)
+			g.MergeVariants(gv)
 			require.Len(t, g.Variants, 3)
 			assert.Equal(t, gvs[0:2], g.Variants[0:2])
-			assert.Equal(t, ngvp.GolangVariantParameters, g.Variants[2].GolangVariantParameters)
+			assert.Equal(t, gv, g.Variants[2])
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
@@ -1074,66 +936,6 @@ func TestGolangMergeVariantParameters(t *testing.T) {
 				Variants: gvs,
 			}
 			testCase(t, &g)
-		})
-	}
-}
-
-func TestGolangMergeEnvironments(t *testing.T) {
-	env := map[string]string{
-		"key1": "val1",
-		"key2": "val2",
-	}
-	for testName, testCase := range map[string]func(t *testing.T, g *Golang){
-		"OverwritesExistingWithMatchingName": func(t *testing.T, g *Golang) {
-			newEnv := map[string]string{
-				"key1": "val3",
-			}
-			_ = g.MergeEnvironments(newEnv)
-			assert.Len(t, g.Environment, 2)
-			assert.Equal(t, newEnv["key1"], g.Environment["key1"])
-			assert.Equal(t, env["key2"], g.Environment["key2"])
-		},
-		"AddsNewEnvVars": func(t *testing.T, g *Golang) {
-			newEnv := map[string]string{
-				"key3": "val3",
-			}
-			_ = g.MergeEnvironments(newEnv)
-			assert.Len(t, g.Environment, 3)
-			assert.Equal(t, env["key1"], g.Environment["key1"])
-			assert.Equal(t, env["key2"], g.Environment["key2"])
-			assert.Equal(t, newEnv["key3"], g.Environment["key3"])
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			g := Golang{
-				Environment: env,
-			}
-			testCase(t, &g)
-		})
-	}
-}
-
-func TestGolangMergeDefaultTags(t *testing.T) {
-	defaultTags := []string{"tag"}
-	for testName, testCase := range map[string]func(t *testing.T, m *Golang){
-		"AddsNewTags": func(t *testing.T, m *Golang) {
-			_ = m.MergeDefaultTags("newTag1", "newTag2")
-			assert.Len(t, m.DefaultTags, len(defaultTags)+2)
-			assert.Subset(t, m.DefaultTags, defaultTags)
-			assert.Contains(t, m.DefaultTags, "newTag1")
-			assert.Contains(t, m.DefaultTags, "newTag2")
-		},
-		"IgnoresDuplicateTags": func(t *testing.T, m *Golang) {
-			_ = m.MergeDefaultTags("tag")
-			assert.Len(t, m.DefaultTags, len(defaultTags))
-			assert.Subset(t, m.DefaultTags, defaultTags)
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			m := Golang{
-				DefaultTags: defaultTags,
-			}
-			testCase(t, &m)
 		})
 	}
 }
@@ -1183,7 +985,11 @@ func TestGolangApplyDefaultTags(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			m := Golang{
-				DefaultTags: defaultTags,
+				GolangGeneralConfig: GolangGeneralConfig{
+					GeneralConfig: GeneralConfig{
+						DefaultTags: defaultTags,
+					},
+				},
 			}
 			testCase(t, &m)
 		})

--- a/metabuild/model/make.go
+++ b/metabuild/model/make.go
@@ -24,12 +24,15 @@ type Make struct {
 // NewMake creates a new evergreen config generator for Make from a single file
 // that contains all the necessary generation information.
 func NewMake(file, workingDir string) (*Make, error) {
-	m := Make{
-		WorkingDirectory: workingDir,
-	}
-	if err := utility.ReadYAMLFileStrict(file, &m); err != nil {
+	mv := struct {
+		Make      `yaml:",inline"`
+		Variables interface{} `yaml:"variables,omitempty"`
+	}{}
+	if err := utility.ReadYAMLFileStrict(file, &mv); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
+	m := mv.Make
+	m.WorkingDirectory = workingDir
 
 	m.ApplyDefaultTags()
 

--- a/metabuild/model/make.go
+++ b/metabuild/model/make.go
@@ -8,17 +8,16 @@ import (
 
 // Make represents the configuration for Make-based projects.
 type Make struct {
+	// GeneralConfig defines general top-level configuration for Make.
+	// Environment defines global environment variables. Definitions can be
+	// overridden at the task or variant level.
+	// DefaultTags are applied to all defined tasks unless explicitly excluded.
+	// WorkingDirectory determines the directory where the project will be
+	// cloned.
+	GeneralConfig   `yaml:",inline"`
 	TargetSequences []MakeTargetSequence `yaml:"sequences,omitempty"`
 	Tasks           []MakeTask           `yaml:"tasks,omitempty"`
 	Variants        []MakeVariant        `yaml:"variants"`
-	DefaultTags     []string             `yaml:"default_tags,omitempty"`
-	// Environment defines global environment variables. Definitions can be
-	// overridden at the task or variant level.
-	Environment map[string]string `yaml:"environment,omitempty"`
-
-	// WorkingDirectory determines the project working directory where the
-	// project will be cloned.
-	WorkingDirectory string `yaml:"-"`
 }
 
 // NewMake creates a new evergreen config generator for Make from a single file
@@ -58,7 +57,7 @@ func (m *Make) ApplyDefaultTags() {
 // MergeTargetSequences merges target sequence definitions with the existing
 // ones by sequence name. For a given sequence name, existing targets are
 // overwritten if they are already defined.
-func (m *Make) MergeTargetSequences(mtss ...MakeTargetSequence) *Make {
+func (m *Make) MergeTargetSequences(mtss ...MakeTargetSequence) {
 	for _, mts := range mtss {
 		if _, i, err := m.GetTargetSequenceIndexByName(mts.Name); err == nil {
 			m.TargetSequences[i] = mts
@@ -66,12 +65,11 @@ func (m *Make) MergeTargetSequences(mtss ...MakeTargetSequence) *Make {
 			m.TargetSequences = append(m.TargetSequences, mts)
 		}
 	}
-	return m
 }
 
 // MergeTasks merges task definitions with the existing ones by task name. For a
 // given task name, existing tasks are overwritten if they are already defined.
-func (m *Make) MergeTasks(mts ...MakeTask) *Make {
+func (m *Make) MergeTasks(mts ...MakeTask) {
 	for _, mt := range mts {
 		if _, i, err := m.GetTaskIndexByName(mt.Name); err == nil {
 			m.Tasks[i] = mt
@@ -79,42 +77,19 @@ func (m *Make) MergeTasks(mts ...MakeTask) *Make {
 			m.Tasks = append(m.Tasks, mt)
 		}
 	}
-	return m
 }
 
-// MergeVariantDistros merges variant-distro mappings with the existing ones by
-// variant name. For a given variant name, existing variant-distro mappings are
-// overwritten if they are already defined.
-func (m *Make) MergeVariantDistros(vds ...VariantDistro) *Make {
-	for _, vd := range vds {
-		if mv, i, err := m.GetVariantIndexByName(vd.Name); err == nil {
-			mv.VariantDistro = vd
-			m.Variants[i] = *mv
+// MergeVariants merges variants with the existing ones by name. For a
+// givenvariant name, existing variants are overwritten if they are already
+// defined.
+func (m *Make) MergeVariants(mvs ...MakeVariant) {
+	for _, mv := range mvs {
+		if _, i, err := m.GetVariantIndexByName(mv.Name); err == nil {
+			m.Variants[i] = mv
 		} else {
-			m.Variants = append(m.Variants, MakeVariant{
-				VariantDistro: vd,
-			})
+			m.Variants = append(m.Variants, mv)
 		}
 	}
-	return m
-}
-
-// MergeVariantParameters merges variant parameters with the existing ones by
-// name. For a given variant name, existing variant options are overwritten if
-// they are already defined.
-func (m *Make) MergeVariantParameters(nmvps ...NamedMakeVariantParameters) *Make {
-	for _, nmvp := range nmvps {
-		if mv, i, err := m.GetVariantIndexByName(nmvp.Name); err == nil {
-			mv.MakeVariantParameters = nmvp.MakeVariantParameters
-			m.Variants[i] = *mv
-		} else {
-			m.Variants = append(m.Variants, MakeVariant{
-				VariantDistro:         VariantDistro{Name: nmvp.Name},
-				MakeVariantParameters: nmvp.MakeVariantParameters,
-			})
-		}
-	}
-	return m
 }
 
 // MergeEnvironments merges the given environments with the existing environment
@@ -139,9 +114,9 @@ func (m *Make) MergeDefaultTags(tags ...string) *Make {
 // Validate checks that the entire Make build configuration is valid.
 func (m *Make) Validate() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.Wrap(m.validateTargetSequences(), "invalid target sequence definitions")
-	catcher.Wrap(m.validateTasks(), "invalid task definitions")
-	catcher.Wrap(m.validateVariants(), "invalid variant definitions")
+	catcher.Wrap(m.validateTargetSequences(), "invalid target sequence definition(s)")
+	catcher.Wrap(m.validateTasks(), "invalid task definition(s)")
+	catcher.Wrap(m.validateVariants(), "invalid variant definition(s)")
 	return catcher.Resolve()
 }
 
@@ -196,7 +171,7 @@ func (m *Make) validateVariants() error {
 	catcher.NewWhen(len(m.Variants) == 0, "must have at least one variant")
 	varNames := map[string]struct{}{}
 	for _, mv := range m.Variants {
-		catcher.Wrapf(mv.Validate(), "invalid definitions for variant '%s'", mv.Name)
+		catcher.Wrapf(mv.Validate(), "invalid definition for variant '%s'", mv.Name)
 
 		if _, ok := varNames[mv.Name]; ok {
 			catcher.Errorf("cannot have duplicate variant name '%s'", mv.Name)
@@ -309,6 +284,7 @@ type MakeTargetSequence struct {
 	Targets []string `yaml:"targets"`
 }
 
+// Validate checks that it has a name and targets.
 func (mts *MakeTargetSequence) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(mts.Name == "", "missing target sequence name")
@@ -331,9 +307,9 @@ type MakeTask struct {
 	// precedence than global environment variables but lower precedence than
 	// variant-specific environment variables.
 	Environment map[string]string `yaml:"environment,omitempty"`
-	// Options are task-specific options that modify runtime execution. If
-	// options are specified at the target level, these options will be appended.
-	Options MakeRuntimeOptions `yaml:"options,omitempty"`
+	// Flags are task-specific flags that modify runtime execution. If
+	// flags are specified at the target level, these flags will be appended.
+	Flags MakeFlags `yaml:"flags,omitempty"`
 	// Report describe how test results are reported after the task is
 	// complete.
 	Reports []FileReport `yaml:"reports,omitempty"`
@@ -346,8 +322,8 @@ type MakeTaskTarget struct {
 	Name string `yaml:"name"`
 	// Sequences is a reference to a defined target sequence.
 	Sequence string `yaml:"sequence"`
-	// Options are target-specific options that modify runtime execution.
-	Options MakeRuntimeOptions `yaml:"options,omitempty"`
+	// Flags are target-specific flags that modify runtime execution.
+	Flags MakeFlags `yaml:"flags,omitempty"`
 	// Reports describe how output files are reported after running the target.
 	Reports []FileReport `yaml:"reports,omitempty"`
 }
@@ -385,28 +361,31 @@ func (mt *MakeTask) Validate() error {
 	return catcher.Resolve()
 }
 
-// MakeRuntimeOptions specify additional optional to the make binary to modify
-// the behavior of runtime execution.
-type MakeRuntimeOptions []string
+// MakeFlags specify additional flags to the make binary to modify the behavior
+// of runtime execution.
+type MakeFlags []string
 
-// Merge appends the new runtime options to the existing ones. Duplicates and
+// Merge appends the new runtime flags to the existing ones. Duplicates and
 // conflicting flags are appended.
-func (mro MakeRuntimeOptions) Merge(toAdd ...MakeRuntimeOptions) MakeRuntimeOptions {
-	merged := mro
-	for _, opts := range toAdd {
-		merged = append(merged, opts...)
+func (mf MakeFlags) Merge(toAdd ...MakeFlags) MakeFlags {
+	merged := mf
+	for _, flags := range toAdd {
+		merged = append(merged, flags...)
 	}
 	return merged
 }
 
 // MakeVariant defines a variant that runs Make tasks.
 type MakeVariant struct {
-	VariantDistro         `yaml:",inline"`
-	MakeVariantParameters `yaml:",inline"`
-	// Options are variant-specific options that modify runtime execution. If
-	// options are specified at the task or target level, these options will be
+	VariantDistro `yaml:",inline"`
+	Tasks         []MakeVariantTask `yaml:"tasks"`
+	// Environment defines variant-specific environment variables. This has
+	// higher precedence than global or task-specific environment variables.
+	Environment map[string]string `yaml:"environment,omitempty"`
+	// Flags are variant-specific flags that modify runtime execution. If
+	// flags are specified at the task or target level, these flags will be
 	// appended.
-	Options MakeRuntimeOptions `yaml:"options,omitempty"`
+	Flags MakeFlags `yaml:"flags,omitempty"`
 }
 
 // Validate checks that the variant-distro mapping and the Make-specific
@@ -414,26 +393,18 @@ type MakeVariant struct {
 func (mv *MakeVariant) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Add(mv.VariantDistro.Validate())
-	catcher.Add(mv.MakeVariantParameters.Validate())
+	catcher.Add(mv.validateTasks())
 	return catcher.Resolve()
 }
 
-// MakeVariantParameters describes Make-specific variant configuration.
-type MakeVariantParameters struct {
-	Tasks []MakeVariantTask `yaml:"tasks"`
-	// Environment defines variant-specific environment variables. This has
-	// higher precedence than global or task-specific environment variables.
-	Environment map[string]string `yaml:"environment,omitempty"`
-}
-
-// Validate checks that task references are specified and each reference is
+// validateTasks checks that task references are specified and each reference is
 // valid.
-func (mvp *MakeVariantParameters) Validate() error {
+func (mv *MakeVariant) validateTasks() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(len(mvp.Tasks) == 0, "must specify at least one task")
+	catcher.NewWhen(len(mv.Tasks) == 0, "must specify at least one task")
 	taskNames := map[string]struct{}{}
 	taskTags := map[string]struct{}{}
-	for _, mvt := range mvp.Tasks {
+	for _, mvt := range mv.Tasks {
 		catcher.Wrap(mvt.Validate(), "invalid task reference")
 		if mvt.Name != "" {
 			if _, ok := taskNames[mvt.Name]; ok {
@@ -448,22 +419,6 @@ func (mvp *MakeVariantParameters) Validate() error {
 			taskTags[mvt.Tag] = struct{}{}
 		}
 	}
-	return catcher.Resolve()
-}
-
-// NamedMakeVariantParameters describes Make-specific variant configuration
-// associated with a particular variant name.
-type NamedMakeVariantParameters struct {
-	// Name is the variant name.
-	Name                  string `yaml:"name"`
-	MakeVariantParameters `yaml:",inline"`
-}
-
-// Validate checks that there is a variant name and valid parameters.
-func (nmvp *NamedMakeVariantParameters) Validate() error {
-	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(nmvp.Name == "", "must specify variant name")
-	catcher.Add(nmvp.MakeVariantParameters.Validate())
 	return catcher.Resolve()
 }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1347
https://jira.mongodb.org/browse/MAKE-1373

* Reorganize and simplify config files so that there are fewer files and similar config options are grouped together.
    * There's still some options that don't have an obvious file to be put in so I just placed them under a `general` section.
* Allow users to specify a `variables` section in their config files (mostly to let them use YAML anchors/aliases).