### PR TITLE
EVG-8507: fix test that depends on timing of context cancellation

### DIFF
--- a/process_test.go
+++ b/process_test.go
@@ -576,7 +576,6 @@ func TestProcessImplementations(t *testing.T) {
 							case <-ctx.Done():
 								assert.Fail(t, "call to Wait() took too long to finish")
 							}
-							require.NoError(t, Terminate(ctx, proc)) // Clean up.
 						},
 						"InfoHasTimeoutWhenProcessTimesOut": func(ctx context.Context, t *testing.T, _ *options.Create, makep ProcessConstructor) {
 							opts := testutil.SleepCreateOpts(100)

--- a/process_test.go
+++ b/process_test.go
@@ -557,18 +557,18 @@ func TestProcessImplementations(t *testing.T) {
 							}
 						},
 						"WaitGivesNegativeOneOnAlternativeError": func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
-							cctx, cancel := context.WithCancel(ctx)
 							proc, err := makep(ctx, testutil.SleepCreateOpts(100))
 							require.NoError(t, err)
 							require.NotNil(t, proc)
 
 							var exitCode int
 							waitFinished := make(chan bool)
+							cctx, cancel := context.WithCancel(ctx)
+							cancel()
 							go func() {
 								exitCode, err = proc.Wait(cctx)
 								waitFinished <- true
 							}()
-							cancel()
 							select {
 							case <-waitFinished:
 								assert.Error(t, err)

--- a/remote/process_test.go
+++ b/remote/process_test.go
@@ -309,18 +309,18 @@ func AddBasicProcessTests(tests ...ProcessTestCase) []ProcessTestCase {
 		{
 			Name: "WaitGivesNegativeOneOnAlternativeError",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makep jasper.ProcessConstructor) {
-				cctx, cancel := context.WithCancel(ctx)
 				proc, err := makep(ctx, testutil.SleepCreateOpts(100))
 				require.NoError(t, err)
 				require.NotNil(t, proc)
 
 				var exitCode int
+				cctx, cancel := context.WithCancel(ctx)
 				waitFinished := make(chan bool)
+				cancel()
 				go func() {
 					exitCode, err = proc.Wait(cctx)
 					waitFinished <- true
 				}()
-				cancel()
 				select {
 				case <-waitFinished:
 					require.Error(t, err)
@@ -329,7 +329,6 @@ func AddBasicProcessTests(tests ...ProcessTestCase) []ProcessTestCase {
 					assert.Fail(t, "call to Wait() took too long to finish")
 				}
 				require.NoError(t, jasper.Terminate(ctx, proc)) // Clean up.
-
 			},
 		},
 		{

--- a/remote/process_test.go
+++ b/remote/process_test.go
@@ -328,7 +328,6 @@ func AddBasicProcessTests(tests ...ProcessTestCase) []ProcessTestCase {
 				case <-ctx.Done():
 					assert.Fail(t, "call to Wait() took too long to finish")
 				}
-				require.NoError(t, jasper.Terminate(ctx, proc)) // Clean up.
 			},
 		},
 		{

--- a/remote/process_test.go
+++ b/remote/process_test.go
@@ -314,8 +314,8 @@ func AddBasicProcessTests(tests ...ProcessTestCase) []ProcessTestCase {
 				require.NotNil(t, proc)
 
 				var exitCode int
-				cctx, cancel := context.WithCancel(ctx)
 				waitFinished := make(chan bool)
+				cctx, cancel := context.WithCancel(ctx)
 				cancel()
 				go func() {
 					exitCode, err = proc.Wait(cctx)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8507

I'm not actually certain that this is the problem, but cancel the context before sending the request for `Wait()` (which should cause the process to start and then should be terminated). It should not be necessary to terminate the process after the process has already returned from `Wait()`.