### PR TITLE
EVG-12467: implement SendMessages for CLI

### DIFF
--- a/cli/remote.go
+++ b/cli/remote.go
@@ -18,6 +18,7 @@ const (
 	GetLogStreamCommand       = "get-log-stream"
 	SignalEventCommand        = "signal-event"
 	WriteFileCommand          = "write-file"
+	SendMessagesCommand       = "send-messages"
 )
 
 // Remote creates a cli.Command that allows the remote-specific methods in the

--- a/cli/remote.go
+++ b/cli/remote.go
@@ -35,6 +35,7 @@ func Remote() cli.Command {
 			remoteGetBuildloggerURLs(),
 			remoteSignalEvent(),
 			remoteWriteFile(),
+			remoteSendMessages(),
 		},
 	}
 }
@@ -140,6 +141,23 @@ func remoteSignalEvent() cli.Command {
 			input := EventInput{}
 			return doPassthroughInputOutput(c, &input, func(ctx context.Context, client remote.Manager) interface{} {
 				if err := client.SignalEvent(ctx, input.Name); err != nil {
+					return makeOutcomeResponse(err)
+				}
+				return makeOutcomeResponse(nil)
+			})
+		},
+	}
+}
+
+func remoteSendMessages() cli.Command {
+	return cli.Command{
+		Name:   SendMessagesCommand,
+		Flags:  clientFlags(),
+		Before: clientBefore(),
+		Action: func(c *cli.Context) error {
+			input := options.LoggingPayload{}
+			return doPassthroughInputOutput(c, &input, func(ctx context.Context, client remote.Manager) interface{} {
+				if err := client.SendMessages(ctx, input); err != nil {
 					return makeOutcomeResponse(err)
 				}
 				return makeOutcomeResponse(nil)

--- a/cli/ssh_client.go
+++ b/cli/ssh_client.go
@@ -106,9 +106,12 @@ func (c *sshClient) CreateCommand(ctx context.Context) *jasper.Command {
 	})
 }
 
+// TODO (EVG-12616): fix this.
 func (c *sshClient) CreateScripting(ctx context.Context, opts options.ScriptingHarness) (scripting.Harness, error) {
 	return c.shCache.Create(c.manager, opts)
 }
+
+// TODO (EVG-12616): fix this.
 func (c *sshClient) GetScripting(ctx context.Context, id string) (scripting.Harness, error) {
 	return c.shCache.Get(id)
 }
@@ -289,13 +292,22 @@ func (c *sshClient) SignalEvent(ctx context.Context, name string) error {
 	return nil
 }
 
+// TODO (EVG-12626): fix this.
 func (c *sshClient) LoggingCache(ctx context.Context) jasper.LoggingCache {
 	return c.manager.LoggingCache(ctx)
 }
 
-// TODO: implement
-func (c *sshClient) SendMessages(_ context.Context, _ options.LoggingPayload) error {
-	return errors.New("message sending is not supported")
+func (c *sshClient) SendMessages(ctx context.Context, opts options.LoggingPayload) error {
+	output, err := c.runRemoteCommand(ctx, SendMessagesCommand, opts)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if _, err := ExtractOutcomeResponse(output); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }
 
 func (c *sshClient) runManagerCommand(ctx context.Context, managerSubcommand string, subcommandInput interface{}) ([]byte, error) {

--- a/options/logging.go
+++ b/options/logging.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/birch"
+	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
@@ -44,9 +45,9 @@ type LoggingPayload struct {
 	LoggerID          string               `bson:"logger_id" json:"logger_id" yaml:"logger_id"`
 	Data              interface{}          `bson:"data" json:"data" yaml:"data"`
 	Priority          level.Priority       `bson:"priority" json:"priority" yaml:"priority"`
-	IsMulti           bool                 `bson:"multi" json:"multi" yaml:"multi"`
-	PreferSendToError bool                 `bson:"prefer_send_to_error" json:"prefer_send_to_error" yaml:"prefer_send_to_error"`
-	AddMetadata       bool                 `bson:"add_metadata" json:"add_metadata" yaml:"add_metadata"`
+	IsMulti           bool                 `bson:"multi,omitempty" json:"multi,omitempty" yaml:"multi,omitempty"`
+	PreferSendToError bool                 `bson:"prefer_send_to_error,omitempty" json:"prefer_send_to_error,omitempty" yaml:"prefer_send_to_error,omitempty"`
+	AddMetadata       bool                 `bson:"add_metadata,omitempty" json:"add_metadata,omitempty" yaml:"add_metadata,omitempty"`
 	Format            LoggingPayloadFormat `bson:"payload_format,omitempty" json:"payload_format,omitempty" yaml:"payload_format,omitempty"`
 }
 
@@ -61,11 +62,28 @@ const (
 	LoggingPayloadFormatString = "string"
 )
 
+// Validate checks that the required fields are populated for the payload and
+// the format is valid.
+func (lp *LoggingPayload) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(lp.Data == nil, "data cannot be empty")
+	switch lp.Format {
+	case "", LoggingPayloadFormatBSON, LoggingPayloadFormatJSON, LoggingPayloadFormatString:
+	default:
+		catcher.Errorf("invalid payload format '%s'", lp.Format)
+	}
+	return catcher.Resolve()
+}
+
 // Send resolves a sender from the cached logger (either the error or
 // output endpoint), and then sends the message from the data
 // payload. This method ultimately is responsible for converting the
 // payload to a message format.
 func (cl *CachedLogger) Send(lp *LoggingPayload) error {
+	if err := lp.Validate(); err != nil {
+		return errors.Wrap(err, "invalid logging payload")
+	}
+
 	sender, err := cl.getSender(lp.PreferSendToError)
 	if err != nil {
 		return errors.WithStack(err)

--- a/options/logging_test.go
+++ b/options/logging_test.go
@@ -21,12 +21,12 @@ func TestLogging(t *testing.T) {
 		cl := &CachedLogger{}
 		t.Run("Unconfigured", func(t *testing.T) {
 			err := cl.Send(lp)
-			require.Error(t, err)
-			require.Equal(t, "no output configured", err.Error())
+			assert.Error(t, err)
 		})
 		t.Run("IvalidMessage", func(t *testing.T) {
 			lp.Format = LoggingPayloadFormatJSON
 			lp.Data = "hello, world!"
+			lp.Priority = level.Trace
 			logger := &CachedLogger{Output: grip.GetSender()}
 			require.Error(t, logger.Send(lp))
 		})

--- a/remote/internal/service.go
+++ b/remote/internal/service.go
@@ -942,19 +942,12 @@ func (s *jasperService) SendMessages(ctx context.Context, lp *LoggingPayload) (*
 	}
 
 	payload := lp.Export()
-	if err := payload.Validate(); err != nil {
-		return &OperationOutcome{
-			Success:  false,
-			Text:     err.Error(),
-			ExitCode: -3,
-		}, nil
-	}
 
 	if err := logger.Send(payload); err != nil {
 		return &OperationOutcome{
 			Success:  false,
 			Text:     err.Error(),
-			ExitCode: -4,
+			ExitCode: -3,
 		}, nil
 	}
 

--- a/remote/internal/service.go
+++ b/remote/internal/service.go
@@ -942,11 +942,19 @@ func (s *jasperService) SendMessages(ctx context.Context, lp *LoggingPayload) (*
 	}
 
 	payload := lp.Export()
-	if err := logger.Send(payload); err != nil {
+	if err := payload.Validate(); err != nil {
 		return &OperationOutcome{
 			Success:  false,
 			Text:     err.Error(),
 			ExitCode: -3,
+		}, nil
+	}
+
+	if err := logger.Send(payload); err != nil {
+		return &OperationOutcome{
+			Success:  false,
+			Text:     err.Error(),
+			ExitCode: -4,
 		}, nil
 	}
 

--- a/remote/mdb_client.go
+++ b/remote/mdb_client.go
@@ -288,7 +288,7 @@ func (c *mdbClient) LoggingCache(ctx context.Context) jasper.LoggingCache {
 }
 
 func (c *mdbClient) SendMessages(ctx context.Context, lp options.LoggingPayload) error {
-	req, err := shell.RequestToMessage(mongowire.OP_QUERY, &loggingSendMessageRequest{Payload: lp})
+	req, err := shell.RequestToMessage(mongowire.OP_QUERY, &loggingSendMessagesRequest{Payload: lp})
 	if err != nil {
 		return errors.Wrap(err, "could not create request")
 	}

--- a/remote/mdb_io.go
+++ b/remote/mdb_io.go
@@ -281,8 +281,8 @@ type loggingCacheLenRequest struct {
 	Len bool `bson:"logging_cache_size"`
 }
 
-type loggingSendMessageRequest struct {
-	Payload options.LoggingPayload `bson:"send_message"`
+type loggingSendMessagesRequest struct {
+	Payload options.LoggingPayload `bson:"send_messages"`
 }
 
 type scriptingCreateRequest struct {

--- a/remote/mdb_service.go
+++ b/remote/mdb_service.go
@@ -110,12 +110,12 @@ func (s *mdbService) registerHandlers() error {
 		ScriptingTestCommand:      s.scriptingTest,
 
 		// Logging Commands
-		LoggingCacheSizeCommand:   s.loggingSize,
-		LoggingCacheCreateCommand: s.loggingCreate,
-		LoggingCacheDeleteCommand: s.loggingDelete,
-		LoggingCacheGetCommand:    s.loggingGet,
-		LoggingCachePruneCommand:  s.loggingPrune,
-		LoggingSendMessageCommand: s.loggingSendMessage,
+		LoggingCacheSizeCommand:    s.loggingSize,
+		LoggingCacheCreateCommand:  s.loggingCreate,
+		LoggingCacheDeleteCommand:  s.loggingDelete,
+		LoggingCacheGetCommand:     s.loggingGet,
+		LoggingCachePruneCommand:   s.loggingPrune,
+		LoggingSendMessagesCommand: s.loggingSendMessages,
 
 		// Remote client commands
 		ConfigureCacheCommand:     s.configureCache,

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -92,7 +92,7 @@ func (s *Service) App(ctx context.Context) *gimlet.APIApp {
 	app.AddRoute("/logging/{id}").Version(1).Post().Handler(s.loggingCacheCreate)
 	app.AddRoute("/logging/{id}").Version(1).Delete().Handler(s.loggingCacheDelete)
 	app.AddRoute("/logging/{id}").Version(1).Get().Handler(s.loggingCacheGet)
-	app.AddRoute("/logging/{id}/send").Version(1).Post().Handler(s.loggingSend)
+	app.AddRoute("/logging/{id}/send").Version(1).Post().Handler(s.loggingSendMessages)
 	app.AddRoute("/file/write").Version(1).Put().Handler(s.writeFile)
 	app.AddRoute("/clear").Version(1).Post().Handler(s.clearManager)
 	app.AddRoute("/close").Version(1).Delete().Handler(s.closeManager)
@@ -812,7 +812,7 @@ func (s *Service) loggingCacheGet(rw http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(rw, s.manager.LoggingCache(r.Context()).Get(gimlet.GetVars(r)["id"]))
 }
 
-func (s *Service) loggingSend(rw http.ResponseWriter, r *http.Request) {
+func (s *Service) loggingSendMessages(rw http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["id"]
 	cache := s.manager.LoggingCache(r.Context())
 	logger := cache.Get(id)
@@ -831,6 +831,13 @@ func (s *Service) loggingSend(rw http.ResponseWriter, r *http.Request) {
 			Message:    errors.Wrapf(err, "problem parsing payload for %s", id).Error(),
 		})
 		return
+	}
+
+	if err := payload.Validate(); err != nil {
+		writeError(rw, gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    errors.Wrapf(err, "invalid logging payload").Error(),
+		})
 	}
 
 	err := logger.Send(payload)

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -833,15 +833,7 @@ func (s *Service) loggingSendMessages(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := payload.Validate(); err != nil {
-		writeError(rw, gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    errors.Wrapf(err, "invalid logging payload").Error(),
-		})
-	}
-
-	err := logger.Send(payload)
-	if err != nil {
+	if err := logger.Send(payload); err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12467

* Implement SendMessages for the CLI and CLI over SSH.
* Add validation for correct logging payloads.
* Fix some misnaming in mongo wire protocol logging.
* We can't test this until [this ticket](https://jira.mongodb.org/browse/EVG-12626) is completed since `SendMessages()` relies on the logging cache.