### PR TITLE
MAKE-1369: allow package and variant level environment variables

### DIFF
--- a/metabuild/model/common.go
+++ b/metabuild/model/common.go
@@ -18,6 +18,12 @@ type GeneralConfig struct {
 	WorkingDirectory string   `yaml:"-"`
 }
 
+func (gc *GeneralConfig) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(gc.WorkingDirectory == "", "must specify working directory")
+	return nil
+}
+
 // VariantDistro represents a mapping between a variant name and the distros
 // that it runs on.
 type VariantDistro struct {

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -461,6 +461,11 @@ func (gp *GolangPackage) Validate() error {
 	}
 	catcher.Wrap(gp.Flags.Validate(), "invalid flag(s)")
 
+	// Do not allow GOPATH to be defined at the package level, because changing
+	// the value will conflict with the value used by the variant, which
+	// determines the location to git clone the repository. Changing GOPATH here
+	// would also interact poorly with task groups due to the assumption that
+	// all packages within a variant share the same project directory location.
 	catcher.ErrorfWhen(gp.Environment["GOPATH"] != "", "cannot define package-level GOPATH in environment")
 
 	return catcher.Resolve()

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -28,9 +28,9 @@ type GolangGeneralConfig struct {
 	// GeneralConfig defines generic top-level configuration.
 	// WorkingDirectory is the absolute path to the base directory where the
 	// GOPATH directory is located.
-	// Environment requires that GOPATH and GOROOT be defined. If the working
-	// directory is specified, GOPATH must be specified as a subdirectory of the
-	// working directory.
+	// Environment requires that GOPATH and GOROOT be defined globally.
+	// GOPATH must be specified as a subdirectory of the working directory.
+	// These can be overridden the the package or variant level.
 	// DefaultTags are applied to all packages (discovered or explicitly
 	// defined) unless explicitly excluded.
 	GeneralConfig `yaml:",inline"`
@@ -42,88 +42,8 @@ type GolangGeneralConfig struct {
 func (ggc *GolangGeneralConfig) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(ggc.RootPackage == "", "must specify the import path of the root package of the project")
-	catcher.Wrap(ggc.validateEnvVars(), "invalid environment variables")
+	catcher.Wrap(ggc.GeneralConfig.Validate(), "invalid general config")
 	return catcher.Resolve()
-}
-
-func (ggc *GolangGeneralConfig) validateEnvVars() error {
-	catcher := grip.NewBasicCatcher()
-	for _, name := range []string{"GOPATH", "GOROOT"} {
-		if val, ok := ggc.Environment[name]; ok && val != "" {
-			ggc.Environment[name] = util.ConsistentFilepath(val)
-			continue
-		}
-		if val := os.Getenv(name); val != "" {
-			ggc.Environment[name] = util.ConsistentFilepath(val)
-			continue
-		}
-		catcher.Errorf("environment variable '%s' must be explicitly defined or already present in the environment", name)
-	}
-	if catcher.HasErrors() {
-		return catcher.Resolve()
-	}
-
-	// According to the semantics of the generator's GOPATH, it must be relative
-	// to the working directory (if specified).
-	relGopath, err := ggc.RelGopath()
-	if err != nil {
-		catcher.Wrap(err, "converting GOPATH to relative path")
-	} else {
-		ggc.Environment["GOPATH"] = relGopath
-	}
-
-	return catcher.Resolve()
-}
-
-// AbsGopath converts the relative GOPATH in the environment into an absolute
-// path based on the working directory.
-func (ggc *GolangGeneralConfig) AbsGopath() (string, error) {
-	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
-	workingDir := util.ConsistentFilepath(ggc.WorkingDirectory)
-	if workingDir != "" && !strings.HasPrefix(gopath, workingDir) {
-		return util.ConsistentFilepath(workingDir, gopath), nil
-	}
-	if !filepath.IsAbs(gopath) {
-		return "", errors.New("GOPATH is relative path, but needs to be absolute path")
-	}
-	return gopath, nil
-}
-
-// RelGopath returns the GOPATH in the environment relative to the working
-// directory (if it is defined).
-func (ggc *GolangGeneralConfig) RelGopath() (string, error) {
-	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
-	workingDir := util.ConsistentFilepath(ggc.WorkingDirectory)
-	if workingDir != "" && strings.HasPrefix(gopath, workingDir) {
-		relGopath, err := filepath.Rel(workingDir, gopath)
-		if err != nil {
-			return "", errors.Wrap(err, "making GOPATH relative")
-		}
-		return util.ConsistentFilepath(relGopath), nil
-	}
-	if filepath.IsAbs(gopath) {
-		return "", errors.New("GOPATH is absolute path, but needs to be relative path")
-	}
-	return gopath, nil
-}
-
-// AbsProjectPath returns the absolute path to the project.
-func (ggc *GolangGeneralConfig) AbsProjectPath() (string, error) {
-	gopath, err := ggc.AbsGopath()
-	if err != nil {
-		return "", errors.Wrap(err, "getting GOPATH as an absolute path")
-	}
-	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage), nil
-}
-
-// RelProjectPath returns the path to the project relative to the working
-// directory.
-func (ggc *GolangGeneralConfig) RelProjectPath() (string, error) {
-	gopath, err := ggc.RelGopath()
-	if err != nil {
-		return "", errors.Wrap(err, "getting GOPATH as a relative path")
-	}
-	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage), nil
 }
 
 // NewGolang returns a model of a Golang build configuration from a single file
