### PR TITLE
EVG-9110: add REST client to remote tests

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -165,7 +165,7 @@ func newRemoteClient(ctx context.Context, service, host string, port int, credsF
 	}
 
 	if service == RESTService {
-		return remote.NewRestClient(addr), nil
+		return remote.NewRESTClient(addr), nil
 	} else if service == RPCService {
 		return remote.NewRPCClientWithFile(ctx, addr, credsFilePath)
 	}

--- a/manager_basic.go
+++ b/manager_basic.go
@@ -124,12 +124,12 @@ func (m *basicProcessManager) Register(ctx context.Context, proc Process) error 
 }
 
 func (m *basicProcessManager) List(ctx context.Context, f options.Filter) ([]Process, error) {
-	out := []Process{}
 
 	if err := f.Validate(); err != nil {
-		return out, errors.Wrap(err, "invalid filter")
+		return nil, errors.Wrap(err, "invalid filter")
 	}
 
+	out := []Process{}
 	for _, proc := range m.procs {
 		if ctx.Err() != nil {
 			return nil, errors.WithStack(ctx.Err())

--- a/manager_test.go
+++ b/manager_test.go
@@ -179,7 +179,7 @@ func TestManagerImplementations(t *testing.T) {
 				"ListErrorsWithInvalidFilter": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					procs, err := manager.List(ctx, options.Filter("foo"))
 					assert.Error(t, err)
-					assert.Nil(t, procs)
+					assert.Empty(t, procs)
 				},
 				"GetMethodErrorsWithNonexistentProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					proc, err := manager.Get(ctx, "foo")

--- a/manager_test.go
+++ b/manager_test.go
@@ -14,7 +14,7 @@ import (
 
 var echoSubCmd = []string{"echo", "foo"}
 
-func TestManagerInterface(t *testing.T) {
+func TestManagerImplementations(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -61,47 +61,54 @@ func TestManagerInterface(t *testing.T) {
 
 		t.Run(mname, func(t *testing.T) {
 			for name, test := range map[string]func(context.Context, *testing.T, Manager, testutil.OptsModify){
-				"ValidateFixture": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ValidateFixture": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					assert.NotNil(t, ctx)
 					assert.NotNil(t, manager)
 					assert.NotNil(t, manager.LoggingCache(ctx))
 				},
-				"IDReturnsNonempty": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"IDReturnsNonempty": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					assert.NotEmpty(t, manager.ID())
 				},
-				"ProcEnvVarMatchesManagerID": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ProcEnvVarMatchesManagerID": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
 					info := proc.Info(ctx)
 					require.NotEmpty(t, info.Options.Environment)
 					assert.Equal(t, manager.ID(), info.Options.Environment[ManagerEnvironID])
 				},
-				"ListDoesNotErrorWhenEmpty": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
-					all, err := manager.List(ctx, options.All)
-					require.NoError(t, err)
-					assert.Len(t, all, 0)
+				"CreateProcessFailsWithEmptyOptions": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
+					opts := &options.Create{}
+					modify(opts)
+					proc, err := manager.CreateProcess(ctx, opts)
+					require.Error(t, err)
+					assert.Nil(t, proc)
 				},
-				"CreateSimpleProcess": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CreateSimpleProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
 					assert.NotNil(t, proc)
 					info := proc.Info(ctx)
 					assert.True(t, info.IsRunning || info.Complete)
 				},
-				"CreateProcessFails": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CreateProcessFails": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := &options.Create{}
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.Error(t, err)
 					assert.Nil(t, proc)
 				},
-				"ListAllOperations": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ListDoesNotErrorWhenEmpty": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
+					all, err := manager.List(ctx, options.All)
+					require.NoError(t, err)
+					assert.Len(t, all, 0)
+				},
+				"ListAllOperations": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 					created, err := createProcs(ctx, opts, manager, 10)
 					require.NoError(t, err)
 					assert.Len(t, created, 10)
@@ -109,10 +116,10 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					assert.Len(t, output, 10)
 				},
-				"ListAllReturnsErrorWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ListAllReturnsErrorWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					cctx, cancel := context.WithCancel(ctx)
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					created, err := createProcs(ctx, opts, manager, 10)
 					require.NoError(t, err)
@@ -122,9 +129,9 @@ func TestManagerInterface(t *testing.T) {
 					require.Error(t, err)
 					assert.Nil(t, output)
 				},
-				"LongRunningOperationsAreListedAsRunning": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"LongRunningOperationsAreListedAsRunning": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.SleepCreateOpts(10)
-					mod(opts)
+					modify(opts)
 
 					procs, err := createProcs(ctx, opts, manager, 10)
 					require.NoError(t, err)
@@ -138,9 +145,9 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					assert.Len(t, procs, 0)
 				},
-				"ListReturnsOneSuccessfulCommand": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ListReturnsOneSuccessfulCommand": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
@@ -151,13 +158,12 @@ func TestManagerInterface(t *testing.T) {
 					listOut, err := manager.List(ctx, options.Successful)
 					require.NoError(t, err)
 
-					if assert.Len(t, listOut, 1) {
-						assert.Equal(t, listOut[0].ID(), proc.ID())
-					}
+					require.Len(t, listOut, 1)
+					assert.Equal(t, listOut[0].ID(), proc.ID())
 				},
-				"ListReturnsOneFailedCommand": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ListReturnsOneFailedCommand": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.FalseCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
@@ -167,18 +173,22 @@ func TestManagerInterface(t *testing.T) {
 					listOut, err := manager.List(ctx, options.Failed)
 					require.NoError(t, err)
 
-					if assert.Len(t, listOut, 1) {
-						assert.Equal(t, listOut[0].ID(), proc.ID())
-					}
+					require.Len(t, listOut, 1)
+					assert.Equal(t, listOut[0].ID(), proc.ID())
 				},
-				"GetMethodErrorsWithNoResponse": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ListErrorsWithInvalidFilter": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
+					procs, err := manager.List(ctx, options.Filter("foo"))
+					assert.Error(t, err)
+					assert.Nil(t, procs)
+				},
+				"GetMethodErrorsWithNonexistentProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					proc, err := manager.Get(ctx, "foo")
 					require.Error(t, err)
 					assert.Nil(t, proc)
 				},
