### PR TITLE
EVG-12493: change working directory semantics

### DIFF
--- a/cli/generate.go
+++ b/cli/generate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/evergreen-ci/shrub"
@@ -47,7 +46,6 @@ func generatedConfigFormatter(format string) (func(*shrub.Configuration) ([]byte
 }
 
 const (
-	workingDirFlagName    = "working_dir"
 	generatorFileFlagName = "generator_file"
 	controlFileFlagName   = "control_file"
 	outputFileFlagName    = "output_file"
@@ -55,13 +53,16 @@ const (
 )
 
 func generateGolang() cli.Command {
+	const (
+		discoveryDirFlagName = "discovery_dir"
+	)
 	return cli.Command{
 		Name:  "golang",
 		Usage: "Generate JSON evergreen config from golang build file(s).",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  workingDirFlagName,
-				Usage: "The directory that contains the GOPATH as a subdirectory.",
+				Name:  discoveryDirFlagName,
+				Usage: "The directory where package discovery should start.",
 			},
 			cli.StringFlag{
 				Name:  generatorFileFlagName,
@@ -82,31 +83,25 @@ func generateGolang() cli.Command {
 			},
 		},
 		Before: mergeBeforeFuncs(
-			requireStringFlag(workingDirFlagName),
+			requireStringFlag(discoveryDirFlagName),
 			requireOneFlag(generatorFileFlagName, controlFileFlagName),
 			checkGeneratedConfigFormat,
 		),
 		Action: func(c *cli.Context) error {
-			workingDir := c.String(workingDirFlagName)
+			discoveryDir := c.String(discoveryDirFlagName)
 			genFile := c.String(generatorFileFlagName)
 			ctrlFile := c.String(controlFileFlagName)
 			outputFile := c.String(outputFileFlagName)
 			var err error
-			if !filepath.IsAbs(workingDir) {
-				workingDir, err = filepath.Abs(workingDir)
-				if err != nil {
-					return errors.Wrapf(err, "getting working directory '%s' as absolute path", workingDir)
-				}
-			}
 
 			var g *model.Golang
 			if genFile != "" {
-				g, err = model.NewGolang(genFile, workingDir)
+				g, err = model.NewGolang(genFile, discoveryDir)
 				if err != nil {
 					return errors.Wrapf(err, "creating generator from build file '%s'", genFile)
 				}
 			} else if ctrlFile != "" {
-				gc, err := model.NewGolangControl(ctrlFile, workingDir)
+				gc, err := model.NewGolangControl(ctrlFile, discoveryDir)
 				if err != nil {
 					return errors.Wrapf(err, "creating builder from control file '%s'", ctrlFile)
 				}
@@ -137,10 +132,6 @@ func generateMake() cli.Command {
 		Usage: "Generate JSON evergreen config from make build file(s).",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  workingDirFlagName,
-				Usage: "The directory containing the project and build files.",
-			},
-			cli.StringFlag{
 				Name:  generatorFileFlagName,
 				Usage: "The build files necessary to generate the evergreen config.",
 			},
@@ -159,13 +150,11 @@ func generateMake() cli.Command {
 			},
 		},
 		Before: mergeBeforeFuncs(
-			requireStringFlag(workingDirFlagName),
 			requireOneFlag(generatorFileFlagName, controlFileFlagName),
 			checkGeneratedConfigFormat,
-			cleanupFilePathSeparators(generatorFileFlagName, controlFileFlagName, workingDirFlagName),
+			cleanupFilePathSeparators(generatorFileFlagName, controlFileFlagName),
 		),
 		Action: func(c *cli.Context) error {
-			workingDir := c.String(workingDirFlagName)
 			genFile := c.String(generatorFileFlagName)
 			ctrlFile := c.String(controlFileFlagName)
 			outputFile := c.String(outputFileFlagName)
@@ -173,13 +162,13 @@ func generateMake() cli.Command {
 			var m *model.Make
 			var err error
 			if genFile != "" {
-				m, err = model.NewMake(genFile, workingDir)
+				m, err = model.NewMake(genFile)
 				if err != nil {
 					return errors.Wrapf(err, "creating model from build file '%s'", genFile)
 				}
 			} else if ctrlFile != "" {
 				var mc *model.MakeControl
-				mc, err = model.NewMakeControl(ctrlFile, workingDir)
+				mc, err = model.NewMakeControl(ctrlFile)
 				if err != nil {
 					return errors.Wrapf(err, "creating builder from control file '%s'", ctrlFile)
 				}

--- a/cli/generate.go
+++ b/cli/generate.go
@@ -86,6 +86,7 @@ func generateGolang() cli.Command {
 			requireStringFlag(discoveryDirFlagName),
 			requireOneFlag(generatorFileFlagName, controlFileFlagName),
 			checkGeneratedConfigFormat,
+			cleanupFilePathSeparators(generatorFileFlagName, controlFileFlagName, discoveryDirFlagName),
 		),
 		Action: func(c *cli.Context) error {
 			discoveryDir := c.String(discoveryDirFlagName)

--- a/metabuild/generator/golang.go
+++ b/metabuild/generator/golang.go
@@ -48,8 +48,7 @@ func (g *Golang) Generate() (*shrub.Configuration, error) {
 			}
 
 			env := model.MergeEnvironments(g.Environment, gv.Environment)
-			gopath := env["GOPATH"]
-			projectPath := g.RelProjectPath(gopath)
+			projectPath := g.RelProjectPath(env["GOPATH"])
 			getProjectCmd := shrub.CmdGetProject{
 				Directory: projectPath,
 			}
@@ -104,8 +103,7 @@ func (g *Golang) generateVariantTasksForRef(c *shrub.Configuration, gv model.Gol
 
 func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangPackage) *shrub.CmdSubprocessScripting {
 	env := model.MergeEnvironments(g.Environment, gp.Environment, gv.Environment)
-	gopath := env["GOPATH"]
-	projectPath := g.RelProjectPath(gopath)
+	projectPath := g.RelProjectPath(env["GOPATH"])
 
 	testOpts := gp.Flags
 	if gv.Flags != nil {
@@ -119,8 +117,7 @@ func (g *Golang) subprocessScriptingCmd(gv model.GolangVariant, gp model.GolangP
 	testOpts = append(testOpts, relPath)
 
 	return &shrub.CmdSubprocessScripting{
-		Harness:     "golang",
-		HarnessPath: gopath,
+		Harness: "golang",
 		// It is not a problem for the environment to set a relative GOPATH
 		// here, which conflicts with the actual GOPATH (an absolute path). The
 		// GOPATH in the environment will be overridden when

--- a/metabuild/generator/golang_test.go
+++ b/metabuild/generator/golang_test.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/shrub"
@@ -24,7 +23,6 @@ func TestGolangGenerate(t *testing.T) {
 
 		scriptingCmd := task.Commands[1]
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
-		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		env, ok := scriptingCmd.Params["env"].(map[string]interface{})
 		require.True(t, ok)
@@ -44,7 +42,6 @@ func TestGolangGenerate(t *testing.T) {
 
 		scriptingCmd := task.Commands[1]
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
-		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		taskEnv, ok := scriptingCmd.Params["env"].(map[string]interface{})
 		require.True(t, ok)
@@ -57,7 +54,6 @@ func TestGolangGenerate(t *testing.T) {
 		scriptingCmd := task.Commands[0]
 		assert.Equal(t, shrub.CmdSubprocessScripting{}.Name(), scriptingCmd.CommandName)
 		gopath := g.Environment["GOPATH"]
-		assert.Equal(t, gopath, scriptingCmd.Params["harness_path"])
 		projectPath := g.RelProjectPath(gopath)
 		assert.Equal(t, projectPath, scriptingCmd.Params["test_dir"])
 		env, ok := scriptingCmd.Params["env"].(map[string]interface{})
@@ -266,7 +262,7 @@ func TestGolangGenerate(t *testing.T) {
 							"GOPATH": gopath,
 							"GOROOT": "some_goroot",
 						},
-						WorkingDirectory: util.ConsistentFilepath(filepath.Dir(gopath)),
+						WorkingDirectory: util.ConsistentFilepath(gopath, rootPackage),
 					},
 					RootPackage: rootPackage,
 				},

--- a/metabuild/model/common.go
+++ b/metabuild/model/common.go
@@ -15,14 +15,7 @@ type GeneralConfig struct {
 	Environment map[string]string `yaml:"env,omitempty"`
 	// DefaultTags are tags that apply to all units of work.
 	DefaultTags      []string `yaml:"default_tags,omitempty"`
-	WorkingDirectory string   `yaml:"-"`
-}
-
-// Validate checks that the working directory is populated.
-func (gc *GeneralConfig) Validate() error {
-	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(gc.WorkingDirectory == "", "must specify working directory")
-	return nil
+	WorkingDirectory string   `yaml:"working_dir,omitempty"`
 }
 
 // VariantDistro represents a mapping between a variant name and the distros

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -43,8 +43,8 @@ type GolangGeneralConfig struct {
 	// default, packages will only be discovered if they contain test files
 	// (i.e. file that ends in "_test.go").
 	DiscoverSourceFiles bool `yaml:"discover_source_files,omitempty"`
-	// DiscoveryDir is the directory where package discovery should occur.
-	DiscoveryDir string `yaml:"-"`
+	// DiscoveryDirectory is the directory where package discovery should occur.
+	DiscoveryDirectory string `yaml:"-"`
 }
 
 // Validate checks that the all the required top-level configuration is
@@ -66,7 +66,7 @@ func NewGolang(file, discoveryDir string) (*Golang, error) {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
 	g := gv.Golang
-	gv.DiscoveryDir = discoveryDir
+	gv.DiscoveryDirectory = discoveryDir
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")
@@ -266,19 +266,15 @@ const (
 // DiscoverPackages discovers directories containing tests in the local file
 // system and adds them if they are not already defined.
 func (g *Golang) DiscoverPackages() error {
-	if err := g.validateEnvVars(); err != nil {
-		return errors.Wrap(err, "invalid environment variables")
-	}
-
-	if !filepath.IsAbs(g.DiscoveryDir) {
-		discoveryDir, err := filepath.Abs(g.DiscoveryDir)
+	if !filepath.IsAbs(g.DiscoveryDirectory) {
+		discoveryDir, err := filepath.Abs(g.DiscoveryDirectory)
 		if err != nil {
-			return errors.Wrapf(err, "converting package discovery root directory '%s' into absolute path", discoveryDir)
+			return errors.Wrapf(err, "converting package discovery root directory '%s' into absolute path", g.DiscoveryDirectory)
 		}
-		g.DiscoveryDir = discoveryDir
+		g.DiscoveryDirectory = discoveryDir
 	}
 
-	if err := filepath.Walk(g.DiscoveryDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(g.DiscoveryDirectory, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -299,7 +295,7 @@ func (g *Golang) DiscoverPackages() error {
 			return nil
 		}
 		dir := filepath.Dir(path)
-		dir, err = filepath.Rel(g.DiscoveryDir, dir)
+		dir, err = filepath.Rel(g.DiscoveryDirectory, dir)
 		if err != nil {
 			return errors.Wrapf(err, "making package path '%s' relative to root package", path)
 		}
@@ -319,7 +315,7 @@ func (g *Golang) DiscoverPackages() error {
 
 		return nil
 	}); err != nil {
-		return errors.Wrapf(err, "walking the file system tree starting from path '%s'", g.DiscoveryDir)
+		return errors.Wrapf(err, "walking the file system tree starting from path '%s'", g.DiscoveryDirectory)
 	}
 
 	return nil

--- a/metabuild/model/golang.go
+++ b/metabuild/model/golang.go
@@ -26,10 +26,11 @@ type Golang struct {
 // GolangGeneralConfig defines general top-level configuration for Golang.
 type GolangGeneralConfig struct {
 	// GeneralConfig defines generic top-level configuration.
-	// WorkingDirectory is the absolute path to the base directory where the
-	// GOPATH directory is located.
+	// WorkingDirectory is the path relative to the task working directory where
+	// the project will be cloned, which is only required if operating outside
+	// of the typical GOPATH (i.e. for modules outside the GOPATH).
 	// Environment requires that GOPATH and GOROOT be defined globally.
-	// GOPATH must be specified as a subdirectory of the working directory.
+	// GOPATH must be specified as a subdirectory of the task working directory.
 	// These can be overridden the the package or variant level.
 	// DefaultTags are applied to all packages (discovered or explicitly
 	// defined) unless explicitly excluded.
@@ -42,20 +43,21 @@ type GolangGeneralConfig struct {
 	// default, packages will only be discovered if they contain test files
 	// (i.e. file that ends in "_test.go").
 	DiscoverSourceFiles bool `yaml:"discover_source_files,omitempty"`
+	// DiscoveryDir is the directory where package discovery should occur.
+	DiscoveryDir string `yaml:"-"`
 }
 
 // Validate checks that the all the required top-level configuration is
 // specified.
 func (ggc *GolangGeneralConfig) Validate() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.NewWhen(ggc.RootPackage == "", "must specify the import path of the root package of the project")
-	catcher.Wrap(ggc.GeneralConfig.Validate(), "invalid general config")
+	catcher.NewWhen(ggc.WorkingDirectory == "" && ggc.RootPackage == "", "must specify either the project clone directory or the import path of the root package of the project")
 	return catcher.Resolve()
 }
 
 // NewGolang returns a model of a Golang build configuration from a single file
-// and working directory where the GOPATH directory is located.
-func NewGolang(file, workingDir string) (*Golang, error) {
+// and directory where packages should be discovered.
+func NewGolang(file, discoveryDir string) (*Golang, error) {
 	gv := struct {
 		Golang           `yaml:",inline"`
 		VariablesSection `yaml:",inline"`
@@ -64,7 +66,7 @@ func NewGolang(file, workingDir string) (*Golang, error) {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
 	g := gv.Golang
-	g.WorkingDirectory = workingDir
+	gv.DiscoveryDir = discoveryDir
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")
@@ -139,16 +141,11 @@ func (g *Golang) Validate() error {
 
 // validateEnvVars checks that:
 // - GOROOT is defined at the top-level global environment.
-// - GOPATH is defined at the top-level global environment and can be converted
-//   to a path relative to the working directory.
+// - GOPATH is defined at the top-level global environment
 func (g *Golang) validateEnvVars() error {
 	catcher := grip.NewBasicCatcher()
 	for _, name := range []string{"GOPATH", "GOROOT"} {
 		if val := g.Environment[name]; val != "" {
-			g.Environment[name] = util.ConsistentFilepath(val)
-			continue
-		}
-		if val := os.Getenv(name); val != "" {
 			g.Environment[name] = util.ConsistentFilepath(val)
 			continue
 		}
@@ -158,48 +155,15 @@ func (g *Golang) validateEnvVars() error {
 		return catcher.Resolve()
 	}
 
-	// According to the semantics of this GOPATH, it must be relative to the
-	// working directory.
-	relGopath, err := g.relGopath()
-	if err != nil {
-		catcher.Wrap(err, "getting GOPATH as relative path")
-	} else {
-		g.Environment["GOPATH"] = relGopath
-	}
-
 	return catcher.Resolve()
 }
 
-// absGopath converts the relative GOPATH in the global environment into an
-// absolute path based on the working directory.
-func (ggc *GolangGeneralConfig) absGopath() (string, error) {
-	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
-	relGopath, err := relToPath(gopath, ggc.WorkingDirectory)
-	if err != nil {
-		return "", errors.Wrap(err, "global GOPATH cannot be made relative to the working directory")
-	}
-	return util.ConsistentFilepath(ggc.WorkingDirectory, relGopath), nil
-}
-
-// relGopath returns the global GOPATH in the environment relative to the
-// working directory.
-func (ggc *GolangGeneralConfig) relGopath() (string, error) {
-	gopath := util.ConsistentFilepath(ggc.Environment["GOPATH"])
-	relGopath, err := relToPath(gopath, ggc.WorkingDirectory)
-	if err != nil {
-		return "", errors.Wrap(err, "global GOPATH cannot be made relative to the working directory")
-	}
-	return relGopath, nil
-}
-
-// absProjectPath returns the absolute path to the project based on the given
-// gopath.
-func (ggc *GolangGeneralConfig) absProjectPath(gopath string) string {
-	return util.ConsistentFilepath(gopath, "src", ggc.RootPackage)
-}
-
-// RelProjectPath returns the path to the project based on the given gopath.
+// RelProjectPath returns the path to the project based either the working
+// directory if it's set or on the given gopath.
 func (g *Golang) RelProjectPath(gopath string) string {
+	if g.WorkingDirectory != "" {
+		return g.WorkingDirectory
+	}
 	return util.ConsistentFilepath(gopath, "src", g.RootPackage)
 }
 
@@ -306,25 +270,27 @@ func (g *Golang) DiscoverPackages() error {
 		return errors.Wrap(err, "invalid environment variables")
 	}
 
-	gopath, err := g.absGopath()
-	if err != nil {
-		return errors.Wrap(err, "getting GOPATH as an absolute path")
+	if !filepath.IsAbs(g.DiscoveryDir) {
+		discoveryDir, err := filepath.Abs(g.DiscoveryDir)
+		if err != nil {
+			return errors.Wrapf(err, "converting package discovery root directory '%s' into absolute path", discoveryDir)
+		}
+		g.DiscoveryDir = discoveryDir
 	}
-	projectPath := g.absProjectPath(gopath)
 
-	if err := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(g.DiscoveryDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
 
 		fileName := filepath.Base(info.Name())
-		if fileName == golangVendorDir {
-			return filepath.SkipDir
-		}
-		if fileName == golangTestDataDir {
-			return filepath.SkipDir
-		}
 		if info.IsDir() {
+			if fileName == golangVendorDir {
+				return filepath.SkipDir
+			}
+			if fileName == golangTestDataDir {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if g.DiscoverSourceFiles && !strings.HasSuffix(fileName, golangFileSuffix) {
@@ -333,7 +299,7 @@ func (g *Golang) DiscoverPackages() error {
 			return nil
 		}
 		dir := filepath.Dir(path)
-		dir, err = filepath.Rel(projectPath, dir)
+		dir, err = filepath.Rel(g.DiscoveryDir, dir)
 		if err != nil {
 			return errors.Wrapf(err, "making package path '%s' relative to root package", path)
 		}
@@ -353,7 +319,7 @@ func (g *Golang) DiscoverPackages() error {
 
 		return nil
 	}); err != nil {
-		return errors.Wrapf(err, "walking the file system tree starting from path '%s'", projectPath)
+		return errors.Wrapf(err, "walking the file system tree starting from path '%s'", g.DiscoveryDir)
 	}
 
 	return nil

--- a/metabuild/model/golang_control.go
+++ b/metabuild/model/golang_control.go
@@ -17,13 +17,12 @@ type GolangControl struct {
 	PackageFiles []string `yaml:"packages,omitempty"`
 
 	ControlDirectory string `yaml:"-"`
-	WorkingDirectory string `yaml:"-"`
+	DiscoveryDir     string `yaml:"-"`
 }
 
 // NewGolangControl creates a new representation of a Golang control file from
-// the given file. The working directory is the directory where the project
-// will be cloned.
-func NewGolangControl(file, workingDir string) (*GolangControl, error) {
+// the given file.
+func NewGolangControl(file string, discoveryDir string) (*GolangControl, error) {
 	gcv := struct {
 		GolangControl    `yaml:",inline"`
 		VariablesSection `yaml:",inline"`
@@ -33,7 +32,7 @@ func NewGolangControl(file, workingDir string) (*GolangControl, error) {
 	}
 	gc := gcv.GolangControl
 	gc.ControlDirectory = util.ConsistentFilepath(filepath.Dir(file))
-	gc.WorkingDirectory = workingDir
+	gc.DiscoveryDir = util.ConsistentFilepath(discoveryDir)
 	return &gc, nil
 }
 
@@ -53,11 +52,13 @@ func (gc *GolangControl) Build() (*Golang, error) {
 	}
 	g.MergeVariants(gvs...)
 
-	ggc, err := gc.buildGeneral(gc.WorkingDirectory)
+	ggc, err := gc.buildGeneral()
 	if err != nil {
 		return nil, errors.Wrap(err, "building top-level configuration")
 	}
 	g.GolangGeneralConfig = ggc
+
+	g.DiscoveryDir = gc.DiscoveryDir
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")
@@ -132,7 +133,7 @@ func (gc *GolangControl) buildVariants() ([]GolangVariant, error) {
 	return all, nil
 }
 
-func (gc *GolangControl) buildGeneral(workingDir string) (GolangGeneralConfig, error) {
+func (gc *GolangControl) buildGeneral() (GolangGeneralConfig, error) {
 	ggcv := struct {
 		GolangGeneralConfig `yaml:"general"`
 		VariablesSection    `yaml:",inline"`
@@ -142,10 +143,6 @@ func (gc *GolangControl) buildGeneral(workingDir string) (GolangGeneralConfig, e
 		return GolangGeneralConfig{}, errors.Wrap(err, "unmarshalling from YAML file")
 	}
 	ggc := ggcv.GolangGeneralConfig
-	ggc.WorkingDirectory = workingDir
-	if err := ggc.Validate(); err != nil {
-		return GolangGeneralConfig{}, errors.Wrap(err, "invalid top-level configuration")
-	}
 
 	return ggc, nil
 }

--- a/metabuild/model/golang_control.go
+++ b/metabuild/model/golang_control.go
@@ -16,8 +16,8 @@ type GolangControl struct {
 	VariantFiles []string `yaml:"variants"`
 	PackageFiles []string `yaml:"packages,omitempty"`
 
-	ControlDirectory string `yaml:"-"`
-	DiscoveryDir     string `yaml:"-"`
+	ControlDirectory   string `yaml:"-"`
+	DiscoveryDirectory string `yaml:"-"`
 }
 
 // NewGolangControl creates a new representation of a Golang control file from
@@ -32,7 +32,7 @@ func NewGolangControl(file string, discoveryDir string) (*GolangControl, error) 
 	}
 	gc := gcv.GolangControl
 	gc.ControlDirectory = util.ConsistentFilepath(filepath.Dir(file))
-	gc.DiscoveryDir = util.ConsistentFilepath(discoveryDir)
+	gc.DiscoveryDirectory = util.ConsistentFilepath(discoveryDir)
 	return &gc, nil
 }
 
@@ -58,7 +58,7 @@ func (gc *GolangControl) Build() (*Golang, error) {
 	}
 	g.GolangGeneralConfig = ggc
 
-	g.DiscoveryDir = gc.DiscoveryDir
+	g.DiscoveryDirectory = gc.DiscoveryDirectory
 
 	if err := g.DiscoverPackages(); err != nil {
 		return nil, errors.Wrap(err, "automatically discovering test packages")

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/utility"
+	"github.com/k0kubun/pp"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
@@ -154,6 +155,7 @@ func TestGolangVariant(t *testing.T) {
 						"GOPATH": util.ConsistentFilepath("/gopath"),
 					}
 				}
+				pp.Println(gv.Validate())
 				assert.Error(t, gv.Validate())
 			},
 		} {

--- a/metabuild/model/golang_test.go
+++ b/metabuild/model/golang_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/utility"
-	"github.com/k0kubun/pp"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
@@ -155,7 +154,6 @@ func TestGolangVariant(t *testing.T) {
 						"GOPATH": util.ConsistentFilepath("/gopath"),
 					}
 				}
-				pp.Println(gv.Validate())
 				assert.Error(t, gv.Validate())
 			},
 		} {

--- a/metabuild/model/make.go
+++ b/metabuild/model/make.go
@@ -12,8 +12,8 @@ type Make struct {
 	// Environment defines global environment variables. Definitions can be
 	// overridden at the task or variant level.
 	// DefaultTags are applied to all defined tasks unless explicitly excluded.
-	// WorkingDirectory determines the directory where the project will be
-	// cloned.
+	// WorkingDirectory is the path relative to the task working directory where
+	// the project will be cloned.
 	GeneralConfig   `yaml:",inline"`
 	TargetSequences []MakeTargetSequence `yaml:"sequences,omitempty"`
 	Tasks           []MakeTask           `yaml:"tasks,omitempty"`
@@ -22,7 +22,7 @@ type Make struct {
 
 // NewMake creates a new evergreen config generator for Make from a single file
 // that contains all the necessary generation information.
-func NewMake(file, workingDir string) (*Make, error) {
+func NewMake(file string) (*Make, error) {
 	mv := struct {
 		Make      `yaml:",inline"`
 		Variables interface{} `yaml:"variables,omitempty"`
@@ -31,7 +31,6 @@ func NewMake(file, workingDir string) (*Make, error) {
 		return nil, errors.Wrap(err, "unmarshalling from YAML file")
 	}
 	m := mv.Make
-	m.WorkingDirectory = workingDir
 
 	m.ApplyDefaultTags()
 
@@ -114,7 +113,6 @@ func (m *Make) MergeDefaultTags(tags ...string) *Make {
 // Validate checks that the entire Make build configuration is valid.
 func (m *Make) Validate() error {
 	catcher := grip.NewBasicCatcher()
-	catcher.Wrap(m.GeneralConfig.Validate(), "invalid general config")
 	catcher.Wrap(m.validateTargetSequences(), "invalid target sequence definition(s)")
 	catcher.Wrap(m.validateTasks(), "invalid task definition(s)")
 	catcher.Wrap(m.validateVariants(), "invalid variant definition(s)")

--- a/metabuild/model/util.go
+++ b/metabuild/model/util.go
@@ -1,9 +1,6 @@
 package model
 
 import (
-	"path/filepath"
-	"strings"
-
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
@@ -31,33 +28,4 @@ func withMatchingFiles(workDir string, patterns []string, op func(file string) e
 	}
 
 	return nil
-}
-
-var errNotRelativeToWorkingDir = errors.New("converting to path relative to working directory")
-
-// relPathToWorkingDir attempts to make the given path relative to the working
-// directory if possible. If the path is already non-absolute, it is returned
-// unchanged and assumed to be relative to the working directory. If it is
-// absolute and can be successfully converted to a relative path, it returns the
-// relative path and nil error. Otherwise, if path is absolute and cannot be
-// made relative to the working directory, it returns the path and
-// errNotRelativeToWorkingDir.
-func relToPath(path, workingDir string) (string, error) {
-	workingDir = util.ConsistentFilepath(workingDir)
-	path = util.ConsistentFilepath(path)
-
-	if !filepath.IsAbs(path) {
-		return path, nil
-	}
-
-	if workingDir == "" || !strings.HasPrefix(path, workingDir) {
-		return path, errNotRelativeToWorkingDir
-	}
-
-	relPath, err := filepath.Rel(workingDir, path)
-	if err != nil {
-		return path, errors.Wrap(err, errNotRelativeToWorkingDir.Error())
-	}
-
-	return util.ConsistentFilepath(relPath), nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12493

The working directory you pass to the CLI used to have inconsistent meaning - for Golang, it was the directory containing the GOPATH while for Make, it was the directory where the task git clones the project. This was done for a slightly silly reason related to the Golang generator's automatic package discovery. Now, it's consistent and it means the directory where git clone occurs (which is configurable by the user). I'll update the docs once this is merged.

* Allow working directory (i.e. git clone directory for task) to be set within YAML config file for Golang and Make.
* Use new CLI flag to determine directory where Golang package discovery occurs.
    * Automatic package discovery does not depend on working directory anymore.