### PR TITLE
MAKE-1371: allow package discovery to include source-only directories

### DIFF
--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -45,12 +45,8 @@ func (g *Golang) Generate() (*shrub.Configuration, error) {
 				tasksForVariant = append(tasksForVariant, newTasks...)
 			}
 
-			gopath := g.Environment["GOPATH"]
-			// kim: TODO: test that this is modified if the variant specifies a
-			// GOPATH.
-			if val := gv.Environment["GOPATH"]; val != "" {
-				gopath = val
-			}
+			env := model.MergeEnvironments(g.Environment, gv.Environment)
+			gopath := env["GOPATH"]
 			projectPath := g.RelProjectPath(gopath)
 			getProjectCmd := shrub.CmdGetProject{
 				Directory: projectPath,
@@ -105,12 +101,8 @@ func (g *Golang) generateVariantTasksForRef(c *shrub.Configuration, gv model.Gol
 }
 
 func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangPackage) *shrub.CmdSubprocessScripting {
-	gopath := g.Environment["GOPATH"]
-	// kim: TODO: test that this is modified if the variant specifies a
-	// GOPATH.
-	if val := gv.Environment["GOPATH"]; val != "" {
-		gopath = val
-	}
+	env := model.MergeEnvironments(g.Environment, gp.Environment, gv.Environment)
+	gopath := env["GOPATH"]
 	projectPath := g.RelProjectPath(gopath)
 
 	testOpts := gp.Flags
@@ -123,8 +115,6 @@ func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangP
 		relPath = "./" + relPath
 	}
 	testOpts = append(testOpts, relPath)
-
-	env := model.MergeEnvironments(g.Environment, gp.Environment, gv.Environment)
 
 	return &shrub.CmdSubprocessScripting{
 		Harness:     "golang",

--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -46,6 +46,8 @@ func (g *Golang) Generate() (*shrub.Configuration, error) {
 			}
 
 			gopath := g.Environment["GOPATH"]
+			// kim: TODO: test that this is modified if the variant specifies a
+			// GOPATH.
 			if val := gv.Environment["GOPATH"]; val != "" {
 				gopath = val
 			}
@@ -104,6 +106,8 @@ func (g *Golang) generateVariantTasksForRef(c *shrub.Configuration, gv model.Gol
 
 func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangPackage) *shrub.CmdSubprocessScripting {
 	gopath := g.Environment["GOPATH"]
+	// kim: TODO: test that this is modified if the variant specifies a
+	// GOPATH.
 	if val := gv.Environment["GOPATH"]; val != "" {
 		gopath = val
 	}

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -32,6 +32,28 @@ func TestGolangGenerate(t *testing.T) {
 		assert.EqualValues(t, g.Environment["GOROOT"], env["GOROOT"])
 	}
 
+	checkTaskWithVariant := func(t *testing.T, g *Golang, gv model.GolangVariant, task *shrub.Task) {
+		require.Len(t, task.Commands, 2)
+
+		env := model.MergeEnvironments(g.Environment, gv.Environment)
+		gopath := env["GOPATH"]
+
+		getProjectCmd := task.Commands[0]
+		assert.Equal(t, shrub.CmdGetProject{}.Name(), getProjectCmd.CommandName)
+		projectPath := g.RelProjectPath(gopath)
+		assert.Equal(t, projectPath, getProjectCmd.Params["directory"])
+
+		scriptingCmd := task.Commands[1]
+		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
+		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
+		assert.Equal(t, g.WorkingDirectory, scriptingCmd.Params["working_dir"])
+		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
+		taskEnv, ok := scriptingCmd.Params["env"].(map[string]interface{})
+		require.True(t, ok)
+		goroot := env["GOROOT"]
+		assert.EqualValues(t, goroot, taskEnv["GOROOT"])
+	}
+
 	checkTaskInTaskGroup := func(t *testing.T, g *Golang, task *shrub.Task) {
 		require.Len(t, task.Commands, 1)
 		scriptingCmd := task.Commands[0]
@@ -213,6 +235,27 @@ func TestGolangGenerate(t *testing.T) {
 			conf, err := g.Generate()
 			assert.Error(t, err)
 			assert.Zero(t, conf)
+		},
+		"VariantGOPATHOverridesGlobalGOPATH": func(t *testing.T, g *Golang) {
+			g.Packages = []model.GolangPackage{
+				{Path: "path"},
+			}
+			g.Variants = []model.GolangVariant{
+				{
+					VariantDistro: model.VariantDistro{
+						Name:    "variant",
+						Distros: []string{"distro"},
+					},
+					Packages: []model.GolangVariantPackage{
+						{Path: "path"},
+					},
+				},
+			}
+			g.Variants[0].Environment = map[string]string{"GOPATH": "variant_gopath"}
+			conf, err := g.Generate()
+			require.NoError(t, err)
+			require.Len(t, conf.Tasks, 1)
+			checkTaskWithVariant(t, g, g.Variants[0], conf.Task(getTaskName(g.Variants[0].Name, g.Packages[0].Path)))
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -37,6 +37,11 @@ type GolangGeneralConfig struct {
 	// RootPackage is the name of the root package for the project (e.g.
 	// github.com/mongodb/jasper).
 	RootPackage string `yaml:"root_package"`
+	// DiscoverSourceFiles determines whether or not source files will also be
+	// taken into consideration when automatically discovering packages. By
+	// default, packages will only be discovered if they contain test files
+	// (i.e. file that ends in "_test.go").
+	DiscoverSourceFiles bool `yaml:"discover_source_files,omitempty"`
 }
 
 func (ggc *GolangGeneralConfig) Validate() error {
@@ -280,8 +285,10 @@ func (g *Golang) validateVariants() error {
 }
 
 const (
-	// golangTestFileSuffix is the suffix indicating that a golang file is meant to
-	// be run as a test.
+	// golangFileSuffix is the suffix for a golang file.
+	golangFileSuffix = ".go"
+	// golangTestFileSuffix is the suffix indicating that a golang file is meant
+	// to be run as a test.
 	golangTestFileSuffix = "_test.go"
 	// golangVendorDir is the special vendor directory for vendoring
 	// dependencies.
@@ -318,7 +325,9 @@ func (g *Golang) DiscoverPackages() error {
 		if info.IsDir() {
 			return nil
 		}
-		if !strings.Contains(fileName, golangTestFileSuffix) {
+		if g.DiscoverSourceFiles && !strings.HasSuffix(fileName, golangFileSuffix) {
+			return nil
+		} else if !g.DiscoverSourceFiles && !strings.HasSuffix(fileName, golangTestFileSuffix) {
 			return nil
 		}
 		dir := filepath.Dir(path)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-1371

The metabuild has a feature for go projects to automatically create task definitions on a per-package basis without you having to explicitly list all the packages (it does this by walking the project directory tree). Right now, the generator will only auto-discover go packages if they have `*_test.go` files in them. This adds an option to auto-discover any package that contains a go file in it (`*.go`).