-				"GetMethodReturnsMatchingDoc": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"GetMethodReturnsMatchingProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
 
@@ -186,14 +196,14 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, ret.ID(), proc.ID())
 				},
-				"GroupDoesNotErrorWithoutResults": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"GroupDoesNotErrorWhenEmptyResult": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					procs, err := manager.Group(ctx, "foo")
 					require.NoError(t, err)
 					assert.Len(t, procs, 0)
 				},
-				"GroupErrorsForCanceledContexts": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"GroupErrorsForCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					_, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
@@ -205,9 +215,9 @@ func TestManagerInterface(t *testing.T) {
 					assert.Len(t, procs, 0)
 					assert.Contains(t, err.Error(), context.Canceled.Error())
 				},
-				"GroupPropagatesMatching": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"GroupPropagatesMatching": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
@@ -219,12 +229,12 @@ func TestManagerInterface(t *testing.T) {
 					require.Len(t, procs, 1)
 					assert.Equal(t, procs[0].ID(), proc.ID())
 				},
-				"CloseEmptyManagerNoops": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CloseEmptyManagerNoops": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					assert.NoError(t, manager.Close(ctx))
 				},
-				"CloseErrorsWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CloseErrorsWithCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.SleepCreateOpts(100)
-					mod(opts)
+					modify(opts)
 
 					_, err := createProcs(ctx, opts, manager, 10)
 					require.NoError(t, err)
@@ -236,9 +246,9 @@ func TestManagerInterface(t *testing.T) {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), context.Canceled.Error())
 				},
-				"CloseSucceedsWithTerminatedProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CloseSucceedsWithTerminatedProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					procs, err := createProcs(ctx, opts, manager, 10)
 					for _, p := range procs {
@@ -249,30 +259,30 @@ func TestManagerInterface(t *testing.T) {
 					require.NoError(t, err)
 					assert.NoError(t, manager.Close(ctx))
 				},
-				"ClosersWithoutTriggersTerminatesProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CloserWithoutTriggersTerminatesProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					if runtime.GOOS == "windows" {
 						t.Skip("manager close tests will error due to process termination on Windows")
 					}
 					opts := testutil.SleepCreateOpts(100)
-					mod(opts)
+					modify(opts)
 
 					_, err := createProcs(ctx, opts, manager, 10)
 					require.NoError(t, err)
 					assert.NoError(t, manager.Close(ctx))
 				},
-				"CloseExecutesClosersForProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CloseExecutesClosersForProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					if runtime.GOOS == "windows" {
 						t.Skip("manager close tests will error due to process termination on Windows")
 					}
 					opts := testutil.SleepCreateOpts(5)
-					mod(opts)
+					modify(opts)
 
 					count := 0
 					countIncremented := make(chan bool, 1)
 					opts.RegisterCloser(func() (_ error) {
+						defer close(countIncremented)
 						count++
 						countIncremented <- true
-						close(countIncremented)
 						return
 					})
 
@@ -288,17 +298,17 @@ func TestManagerInterface(t *testing.T) {
 						assert.Equal(t, 1, count)
 					}
 				},
-				"RegisterProcessErrorsForNilProcess": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RegisterProcessErrorsForNilProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					err := manager.Register(ctx, nil)
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), "not defined")
 				},
-				"RegisterProcessErrorsForCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RegisterProcessErrorsForCanceledContext": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					cctx, cancel := context.WithCancel(ctx)
 					cancel()
 
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := newBlockingProcess(ctx, opts)
 					require.NoError(t, err)
@@ -306,16 +316,16 @@ func TestManagerInterface(t *testing.T) {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), context.Canceled.Error())
 				},
-				"RegisterProcessErrorsWhenMissingID": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RegisterProcessErrorsWhenMissingID": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					proc := &blockingProcess{}
 					assert.Equal(t, proc.ID(), "")
 					err := manager.Register(ctx, proc)
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), "malformed")
 				},
-				"RegisterProcessModifiesManagerState": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RegisterProcessModifiesManagerState": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := newBlockingProcess(ctx, opts)
 					require.NoError(t, err)
@@ -328,9 +338,9 @@ func TestManagerInterface(t *testing.T) {
 
 					assert.Equal(t, procs[0].ID(), proc.ID())
 				},
-				"RegisterProcessErrorsForDuplicateProcess": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RegisterProcessErrorsForDuplicateProcess": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 
 					proc, err := newBlockingProcess(ctx, opts)
 					require.NoError(t, err)
@@ -340,9 +350,9 @@ func TestManagerInterface(t *testing.T) {
 					err = manager.Register(ctx, proc)
 					assert.Error(t, err)
 				},
-				"ManagerCallsOptionsCloseByDefault": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ManagerCallsOptionsCloseByDefault": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := &options.Create{}
-					mod(opts)
+					modify(opts)
 					opts.Args = []string{"echo", "foobar"}
 					count := 0
 					countIncremented := make(chan bool, 1)
@@ -365,9 +375,9 @@ func TestManagerInterface(t *testing.T) {
 						assert.Equal(t, 1, count)
 					}
 				},
-				"ClearCausesDeletionOfProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ClearCausesDeletionOfProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.TrueCreateOpts()
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
 					sameProc, err := manager.Get(ctx, proc.ID())
@@ -380,9 +390,9 @@ func TestManagerInterface(t *testing.T) {
 					require.Error(t, err)
 					assert.Nil(t, nilProc)
 				},
-				"ClearIsANoopForActiveProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ClearIsANoopForActiveProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					opts := testutil.SleepCreateOpts(20)
-					mod(opts)
+					modify(opts)
 					proc, err := manager.CreateProcess(ctx, opts)
 					require.NoError(t, err)
 					manager.Clear(ctx)
