### PR TITLE
EVG-12388: do not set subprocess.scripting working directory in generator

### DIFF
--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -120,7 +120,6 @@ func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangP
 
 	return &shrub.CmdSubprocessScripting{
 		Harness:     "golang",
-		WorkingDir:  g.WorkingDirectory,
 		HarnessPath: gopath,
 		// It is not a problem for the environment to set a relative GOPATH
 		// here, which conflicts with the actual GOPATH (an absolute path). The

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -25,7 +25,6 @@ func TestGolangGenerate(t *testing.T) {
 		scriptingCmd := task.Commands[1]
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
 		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
-		assert.Equal(t, g.WorkingDirectory, scriptingCmd.Params["working_dir"])
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		env, ok := scriptingCmd.Params["env"].(map[string]interface{})
 		require.True(t, ok)
@@ -46,7 +45,6 @@ func TestGolangGenerate(t *testing.T) {
 		scriptingCmd := task.Commands[1]
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
 		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
-		assert.Equal(t, g.WorkingDirectory, scriptingCmd.Params["working_dir"])
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		taskEnv, ok := scriptingCmd.Params["env"].(map[string]interface{})
 		require.True(t, ok)
@@ -60,7 +58,6 @@ func TestGolangGenerate(t *testing.T) {
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
 		gopath := g.Environment["GOPATH"]
 		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
-		assert.Equal(t, g.WorkingDirectory, scriptingCmd.Params["working_dir"])
 		projectPath := g.RelProjectPath(gopath)
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		env, ok := scriptingCmd.Params["env"].(map[string]interface{})


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12388

We have to do this for Golang, because if you generate the config on your local machine, the working directory won't exist on the host. The working directory will be automatically set to be the agent's default working directory for the task.