@@ -203,10 +123,77 @@ func (g *Golang) Validate() error {
 	catcher := grip.NewBasicCatcher()
 
 	catcher.Wrap(g.GolangGeneralConfig.Validate(), "invalid top-level configuration")
+	catcher.Wrap(g.validateEnvVars(), "invalid environment variable(s)")
 	catcher.Wrap(g.validatePackages(), "invalid package definition(s)")
 	catcher.Wrap(g.validateVariants(), "invalid variant definition(s)")
 
 	return catcher.Resolve()
+}
+
+// validateEnvVars checks that:
+// - GOROOT is defined at the top-level global environment.
+// - GOPATH is defined at the top-level global environment and can be converted
+//   to a path relative to the working directory.
+func (g *Golang) validateEnvVars() error {
+	catcher := grip.NewBasicCatcher()
+	for _, name := range []string{"GOPATH", "GOROOT"} {
+		if val := g.Environment[name]; val != "" {
+			g.Environment[name] = util.ConsistentFilepath(val)
+			continue
+		}
+		if val := os.Getenv(name); val != "" {
+			g.Environment[name] = util.ConsistentFilepath(val)
+			continue
+		}
+		catcher.Errorf("environment variable '%s' must be explicitly defined or already present in the environment", name)
+	}
+	if catcher.HasErrors() {
+		return catcher.Resolve()
+	}
+
+	// According to the semantics of this GOPATH, it must be relative to the
+	// working directory.
+	relGopath, err := g.relGopath()
+	if err != nil {
+		catcher.Wrap(err, "getting GOPATH as relative path")
+	} else {
+		g.Environment["GOPATH"] = relGopath
+	}
+
+	return catcher.Resolve()
+}
+
+// absGopath converts the relative GOPATH in the global environment into an
+// absolute path based on the working directory.
+func (ggc *GolangGeneralConfig) absGopath() (string, error) {
+	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
+	relGopath, err := relToPath(gopath, ggc.WorkingDirectory)
+	if err != nil {
+		return "", errors.Wrap(err, "global GOPATH cannot be made relative to the working directory")
+	}
+	return util.ConsistentFilepath(ggc.WorkingDirectory, relGopath), nil
+}
+
+// relGopath returns the global GOPATH in the environment relative to the
+// working directory.
+func (ggc *GolangGeneralConfig) relGopath() (string, error) {
+	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
+	relGopath, err := relToPath(gopath, ggc.WorkingDirectory)
+	if err != nil {
+		return "", errors.Wrap(err, "global GOPATH cannot be made relative to the working directory")
+	}
+	return relGopath, nil
+}
+
+// absProjectPath returns the absolute path to the project based on the given
+// gopath.
+func (ggc *GolangGeneralConfig) absProjectPath(gopath string) string {
+	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage)
+}
+
+// RelProjectPath returns the path to the project based on the given gopath.
+func (g *Golang) RelProjectPath(gopath string) string {
+	return util.ConsistentFilepath(gopath, "src", g.RootPackage)
 }
 
 // validatePackages checks that:
@@ -248,10 +235,6 @@ func (g *Golang) validatePackages() error {
 	return catcher.Resolve()
 }
 