@@ -391,14 +401,14 @@ func TestManagerInterface(t *testing.T) {
 					assert.Equal(t, proc.ID(), sameProc.ID())
 					require.NoError(t, Terminate(ctx, proc)) // Clean up
 				},
-				"ClearSelectivelyDeletesOnlyDeadProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"ClearSelectivelyDeletesOnlyDeadProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					trueOpts := testutil.TrueCreateOpts()
-					mod(trueOpts)
+					modify(trueOpts)
 					lsProc, err := manager.CreateProcess(ctx, trueOpts)
 					require.NoError(t, err)
 
 					sleepOpts := testutil.SleepCreateOpts(20)
-					mod(sleepOpts)
+					modify(sleepOpts)
 					sleepProc, err := manager.CreateProcess(ctx, sleepOpts)
 					require.NoError(t, err)
 
@@ -416,30 +426,30 @@ func TestManagerInterface(t *testing.T) {
 					assert.Nil(t, nilProc)
 					require.NoError(t, Terminate(ctx, sleepProc)) // Clean up
 				},
-				"CreateCommandPasses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CreateCommandPasses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					cmd := manager.CreateCommand(ctx)
 					cmd.Add(echoSubCmd)
-					mod(&cmd.opts.Process)
+					modify(&cmd.opts.Process)
 					assert.NoError(t, cmd.Run(ctx))
 				},
-				"RunningCommandCreatesNewProcesses": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"RunningCommandCreatesNewProcesses": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					procList, err := manager.List(ctx, options.All)
 					require.NoError(t, err)
 					originalProcCount := len(procList) // zero
 					cmd := manager.CreateCommand(ctx)
 					subCmds := [][]string{echoSubCmd, echoSubCmd, echoSubCmd}
 					cmd.Extend(subCmds)
-					mod(&cmd.opts.Process)
+					modify(&cmd.opts.Process)
 					require.NoError(t, cmd.Run(ctx))
 					newProcList, err := manager.List(ctx, options.All)
 					require.NoError(t, err)
 
 					assert.Len(t, newProcList, originalProcCount+len(subCmds))
 				},
