### PR TITLE
EVG-9706 use regexp

### DIFF
--- a/subtree_oom.go
+++ b/subtree_oom.go
@@ -3,6 +3,7 @@ package jasper
 import (
 	"context"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -49,12 +50,12 @@ func dmesgContainsOOMKill(line string) bool {
 }
 
 func getPidFromDmesg(line string) (int, bool) {
-	split := strings.Split(line, "Killed process")
-	if len(split) <= 1 {
+	r := regexp.MustCompile(`Killed process (\d+)`)
+	matches := r.FindStringSubmatch(line)
+	if len(matches) != 2 {
 		return 0, false
 	}
-	newSplit := strings.Split(strings.TrimSpace(split[1]), " ")
-	pid, err := strconv.Atoi(newSplit[0])
+	pid, err := strconv.Atoi(matches[1])
 	if err != nil {
 		return 0, false
 	}
@@ -62,12 +63,12 @@ func getPidFromDmesg(line string) (int, bool) {
 }
 
 func getPidFromLog(line string) (int, bool) {
-	split := strings.Split(line, "pid")
-	if len(split) <= 1 {
+	r := regexp.MustCompile(`pid (\d+)`)
+	matches := r.FindStringSubmatch(line)
+	if len(matches) != 2 {
 		return 0, false
 	}
-	newSplit := strings.Split(strings.TrimSpace(split[1]), " ")
-	pid, err := strconv.Atoi(newSplit[0])
+	pid, err := strconv.Atoi(matches[1])
 	if err != nil {
 		return 0, false
 	}

--- a/subtree_oom_test.go
+++ b/subtree_oom_test.go
@@ -9,17 +9,20 @@ import (
 func TestGetPids(t *testing.T) {
 	assert := assert.New(t)
 
-	log := "2018-10-03 21:55:21.478932+0000 0x16b Default 0x0 0 kernel: low swap: killing largest compressed process with pid 29670 (mongod) and size 1 MB"
-
 	dmesg := "[11686.043647] Killed process 2603 (flasherav) total-vm:1498536kB, anon-rss:721784kB, file-rss:4228kB"
-
 	assert.True(dmesgContainsOOMKill(dmesg))
-
 	pid, hasPid := getPidFromDmesg(dmesg)
 	assert.True(hasPid)
-	assert.Equal(pid, 2603)
+	assert.Equal(2603, pid)
 
+	dmesg = "Killed process 9823, UID 0, (FlowCon.fresher) total-vm:3098244kB, anon-rss:1157280kB, file-rss:36kB"
+	assert.True(dmesgContainsOOMKill(dmesg))
+	pid, hasPid = getPidFromDmesg(dmesg)
+	assert.True(hasPid)
+	assert.Equal(9823, pid)
+
+	log := "2018-10-03 21:55:21.478932+0000 0x16b Default 0x0 0 kernel: low swap: killing largest compressed process with pid 29670 (mongod) and size 1 MB"
 	pid, hasPid = getPidFromLog(log)
 	assert.True(hasPid)
-	assert.Equal(pid, 29670)
+	assert.Equal(29670, pid)
 }


### PR DESCRIPTION
The parsing was relying on a space after the pid, which wasn't true on rhel

```
Killed process 9823, UID 0, (FlowCon.fresher) total-vm:3098244kB, anon-rss:1157280kB, file-rss:36kB
```