-// validateEnvVars checks that:
-// - GOROOT is defined.
-// - GOPATH is defined and can be converted to a path relative to the working
-//   directory.
 // validateVariants checks that:
 // - Variants are defined.
 // - Each variant name is unique.
@@ -314,10 +297,11 @@ func (g *Golang) DiscoverPackages() error {
 		return errors.Wrap(err, "invalid environment variables")
 	}
 
-	projectPath, err := g.AbsProjectPath()
+	gopath, err := g.absGopath()
 	if err != nil {
-		return errors.Wrap(err, "getting project path as an absolute path")
+		return errors.Wrap(err, "getting GOPATH as an absolute path")
 	}
+	projectPath := g.absProjectPath(gopath)
 
 	if err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -451,6 +435,14 @@ type GolangPackage struct {
 	ExcludeTags []string `yaml:"exclude_tags,omitempty"`
 	// Flags are package-specific Golang flags that modify runtime execution.
 	Flags GolangFlags `yaml:"flags,omitempty"`
+	// Environment defines environment variables for this package. This takes
+	// precedence over the top-level global environment.  Therefore, if an
+	// environment variable is already defined in the global environment and is
+	// redefined in this package, the global environment variable will be
+	// overridden by the value in this environment. GOPATH cannot be redefined
+	// in a package, because it could conflict with the GOPATH used at the
+	// variant or global level.
+	Environment map[string]string `yaml:"env,omitempty"`
 }
 
 // Validate ensures that for each package:
@@ -468,6 +460,9 @@ func (gp *GolangPackage) Validate() error {
 		tags[tag] = struct{}{}
 	}
 	catcher.Wrap(gp.Flags.Validate(), "invalid flag(s)")
+
+	catcher.ErrorfWhen(gp.Environment["GOPATH"] != "", "cannot define package-level GOPATH in environment")
+
 	return catcher.Resolve()
 }
 
@@ -481,7 +476,15 @@ type GolangVariant struct {
 	// Golang are variant-specific flags that modify runtime execution.
 	// Explicitly setting these values will override any flags specified under
 	// the package definitions.
-	Flags *GolangFlags `yaml:"flags,omitempty"`
+	Flags GolangFlags `yaml:"flags,omitempty"`
+	// Environment defines environment variables for this variant. This takes
+	// precedence over the package environment and top-level global environment.
+	// This has higher precedence than the global environment. Therefore, if an
+	// environment variable is already defined in the global or package-level
+	// environment and is redefined in this variant, the global or package-level
+	// environement variable will be overridden by the value in this
+	// environment.
+	Environment map[string]string `yaml:"env,omitempty"`
 }
 
 // Validate checks that the variant-distro mapping and the Golang-specific