-				"CommandProcessIDsMatchManagedProcessIDs": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {
+				"CommandProcessIDsMatchManagedProcessIDs": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {
 					cmd := manager.CreateCommand(ctx)
 					cmd.Extend([][]string{echoSubCmd, echoSubCmd, echoSubCmd})
-					mod(&cmd.opts.Process)
+					modify(&cmd.opts.Process)
 					require.NoError(t, cmd.Run(ctx))
 					newProcList, err := manager.List(ctx, options.All)
 					require.NoError(t, err)
@@ -582,7 +592,7 @@ func TestTrackedManager(t *testing.T) {
 					require.NoError(t, manager.Close(ctx))
 					assert.Len(t, mockTracker.Infos, 0)
 				},
-				// "": func(ctx context.Context, t *testing.T, manager Manager, mod testutil.OptsModify) {},
+				// "": func(ctx context.Context, t *testing.T, manager Manager, modify testutil.OptsModify) {},
 			} {
 				tctx, cancel := context.WithTimeout(ctx, testutil.ManagerTestTimeout)
 				defer cancel()

--- a/options/create.go
+++ b/options/create.go
@@ -322,14 +322,10 @@ func (opts *Create) Close() error {
 }
 
 // RegisterCloser adds the closer function to the processes closer
-// functions, which are called when the process is closed.
+// functions, which are called when the process finishes running.
 func (opts *Create) RegisterCloser(fn func() error) {
 	if fn == nil {
 		return
-	}
-
-	if opts.closers == nil {
-		opts.closers = []func() error{}
 	}
 
 	opts.closers = append(opts.closers, fn)

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -201,7 +201,7 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
 				procs, err := client.List(ctx, options.Filter("foo"))
 				assert.Error(t, err)
-				assert.Nil(t, procs)
+				assert.Empty(t, procs)
 			},
 		},
 		{

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -37,6 +37,10 @@ type clientTestCase struct {
 	Case func(context.Context, *testing.T, Manager)
 }
 
+// addBasicClientTests contains all the manager tests found in the root package
+// TestManagerImplementations, minus the ones that are not compatible with
+// remote interfaces. Other than incompatible tests, these tests should exactly
+// mirror the ones in the root package.
 func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []clientTestCase {
 	return append([]clientTestCase{
 		{
@@ -75,6 +79,65 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
+			Name: "CreateSimpleProcess",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				opts := testutil.TrueCreateOpts()
+				modify(opts)
+				proc, err := client.CreateProcess(ctx, opts)
+				require.NoError(t, err)
+				assert.NotNil(t, proc)
+				info := proc.Info(ctx)
+				assert.True(t, info.IsRunning || info.Complete)
+			},
+		},
+		{
+			Name: "CreateProcessFails",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				opts := &options.Create{}
+				modify(opts)
+				proc, err := client.CreateProcess(ctx, opts)
+				require.Error(t, err)
+				assert.Nil(t, proc)
+			},
+		},
+		{
+			Name: "ListDoesNotErrorWhenEmpty",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				all, err := client.List(ctx, options.All)
+				require.NoError(t, err)
+				assert.Len(t, all, 0)
+			},
+		},
+		{
+			Name: "ListAllOperations",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				opts := testutil.TrueCreateOpts()
+				modify(opts)
+				created, err := createProcs(ctx, opts, client, 10)
+				require.NoError(t, err)
+				assert.Len(t, created, 10)
+				output, err := client.List(ctx, options.All)
+				require.NoError(t, err)
+				assert.Len(t, output, 10)
+			},
+		},
+		{
+			Name: "ListAllReturnsErrorWithCanceledContext",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				cctx, cancel := context.WithCancel(ctx)
+				opts := testutil.TrueCreateOpts()
+				modify(opts)
+
+				created, err := createProcs(ctx, opts, client, 10)
+				require.NoError(t, err)
+				assert.Len(t, created, 10)
+				cancel()
+				output, err := client.List(cctx, options.All)
+				require.Error(t, err)
+				assert.Nil(t, output)
+			},
+		},
+		{
 			Name: "LongRunningOperationsAreListedAsRunning",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
 				opts := testutil.SleepCreateOpts(20)
@@ -97,11 +160,40 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
-			Name: "ListDoesNotErrorWhenEmptyResult",
+			Name: "ListReturnsOneSuccessfulCommand",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				all, err := client.List(ctx, options.All)
+				opts := testutil.TrueCreateOpts()
+				modify(opts)
+
+				proc, err := client.CreateProcess(ctx, opts)
 				require.NoError(t, err)
-				assert.Len(t, all, 0)
+
+				_, err = proc.Wait(ctx)
+				require.NoError(t, err)
+
+				listOut, err := client.List(ctx, options.Successful)
+				require.NoError(t, err)
+
+				require.Len(t, listOut, 1)
+				assert.Equal(t, listOut[0].ID(), proc.ID())
+			},
+		},
+		{
+			Name: "ListReturnsOneFailedCommand",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				opts := testutil.FalseCreateOpts()
+				modify(opts)
+
+				proc, err := client.CreateProcess(ctx, opts)
+				require.NoError(t, err)
+				_, err = proc.Wait(ctx)
+				require.Error(t, err)
+
+				listOut, err := client.List(ctx, options.Failed)
+				require.NoError(t, err)
+
+				require.Len(t, listOut, 1)
+				assert.Equal(t, listOut[0].ID(), proc.ID())
 			},
 		},
 		{
@@ -113,52 +205,7 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
-			Name: "ListAllReturnsErrorWithCanceledContext",
-			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				cctx, cancel := context.WithCancel(ctx)
-				opts := testutil.TrueCreateOpts()
-				modify(opts)
-				created, err := createProcs(ctx, opts, client, 10)
-				require.NoError(t, err)
-				assert.Len(t, created, 10)
-				cancel()
-				output, err := client.List(cctx, options.All)
-				require.Error(t, err)
-				assert.Nil(t, output)
-			},
-		},
-		{
-			Name: "ListReturnsOneSuccessfulCommand",
-			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				opts := testutil.TrueCreateOpts()
-				modify(opts)
-				proc, err := client.CreateProcess(ctx, opts)
-				require.NoError(t, err)
-
-				_, err = proc.Wait(ctx)
-				require.NoError(t, err)
-
-				listOut, err := client.List(ctx, options.Successful)
-				require.NoError(t, err)
-
-				if assert.Len(t, listOut, 1) {
-					assert.Equal(t, listOut[0].ID(), proc.ID())
-				}
-			},
-		},
-		{
-			Name: "RegisterAlwaysErrors",
-			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				proc, err := client.CreateProcess(ctx, &options.Create{Args: []string{"ls"}})
-				assert.NotNil(t, proc)
-				require.NoError(t, err)
-
-				assert.Error(t, client.Register(ctx, nil))
-				assert.Error(t, client.Register(ctx, proc))
-			},
-		},
-		{
-			Name: "GetMethodErrorsWithNoResponse",
+			Name: "GetMethodErrorsWithNonexistentProcess",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
 				proc, err := client.Get(ctx, "foo")
 				require.Error(t, err)
@@ -166,7 +213,7 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
-			Name: "GetMethodReturnsMatchingProc",
+			Name: "GetMethodReturnsMatchingProcess",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
 				opts := testutil.TrueCreateOpts()
 				modify(opts)
@@ -187,7 +234,7 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
-			Name: "GroupErrorsForCanceledContexts",
+			Name: "GroupErrorsForCanceledContext",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
 				opts := testutil.TrueCreateOpts()
 				modify(opts)
@@ -222,20 +269,6 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 		{
 			Name: "CloseEmptyManagerNoops",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				require.NoError(t, client.Close(ctx))
-			},
-		},
-		{
-			Name: "ClosersWithoutTriggersTerminatesProcesses",
-			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				if runtime.GOOS == "windows" {
-					t.Skip("the sleep tests don't block correctly on windows")
-				}
-				opts := testutil.SleepCreateOpts(100)
-				modify(opts)
-
-				_, err := createProcs(ctx, opts, client, 10)
-				require.NoError(t, err)
 				assert.NoError(t, client.Close(ctx))
 			},
 		},
@@ -270,24 +303,17 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 			},
 		},
 		{
-			Name: "WaitingOnNonExistentProcessErrors",
+			Name: "CloserWithoutTriggersTerminatesProcesses",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				opts := testutil.TrueCreateOpts()
+				if runtime.GOOS == "windows" {
+					t.Skip("manager close tests will error due to process termination on Windows")
+				}
+				opts := testutil.SleepCreateOpts(100)
 				modify(opts)
 
-				proc, err := client.CreateProcess(ctx, opts)
+				_, err := createProcs(ctx, opts, client, 10)
 				require.NoError(t, err)
-
-				_, err = proc.Wait(ctx)
-				require.NoError(t, err)
-
-				client.Clear(ctx)
-
-				_, err = proc.Wait(ctx)
-				require.Error(t, err)
-				procs, err := client.List(ctx, options.All)
-				require.NoError(t, err)
-				assert.Len(t, procs, 0)
+				assert.NoError(t, client.Close(ctx))
 			},
 		},
 		{
@@ -350,12 +376,39 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 				require.NoError(t, jasper.Terminate(ctx, sleepProc)) // Clean up
 			},
 		},
+		//
+		// The tests below this are specific to the remote manager.
+		//
 		{
-			Name: "RegisterIsDisabled",
+			Name: "WaitingOnNonexistentProcessErrors",
 			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				err := client.Register(ctx, nil)
+				opts := testutil.TrueCreateOpts()
+				modify(opts)
+
+				proc, err := client.CreateProcess(ctx, opts)
+				require.NoError(t, err)
+
+				_, err = proc.Wait(ctx)
+				require.NoError(t, err)
+
+				client.Clear(ctx)
+
+				_, err = proc.Wait(ctx)
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "cannot register")
+				procs, err := client.List(ctx, options.All)
+				require.NoError(t, err)
+				assert.Len(t, procs, 0)
+			},
+		},
+		{
+			Name: "RegisterAlwaysErrors",
+			Case: func(ctx context.Context, t *testing.T, client Manager) {
+				proc, err := client.CreateProcess(ctx, &options.Create{Args: []string{"ls"}})
+				assert.NotNil(t, proc)
+				require.NoError(t, err)
+
+				assert.Error(t, client.Register(ctx, nil))
+				assert.Error(t, client.Register(ctx, proc))
 			},
 		},
 		{
@@ -395,19 +448,15 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 				}
 			},
 		},
