### PR TITLE
EVG-8852: fixup small inconveniences in Make generator

### DIFF
--- a/makefile
+++ b/makefile
@@ -107,11 +107,16 @@ ifeq ($(docker_image),)
 endif
 
 docker-setup:
+ifeq (,$(SKIP_DOCKER_TESTS))
 	docker pull $(docker_image)
+endif
 
 docker-cleanup:
+ifeq (,$(SKIP_DOCKER_TESTS))
 	docker rm -f $(docker ps -a -q)
 	docker rmi -f $(docker_image)
+endif
+
 # end Docker
 
 # user-facing targets for basic build and development operations

--- a/metabuild/generator/util.go
+++ b/metabuild/generator/util.go
@@ -32,43 +32,50 @@ func getTaskGroupName(name string) string {
 
 // fileReportCmds converts the given files to report to the evergreen command
 // that will report the file.
-func fileReportCmds(frs ...model.FileReport) ([]shrub.Command, error) {
-	var cmds []shrub.Command
+func fileReportCmds(frs ...model.FileReport) ([]shrub.CommandDefinition, error) {
+	var cmds []shrub.CommandDefinition
 	for _, fr := range frs {
 		cmd, err := fileReportCmd(fr)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		cmds = append(cmds, cmd)
+		cmds = append(cmds, *cmd)
 	}
 	return cmds, nil
 }
 
 // fileReportCmd converts a single file report to the evergreen command that
 // will report the file.
-func fileReportCmd(fr model.FileReport) (shrub.Command, error) {
+func fileReportCmd(fr model.FileReport) (*shrub.CommandDefinition, error) {
+	var cmd shrub.Command
 	switch fr.Format {
 	case model.Artifact:
-		return shrub.CmdAttachArtifacts{
+		cmd = shrub.CmdAttachArtifacts{
 			Files: fr.Files,
-		}, nil
+		}
 	case model.EvergreenJSON:
 		if len(fr.Files) != 1 {
 			return nil, errors.New("evergreen JSON results format requires exactly one test results file to be provided")
 		}
-		return shrub.CmdResultsJSON{
+		cmd = shrub.CmdResultsJSON{
 			File: fr.Files[0],
-		}, nil
+		}
 	case model.GoTest:
-		return shrub.CmdResultsGoTest{
+		cmd = shrub.CmdResultsGoTest{
 			LegacyFormat: true,
 			Files:        fr.Files,
-		}, nil
+		}
 	case model.XUnit:
-		return shrub.CmdResultsXunit{
+		cmd = shrub.CmdResultsXunit{
 			Files: fr.Files,
-		}, nil
+		}
 	default:
 		return nil, errors.Errorf("unrecognized file report format '%s'", fr.Format)
 	}
+
+	cmdDef := cmd.Resolve()
+	// Do not fail the task if file reporting fails.
+	cmdDef.ExecutionType = "setup"
+
+	return cmdDef, nil
 }

--- a/metabuild/generator/util_test.go
+++ b/metabuild/generator/util_test.go
@@ -68,9 +68,7 @@ func TestFileReportCmds(t *testing.T) {
 				}
 				cmd, err := fileReportCmd(fr)
 				require.NoError(t, err)
-				cmdDef := cmd.Resolve()
-				require.NotNil(t, cmdDef)
-				testParams.testCase(t, fr, cmdDef)
+				testParams.testCase(t, fr, cmd)
 			})
 		}
 		t.Run("FailsWithEvergreenJSONWithInvalidNumFiles", func(t *testing.T) {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8852

I tested generating `evergreen.yaml` for Jasper with the Make generator.

* Make file reports run as "setup" commands so that they do not fail a task (e.g. if no files are found).
* Continue on error for make targets (this may or may not be the most sane setting).