@@ -493,6 +496,10 @@ func (gv *GolangVariant) Validate() error {
 
 	if gv.Flags != nil {
 		catcher.Wrap(gv.Flags.Validate(), "invalid flag(s)")
+	}
+
+	if gopath := gv.Environment["GOPATH"]; gopath != "" && filepath.IsAbs(gopath) {
+		catcher.Errorf("variant-level GOPATH '%s' must be relative to the working directory", gopath)
 	}
 
 	return catcher.Resolve()

--- a/metabuild/model/golang_control.go
+++ b/metabuild/model/golang_control.go
@@ -53,13 +53,11 @@ func (gc *GolangControl) Build() (*Golang, error) {
 	}
 	g.MergeVariants(gvs...)
 
-	ggc, err := gc.buildGeneral()
+	ggc, err := gc.buildGeneral(gc.WorkingDirectory)
 	if err != nil {
 		return nil, errors.Wrap(err, "building top-level configuration")
 	}
 	g.GolangGeneralConfig = ggc
-
-	g.WorkingDirectory = gc.WorkingDirectory
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")
@@ -134,7 +132,7 @@ func (gc *GolangControl) buildVariants() ([]GolangVariant, error) {
 	return all, nil
 }
 
-func (gc *GolangControl) buildGeneral() (GolangGeneralConfig, error) {
+func (gc *GolangControl) buildGeneral(workingDir string) (GolangGeneralConfig, error) {
 	ggcv := struct {
 		GolangGeneralConfig `yaml:"general"`
 		VariablesSection    `yaml:",inline"`
@@ -144,6 +142,7 @@ func (gc *GolangControl) buildGeneral() (GolangGeneralConfig, error) {
 		return GolangGeneralConfig{}, errors.Wrap(err, "unmarshalling from YAML file")
 	}
 	ggc := ggcv.GolangGeneralConfig
+	ggc.WorkingDirectory = workingDir
 	if err := ggc.Validate(); err != nil {
 		return GolangGeneralConfig{}, errors.Wrap(err, "invalid top-level configuration")
 	}

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/evergreen-ci/utility"
@@ -408,7 +409,11 @@ func TestGolangValidate(t *testing.T) {
 			assert.Equal(t, util.ConsistentFilepath(relGopath), util.ConsistentFilepath(g.Environment["GOPATH"]))
 		},
 		"FailsIfGOPATHNotWithinWorkingDirectory": func(t *testing.T, g *Golang) {
-			g.Environment["GOPATH"] = util.ConsistentFilepath("/gopath")
+			if runtime.GOOS == "windows" {
+				g.Environment["GOPATH"] = util.ConsistentFilepath("C:", "gopath")
+			} else {
+				g.Environment["GOPATH"] = util.ConsistentFilepath("/gopath")
+			}
 			g.WorkingDirectory = util.ConsistentFilepath("/working", "directory")
 			assert.Error(t, g.Validate())
 		},

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -140,8 +140,7 @@ func TestGolangVariant(t *testing.T) {
 				assert.Error(t, gv.Validate())
 			},
 			"FailsWithInvalidOptions": func(t *testing.T, gv *GolangVariant) {
-				flags := GolangFlags([]string{"-v"})
-				gv.Flags = &flags
+				gv.Flags = GolangFlags([]string{"-v"})
 				assert.Error(t, gv.Validate())
 			},
 		} {

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -147,7 +147,7 @@ func TestGolangVariant(t *testing.T) {
 			"FailsWithAbsoluteGOPATH": func(t *testing.T, gv *GolangVariant) {
 				if runtime.GOOS == "windows" {
 					gv.Environment = map[string]string{
-						"GOPATH": util.ConsistentFilepath("C:", "gopath"),
+						"GOPATH": util.ConsistentFilepath("C:", "/gopath"),
 					}
 				} else {
 					gv.Environment = map[string]string{
@@ -384,7 +384,7 @@ func TestGolangValidate(t *testing.T) {
 			assert.Error(t, g.Validate())
 		},
 		"SucceedsWithGOROOTInEnvironment": func(t *testing.T, g *Golang) {
-			goroot := os.Getenv("GOROOT")
+			goroot := util.ConsistentFilepath(os.Getenv("GOROOT"))
 			if goroot == "" {
 				t.Skip("GOROOT is not defined in environment")
 			}
@@ -416,7 +416,7 @@ func TestGolangValidate(t *testing.T) {
 		},
 		"FailsIfGOPATHNotWithinWorkingDirectory": func(t *testing.T, g *Golang) {
 			if runtime.GOOS == "windows" {
-				g.Environment["GOPATH"] = util.ConsistentFilepath("C:", "gopath")
+				g.Environment["GOPATH"] = util.ConsistentFilepath("C:", "/gopath")
 			} else {
 				g.Environment["GOPATH"] = util.ConsistentFilepath("/gopath")
 			}

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -145,8 +145,14 @@ func TestGolangVariant(t *testing.T) {
 				assert.Error(t, gv.Validate())
 			},
 			"FailsWithAbsoluteGOPATH": func(t *testing.T, gv *GolangVariant) {
-				gv.Environment = map[string]string{
-					"GOPATH": util.ConsistentFilepath("/absolute", "gopath"),
+				if runtime.GOOS == "windows" {
+					gv.Environment = map[string]string{
+						"GOPATH": util.ConsistentFilepath("C:", "gopath"),
+					}
+				} else {
+					gv.Environment = map[string]string{
+						"GOPATH": util.ConsistentFilepath("/gopath"),
+					}
 				}
 				assert.Error(t, gv.Validate())
 			},

--- a/metabuild/model/make.go
+++ b/metabuild/model/make.go
@@ -114,6 +114,7 @@ func (m *Make) MergeDefaultTags(tags ...string) *Make {
 // Validate checks that the entire Make build configuration is valid.
 func (m *Make) Validate() error {
 	catcher := grip.NewBasicCatcher()
+	catcher.Wrap(m.GeneralConfig.Validate(), "invalid general config")
 	catcher.Wrap(m.validateTargetSequences(), "invalid target sequence definition(s)")
 	catcher.Wrap(m.validateTasks(), "invalid task definition(s)")
 	catcher.Wrap(m.validateVariants(), "invalid variant definition(s)")

--- a/metabuild/model/make_control.go
+++ b/metabuild/model/make_control.go
@@ -50,13 +50,11 @@ func (mc *MakeControl) Build() (*Make, error) {
 	}
 	m.MergeVariants(mvs...)
 
-	gc, err := mc.buildGeneral()
+	gc, err := mc.buildGeneral(mc.WorkingDirectory)
 	if err != nil {
 		return nil, errors.Wrap(err, "building top-level configuration")
 	}
 	m.GeneralConfig = gc
-
-	m.WorkingDirectory = mc.WorkingDirectory
 
 	m.ApplyDefaultTags()
 
@@ -136,7 +134,7 @@ func (mc *MakeControl) buildVariants() ([]MakeVariant, error) {
 	return all, nil
 }
 
-func (mc *MakeControl) buildGeneral() (GeneralConfig, error) {
+func (mc *MakeControl) buildGeneral(workingDir string) (GeneralConfig, error) {
 	gcv := struct {
 		GeneralConfig    `yaml:"general"`
 		VariablesSection `yaml:",inline"`
@@ -146,6 +144,11 @@ func (mc *MakeControl) buildGeneral() (GeneralConfig, error) {
 	}
 
 	gc := gcv.GeneralConfig
+	gc.WorkingDirectory = workingDir
+
+	if err := gc.Validate(); err != nil {
+		return GeneralConfig{}, errors.Wrap(err, "invalid general config")
+	}
 
 	return gc, nil
 }

--- a/metabuild/model/util.go
+++ b/metabuild/model/util.go
@@ -33,7 +33,7 @@ var errNotRelativeToWorkingDir = errors.New("converting to path relative to work
 // absolute and can be successfully converted to a relative path, it returns the
 // relative path and nil error. Otherwise, if path is absolute and cannot be
 // made relative to the working directory, it returns the path and
-// errNotRelativeToWorkingDir.  kim: TODO: update docs if necessary.
+// errNotRelativeToWorkingDir.
 func relToPath(path, workingDir string) (string, error) {
 	workingDir = util.ConsistentFilepath(workingDir)
 	path = util.ConsistentFilepath(path)

--- a/metabuild/model/util.go
+++ b/metabuild/model/util.go
@@ -1,6 +1,9 @@
 package model
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
@@ -20,4 +23,33 @@ func withMatchingFiles(workDir string, patterns []string, op func(file string) e
 	}
 
 	return nil
+}
+
+var errNotRelativeToWorkingDir = errors.New("converting to path relative to working directory")
+
+// relPathToWorkingDir attempts to make the given path relative to the working
+// directory if possible. If the path is already non-absolute, it is returned
+// unchanged and assumed to be relative to the working directory. If it is
+// absolute and can be successfully converted to a relative path, it returns the
+// relative path and nil error. Otherwise, if path is absolute and cannot be
+// made relative to the working directory, it returns the path and
+// errNotRelativeToWorkingDir.  kim: TODO: update docs if necessary.
+func relToPath(path, workingDir string) (string, error) {
+	workingDir = util.ConsistentFilepath(workingDir)
+	path = util.ConsistentFilepath(path)
+
+	if !filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	if workingDir == "" || !strings.HasPrefix(path, workingDir) {
+		return path, errNotRelativeToWorkingDir
+	}
+
+	relPath, err := filepath.Rel(workingDir, path)
+	if err != nil {
+		return path, errors.Wrap(err, errNotRelativeToWorkingDir.Error())
+	}
+
+	return util.ConsistentFilepath(relPath), nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1369

* Users can specify package-specific and variant-specific environment variables.
    * Environment precedence: global env < package env < variant env
* We don't let users specify their `GOPATH` on a package level because this would cause various problems with the fact that the `GOPATH` is used to determine the project clone directory and task group behavior would be undesirable if the `GOPATH` could change for each package.