-		{
-			Name: "WriteFileFailsWithInvalidPath",
-			Case: func(ctx context.Context, t *testing.T, client Manager) {
-				opts := options.WriteFile{Content: []byte("foo")}
-				assert.Error(t, client.WriteFile(ctx, opts))
-			},
-		},
 	}, tests...)
 }
 
-func TestManager(t *testing.T) {
+func TestManagerImplementations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	httpClient := testutil.GetHTTPClient()
+	defer testutil.PutHTTPClient(httpClient)
 
 	for _, factory := range []struct {
 		Name        string
@@ -450,6 +499,19 @@ func TestManager(t *testing.T) {
 				return client
 			},
 		},
+		// {
+		//     Name: "REST",
+		//     Constructor: func(ctx context.Context, t *testing.T) Manager {
+		//         _, port, err := startRESTService(ctx, httpClient)
+		//         require.NoError(t, err)
+		//
+		//         client := &restClient{
+		//             prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
+		//             client: httpClient,
+		//         }
+		//         return client
+		//     },
+		// },
 	} {
 		t.Run(factory.Name, func(t *testing.T) {
 			for _, modify := range []struct {
@@ -650,6 +712,13 @@ func TestManager(t *testing.T) {
 								require.NoError(t, err)
 
 								assert.Zero(t, stat.Size())
+							},
+						},
+						clientTestCase{
+							Name: "WriteFileFailsWithInvalidPath",
+							Case: func(ctx context.Context, t *testing.T, client Manager) {
+								opts := options.WriteFile{Content: []byte("foo")}
+								assert.Error(t, client.WriteFile(ctx, opts))
 							},
 						},
 						clientTestCase{
@@ -994,7 +1063,7 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheCreate",
+							Name: "LoggingCacheCreateSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								logger, err := lc.Create("new_logger", &options.Output{})
@@ -1014,7 +1083,7 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheGetExists",
+							Name: "LoggingCacheGetSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								expectedLogger, err := lc.Create("new_logger", &options.Output{})
@@ -1026,15 +1095,15 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheGetDNE",
+							Name: "LoggingCacheGetFailsWithNonexistentLogger",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
-								logger := lc.Get("DNE")
+								logger := lc.Get("nonexistent")
 								require.Nil(t, logger)
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheRemove",
+							Name: "LoggingCacheRemoveSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								logger1, err := lc.Create("logger1", &options.Output{})
@@ -1050,7 +1119,7 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCachePrune",
+							Name: "LoggingCachePruneSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								logger1, err := lc.Create("logger1", &options.Output{})
@@ -1067,7 +1136,7 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheLenEmpty",
+							Name: "LoggingCacheLenIsNonzero",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								_, err := lc.Create("logger1", &options.Output{})
@@ -1079,17 +1148,17 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingCacheLenNotEmpty",
+							Name: "LoggingCacheLenIsZero",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								assert.Zero(t, lc.Len())
 							},
 						},
 						clientTestCase{
-							Name: "LoggingSendMessagesInvalid",
+							Name: "SendMessagesFailsWithNonexistentLogger",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								payload := options.LoggingPayload{
-									LoggerID: "DNE",
+									LoggerID: "nonexistent",
 									Data:     "new log message",
 									Priority: level.Warning,
 									Format:   options.LoggingPayloadFormatString,
@@ -1098,7 +1167,7 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "LoggingSendMessagesValid",
+							Name: "SendMessagesSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
 								logger1, err := lc.Create("logger1", &options.Output{})
@@ -1114,16 +1183,21 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingGetDNE",
+							Name: "ScriptingGetWithNonexistentHarnessFails",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								_, err := client.GetScripting(ctx, "DNE")
+								_, err := client.GetScripting(ctx, "nonexistent")
 								assert.Error(t, err)
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingGetExists",
+							Name: "ScriptingGetWithExistingHarnessSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								expectedHarness := createTestScriptingHarness(ctx, t, client, ".")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								require.NoError(t, err)
+								defer func() {
+									assert.NoError(t, os.RemoveAll(tmpDir))
+								}()
+								expectedHarness := createTestScriptingHarness(ctx, t, client, tmpDir)
 
 								harness, err := client.GetScripting(ctx, expectedHarness.ID())
 								require.NoError(t, err)
@@ -1131,91 +1205,100 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingSetup",
+							Name: "ScriptingSetupSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								harness := createTestScriptingHarness(ctx, t, client, ".")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								require.NoError(t, err)
+								defer func() {
+									assert.NoError(t, os.RemoveAll(tmpDir))
+								}()
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 								assert.NoError(t, harness.Setup(ctx))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingCleanup",
+							Name: "ScriptingCleanupSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								harness := createTestScriptingHarness(ctx, t, client, ".")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								require.NoError(t, err)
+								defer func() {
+									assert.NoError(t, os.RemoveAll(tmpDir))
+								}()
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 								assert.NoError(t, harness.Cleanup(ctx))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingRunNoError",
+							Name: "ScriptingRunSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 
 								require.NoError(t, err)
-								tmpFile := filepath.Join(tmpdir, "fake_script.go")
+								tmpFile := filepath.Join(tmpDir, "fake_script.go")
 								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; import "os"; func main() { os.Exit(0) }`), 0755))
 								assert.NoError(t, harness.Run(ctx, []string{tmpFile}))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingRunError",
+							Name: "ScriptingRunErrors",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 
-								tmpFile := filepath.Join(tmpdir, "fake_script.go")
+								tmpFile := filepath.Join(tmpDir, "fake_script.go")
 								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; import "os"; func main() { os.Exit(42) }`), 0755))
 								assert.Error(t, harness.Run(ctx, []string{tmpFile}))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingRunScriptNoError",
+							Name: "ScriptingRunScriptSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
-
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 								assert.NoError(t, harness.RunScript(ctx, `package main; import "fmt"; func main() { fmt.Println("Hello World") }`))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingRunScriptError",
+							Name: "ScriptingRunScriptErrors",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
 
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 								require.Error(t, harness.RunScript(ctx, `package main; import "os"; func main() { os.Exit(42) }`))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingBuild",
+							Name: "ScriptingBuildSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 
-								tmpFile := filepath.Join(tmpdir, "fake_script.go")
+								tmpFile := filepath.Join(tmpDir, "fake_script.go")
 								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; import "os"; func main() { os.Exit(0) }`), 0755))
-								_, err = harness.Build(ctx, tmpdir, []string{
+								_, err = harness.Build(ctx, tmpDir, []string{
 									"-o",
-									filepath.Join(tmpdir, "fake_script"),
+									filepath.Join(tmpDir, "fake_script"),
 									tmpFile,
 								})
 								require.NoError(t, err)
@@ -1224,18 +1307,18 @@ func TestManager(t *testing.T) {
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingTest",
+							Name: "ScriptingTestSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpdir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
 								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpdir))
+									assert.NoError(t, os.RemoveAll(tmpDir))
 								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpdir)
+								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 
-								tmpFile := filepath.Join(tmpdir, "fake_script_test.go")
+								tmpFile := filepath.Join(tmpDir, "fake_script_test.go")
 								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; import "testing"; func TestMain(t *testing.T) { return }`), 0755))
-								results, err := harness.Test(ctx, tmpdir, scripting.TestOptions{Name: "dummy"})
+								results, err := harness.Test(ctx, tmpDir, scripting.TestOptions{Name: "dummy"})
 								require.NoError(t, err)
 								require.Len(t, results, 1)
 							},
@@ -1244,7 +1327,11 @@ func TestManager(t *testing.T) {
 						t.Run(test.Name, func(t *testing.T) {
 							tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
 							defer cancel()
-							test.Case(tctx, t, factory.Constructor(tctx, t))
+							client := factory.Constructor(tctx, t)
+							defer func() {
+								assert.NoError(t, client.CloseConnection())
+							}()
+							test.Case(tctx, t, client)
 						})
 					}
 				})
@@ -1259,4 +1346,20 @@ func createTestScriptingHarness(ctx context.Context, t *testing.T, client Manage
 	require.NoError(t, err)
 
 	return harness
+}
+
+func createProcs(ctx context.Context, opts *options.Create, manager Manager, num int) ([]jasper.Process, error) {
+	catcher := grip.NewBasicCatcher()
+	var procs []jasper.Process
+	for i := 0; i < num; i++ {
+		optsCopy := *opts
+
+		proc, err := manager.CreateProcess(ctx, &optsCopy)
+		catcher.Add(err)
+		if proc != nil {
+			procs = append(procs, proc)
+		}
+	}
+
+	return procs, catcher.Resolve()
 }

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -499,19 +499,19 @@ func TestManagerImplementations(t *testing.T) {
 				return client
 			},
 		},
-		// {
-		//     Name: "REST",
-		//     Constructor: func(ctx context.Context, t *testing.T) Manager {
-		//         _, port, err := startRESTService(ctx, httpClient)
-		//         require.NoError(t, err)
-		//
-		//         client := &restClient{
-		//             prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
-		//             client: httpClient,
-		//         }
-		//         return client
-		//     },
-		// },
+		{
+			Name: "REST",
+			Constructor: func(ctx context.Context, t *testing.T) Manager {
+				_, port, err := startRESTService(ctx, httpClient)
+				require.NoError(t, err)
+
+				client := &restClient{
+					prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
+					client: httpClient,
+				}
+				return client
+			},
+		},
 	} {
 		t.Run(factory.Name, func(t *testing.T) {
 			for _, modify := range []struct {

--- a/remote/rest_client.go
+++ b/remote/rest_client.go
@@ -22,9 +22,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// NewRestClient creates a REST client that connecst to the given address
+// NewRESTClient creates a REST client that connects to the given address
 // running the Jasper REST service.
-func NewRestClient(addr net.Addr) Manager {
+func NewRESTClient(addr net.Addr) Manager {
 	return &restClient{
 		prefix: fmt.Sprintf("http://%s/jasper/v1", addr),
 		client: bond.GetHTTPClient(),

--- a/remote/rest_client.go
+++ b/remote/rest_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -67,12 +68,20 @@ func handleError(resp *http.Response) error {
 		return nil
 	}
 
-	gimerr := gimlet.ErrorResponse{}
-	if err := gimlet.GetJSON(resp.Body, &gimerr); err != nil {
-		return errors.WithStack(err)
+	wrapError := func(err error) error {
+		return errors.Wrapf(err, "HTTP status code %d", resp.StatusCode)
 	}
 
-	return errors.WithStack(gimerr)
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return wrapError(errors.Wrap(err, "reading response body"))
+	}
+	gimerr := gimlet.ErrorResponse{}
+	if err := json.Unmarshal(body, &gimerr); err != nil {
+		return wrapError(errors.Errorf("received response: %s", string(body)))
+	}
+
+	return wrapError(gimerr)
 }
 
 func (c *restClient) doRequest(ctx context.Context, method string, url string, body io.Reader) (*http.Response, error) {
@@ -172,7 +181,7 @@ func (c *restClient) CreateScripting(ctx context.Context, opts options.Scripting
 }
 
 func (c *restClient) GetScripting(ctx context.Context, id string) (scripting.Harness, error) {
-	resp, err := c.doRequest(ctx, http.MethodPost, c.getURL("/scripting/%s", id), nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, c.getURL("/scripting/%s", id), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "request returned error")
 	}
@@ -353,7 +362,7 @@ func (c *restClient) DownloadFile(ctx context.Context, opts options.Download) er
 func (c *restClient) DownloadMongoDB(ctx context.Context, opts options.MongoDBDownload) error {
 	body, err := makeBody(opts)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "building request")
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, c.getURL("/download/mongodb"), body)
@@ -369,7 +378,7 @@ func (c *restClient) DownloadMongoDB(ctx context.Context, opts options.MongoDBDo
 func (c *restClient) ConfigureCache(ctx context.Context, opts options.Cache) error {
 	body, err := makeBody(opts)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "building request")
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, c.getURL("/download/cache"), body)
@@ -410,12 +419,12 @@ func (c *restClient) WriteFile(ctx context.Context, opts options.WriteFile) erro
 func (c *restClient) SendMessages(ctx context.Context, lp options.LoggingPayload) error {
 	body, err := makeBody(lp)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "building request")
 	}
 
 	resp, err := c.doRequest(ctx, http.MethodPost, c.getURL("/logging/%s/send", lp.LoggerID), body)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "request returned error")
 	}
 	defer resp.Body.Close()
 
@@ -441,12 +450,12 @@ type restLoggingCache struct {
 func (lc *restLoggingCache) Create(id string, opts *options.Output) (*options.CachedLogger, error) {
 	body, err := makeBody(opts)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "building request")
 	}
 
-	resp, err := lc.client.doRequest(lc.ctx, http.MethodPost, lc.client.getURL("/download/cache"), body)
+	resp, err := lc.client.doRequest(lc.ctx, http.MethodPost, lc.client.getURL("/logging/%s", id), body)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "request returned error")
 	}
 	defer resp.Body.Close()
 
@@ -456,7 +465,7 @@ func (lc *restLoggingCache) Create(id string, opts *options.Output) (*options.Ca
 
 	out := &options.CachedLogger{}
 	if err = gimlet.GetJSON(resp.Body, out); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "getting cached logger info from response")
 	}
 
 	return out, nil
@@ -469,11 +478,13 @@ func (lc *restLoggingCache) Put(id string, cl *options.CachedLogger) error {
 func (lc *restLoggingCache) Get(id string) *options.CachedLogger {
 	resp, err := lc.client.doRequest(lc.ctx, http.MethodGet, lc.client.getURL("/logging/%s", id), nil)
 	if err != nil {
+		grip.Debug(errors.Wrap(err, "request returned error"))
 		return nil
 	}
 	defer resp.Body.Close()
 
 	if err = handleError(resp); err != nil {
+		grip.Debug(errors.WithStack(err))
 		return nil
 	}
 
@@ -486,44 +497,46 @@ func (lc *restLoggingCache) Get(id string) *options.CachedLogger {
 
 func (lc *restLoggingCache) Remove(id string) {
 	resp, err := lc.client.doRequest(lc.ctx, http.MethodDelete, lc.client.getURL("/logging/%s", id), nil)
-	grip.Info(message.Fields{
-		"has_error": err == nil,
-		"code":      resp.StatusCode,
-		"status":    resp.Status,
-		"op":        "delete",
-		"logger":    id,
-		"err":       err,
-	})
+	if err != nil {
+		grip.Debug(errors.Wrap(err, "request returned error"))
+		return
+	}
+	defer resp.Body.Close()
+
+	grip.Debug(errors.WithStack(handleError(resp)))
 }
 
 func (lc *restLoggingCache) Prune(ts time.Time) {
 	resp, err := lc.client.doRequest(lc.ctx, http.MethodDelete, lc.client.getURL("/logging/prune/%s", ts.Format(time.RFC3339)), nil)
-	grip.Info(message.Fields{
-		"has_error": err == nil,
-		"code":      resp.StatusCode,
-		"status":    resp.Status,
-		"op":        "prune",
-		"err":       err,
-	})
+	if err != nil {
+		grip.Debug(errors.Wrap(err, "request returned error"))
+		return
+	}
+	defer resp.Body.Close()
+
+	grip.Debug(errors.WithStack(handleError(resp)))
 }
 
 func (lc *restLoggingCache) Len() int {
-	resp, err := lc.client.doRequest(lc.ctx, http.MethodDelete, lc.client.getURL("/logging/size"), nil)
+	resp, err := lc.client.doRequest(lc.ctx, http.MethodGet, lc.client.getURL("/logging/len"), nil)
 	if err != nil {
+		grip.Debug(errors.Wrap(err, "request returned error"))
 		return 0
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if err := handleError(resp); err != nil {
+		grip.Debug(errors.WithStack(err))
 		return 0
 	}
 
-	out := restLoggingCacheSize{}
+	out := restLoggingCacheLen{}
 	if err = gimlet.GetJSON(resp.Body, &out); err != nil {
+		grip.Debug(errors.Wrap(err, "getting logging cache length from response"))
 		return 0
 	}
 
-	return out.Size
+	return out.Len
 }
 
 type restProcess struct {

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -87,7 +87,7 @@ func (s *Service) App(ctx context.Context) *gimlet.APIApp {
 	app.AddRoute("/scripting/{id}/script").Version(1).Post().Handler(s.scriptingRunScript)
 	app.AddRoute("/scripting/{id}/build").Version(1).Post().Handler(s.scriptingBuild)
 	app.AddRoute("/scripting/{id}/test").Version(1).Post().Handler(s.scriptingTest)
-	app.AddRoute("/logging/size").Version(1).Get().Handler(s.loggingCacheSize)
+	app.AddRoute("/logging/len").Version(1).Get().Handler(s.loggingCacheLen)
 	app.AddRoute("/logging/prune/{time}").Version(1).Delete().Handler(s.loggingCachePrune)
 	app.AddRoute("/logging/{id}").Version(1).Post().Handler(s.loggingCacheCreate)
 	app.AddRoute("/logging/{id}").Version(1).Delete().Handler(s.loggingCacheDelete)
@@ -760,12 +760,20 @@ func (s *Service) registerSignalTriggerID(rw http.ResponseWriter, r *http.Reques
 	gimlet.WriteJSON(rw, struct{}{})
 }
 
-type restLoggingCacheSize struct {
-	Size int `json:"size"`
+type restLoggingCacheLen struct {
+	Len int `json:"len"`
 }
 
-func (s *Service) loggingCacheSize(rw http.ResponseWriter, r *http.Request) {
-	gimlet.WriteJSON(rw, &restLoggingCacheSize{Size: s.manager.LoggingCache(r.Context()).Len()})
+func (s *Service) loggingCacheLen(rw http.ResponseWriter, r *http.Request) {
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
+		return
+	}
+	gimlet.WriteJSON(rw, &restLoggingCacheLen{Len: lc.Len()})
 }
 
 func (s *Service) loggingCacheCreate(rw http.ResponseWriter, r *http.Request) {
@@ -779,7 +787,15 @@ func (s *Service) loggingCacheCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cl, err := s.manager.LoggingCache(r.Context()).Create(id, args)
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
+	}
+
+	logger, err := lc.Create(id, args)
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -788,34 +804,40 @@ func (s *Service) loggingCacheCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gimlet.WriteJSON(rw, cl)
-}
-
-func (s *Service) loggingCacheDelete(rw http.ResponseWriter, r *http.Request) {
-	s.manager.LoggingCache(r.Context()).Remove(gimlet.GetVars(r)["id"])
-}
-
-func (s *Service) loggingCachePrune(rw http.ResponseWriter, r *http.Request) {
-	ts, err := time.Parse(time.RFC3339, gimlet.GetVars(r)["time"])
-	if err != nil {
-		writeError(rw, gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    errors.Wrapf(err, "problem parsing timestamp").Error(),
-		})
-		return
-	}
-
-	s.manager.LoggingCache(r.Context()).Prune(ts)
+	gimlet.WriteJSON(rw, logger)
 }
 
 func (s *Service) loggingCacheGet(rw http.ResponseWriter, r *http.Request) {
-	gimlet.WriteJSON(rw, s.manager.LoggingCache(r.Context()).Get(gimlet.GetVars(r)["id"]))
+	id := gimlet.GetVars(r)["id"]
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
+		return
+	}
+	logger := lc.Get(id)
+	if logger == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("logger '%s' does not exist", id),
+		})
+	}
+	gimlet.WriteJSON(rw, logger)
 }
 
 func (s *Service) loggingSend(rw http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["id"]
-	cache := s.manager.LoggingCache(r.Context())
-	logger := cache.Get(id)
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
+		return
+	}
+	logger := lc.Get(id)
 	if logger == nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -845,26 +867,44 @@ func (s *Service) loggingSend(rw http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(rw, struct{}{})
 }
 
-func (s *Service) oomTrackerClear(rw http.ResponseWriter, r *http.Request) {
-	resp := jasper.NewOOMTracker()
-
-	if err := resp.Clear(r.Context()); err != nil {
-		gimlet.WriteJSONInternalError(rw, err.Error())
+func (s *Service) loggingCacheDelete(rw http.ResponseWriter, r *http.Request) {
+	id := gimlet.GetVars(r)["id"]
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
 		return
 	}
 
-	gimlet.WriteJSON(rw, resp)
+	lc.Remove(id)
+
+	gimlet.WriteJSON(rw, struct{}{})
 }
 
-func (s *Service) oomTrackerList(rw http.ResponseWriter, r *http.Request) {
-	resp := jasper.NewOOMTracker()
-
-	if err := resp.Check(r.Context()); err != nil {
-		gimlet.WriteJSONInternalError(rw, err.Error())
+func (s *Service) loggingCachePrune(rw http.ResponseWriter, r *http.Request) {
+	ts, err := time.Parse(time.RFC3339, gimlet.GetVars(r)["time"])
+	if err != nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    errors.Wrapf(err, "problem parsing timestamp").Error(),
+		})
 		return
 	}
 
-	gimlet.WriteJSON(rw, resp)
+	lc := s.manager.LoggingCache(r.Context())
+	if lc == nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "logging cache is not supported",
+		})
+		return
+	}
+
+	lc.Prune(ts)
+
+	gimlet.WriteJSON(rw, struct{}{})
 }
 
 func (s *Service) scriptingCreate(rw http.ResponseWriter, r *http.Request) {
@@ -1100,4 +1140,26 @@ func (s *Service) scriptingCleanup(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	gimlet.WriteJSON(rw, struct{}{})
+}
+
+func (s *Service) oomTrackerClear(rw http.ResponseWriter, r *http.Request) {
+	resp := jasper.NewOOMTracker()
+
+	if err := resp.Clear(r.Context()); err != nil {
+		gimlet.WriteJSONInternalError(rw, err.Error())
+		return
+	}
+
+	gimlet.WriteJSON(rw, resp)
+}
+
+func (s *Service) oomTrackerList(rw http.ResponseWriter, r *http.Request) {
+	resp := jasper.NewOOMTracker()
+
+	if err := resp.Check(r.Context()); err != nil {
+		gimlet.WriteJSONInternalError(rw, err.Error())
+		return
+	}
+
+	gimlet.WriteJSON(rw, resp)
 }

--- a/remote/rpc_util_test.go
+++ b/remote/rpc_util_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/certdepot"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper"
-	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/pkg/errors"
 )
@@ -132,20 +131,4 @@ func newTestRPCClient(ctx context.Context, addr net.Addr, creds *certdepot.Crede
 	}()
 
 	return client, nil
-}
-
-func createProcs(ctx context.Context, opts *options.Create, manager jasper.Manager, num int) ([]jasper.Process, error) {
-	catcher := grip.NewBasicCatcher()
-	out := []jasper.Process{}
-	for i := 0; i < num; i++ {
-		optsCopy := *opts
-
-		proc, err := manager.CreateProcess(ctx, &optsCopy)
-		catcher.Add(err)
-		if proc != nil {
-			out = append(out, proc)
-		}
-	}
-
-	return out, catcher.Resolve()
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9110

* Add tests that were missing from the remote tests but were present in the root package tests.
* Fix REST manager logging and scripting cache to pass tests.
* Add REST manager to remote manager tests.