### PR TITLE
EVG-12738: handle nil times and durations from gRPC

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -207,7 +207,10 @@ func printLogs(ctx context.Context, client remote.Manager, cmd *jasper.Command, 
 		}
 	}()
 
-	<-logDone
+	select {
+	case <-logDone:
+	case <-ctx.Done():
+	}
 	return cmd.Wait(ctx)
 }
 

--- a/remote/internal/jasper.ext.go
+++ b/remote/internal/jasper.ext.go
@@ -124,13 +124,20 @@ func ConvertCreateOptions(opts *options.Create) (*CreateOptions, error) {
 // Export takes a protobuf RPC ProcessInfo struct and returns the analogous
 // Jasper ProcessInfo struct.
 func (info *ProcessInfo) Export() (jasper.ProcessInfo, error) {
-	startAt, err := ptypes.Timestamp(info.StartAt)
-	if err != nil {
-		return jasper.ProcessInfo{}, errors.Wrap(err, "could not convert end timestamp from equivalent protobuf RPC timestamp")
+	var startAt time.Time
+	var err error
+	if info.StartAt != nil {
+		startAt, err = ptypes.Timestamp(info.StartAt)
+		if err != nil {
+			return jasper.ProcessInfo{}, errors.Wrap(err, "could not convert start timestamp from equivalent protobuf RPC timestamp")
+		}
 	}
-	endAt, err := ptypes.Timestamp(info.EndAt)
-	if err != nil {
-		return jasper.ProcessInfo{}, errors.Wrap(err, "could not convert end timestamp from equivalent protobuf RPC timestamp")
+	var endAt time.Time
+	if info.EndAt != nil {
+		endAt, err = ptypes.Timestamp(info.EndAt)
+		if err != nil {
+			return jasper.ProcessInfo{}, errors.Wrap(err, "could not convert end timestamp from equivalent protobuf RPC timestamp")
+		}
 	}
 	opts, err := info.Options.Export()
 	if err != nil {
@@ -945,13 +952,20 @@ func ConvertScriptingTestResults(res []scripting.TestResult) ([]*ScriptingHarnes
 func (r *ScriptingHarnessTestResponse) Export() ([]scripting.TestResult, error) {
 	out := make([]scripting.TestResult, len(r.Results))
 	for idx, res := range r.Results {
-		startAt, err := ptypes.Timestamp(res.StartAt)
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not convert start time from equivalent protobuf RPC time for script '%s'", res.Name)
+		var startAt time.Time
+		var err error
+		if res.StartAt != nil {
+			startAt, err = ptypes.Timestamp(res.StartAt)
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not convert start time from equivalent protobuf RPC time for script '%s'", res.Name)
+			}
 		}
-		duration, err := ptypes.Duration(res.Duration)
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not convert script duration from equivalent protobuf RPC duration for script '%s'", res.Name)
+		var duration time.Duration
+		if res.Duration != nil {
+			duration, err = ptypes.Duration(res.Duration)
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not convert script duration from equivalent protobuf RPC duration for script '%s'", res.Name)
+			}
 		}
 
 		out[idx] = scripting.TestResult{

--- a/remote/rpc_client.go
+++ b/remote/rpc_client.go
@@ -58,7 +58,7 @@ func NewRPCClient(ctx context.Context, addr net.Addr, creds *certdepot.Credentia
 // NewRPCClientWithFile is the same as NewRPCClient but the credentials will
 // be read from the file given by filePath if the filePath is non-empty. The
 // credentials file should contain the JSON-encoded bytes from
-// (*Credentials).Export().
+// (*certdepot.Credentials).Export().
 func NewRPCClientWithFile(ctx context.Context, addr net.Addr, filePath string) (Manager, error) {
 	var creds *certdepot.Credentials
 	if filePath != "" {

--- a/remote/rpc_service.go
+++ b/remote/rpc_service.go
@@ -65,7 +65,7 @@ func StartRPCService(ctx context.Context, manager jasper.Manager, addr net.Addr,
 // StartRPCServiceWithFile is the same as StartService, but the credentials will be
 // read from the file given by filePath if the filePath is non-empty. The
 // credentials file should contain the JSON-encoded bytes from
-// (*Credentials).Export().
+// (*certdepot.Credentials).Export().
 func StartRPCServiceWithFile(ctx context.Context, manager jasper.Manager, addr net.Addr, filePath string) (util.CloseFunc, error) {
 	var creds *certdepot.Credentials
 	if filePath != "" {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12738

If the gRPC timestamp type or gRPC duration type is unset (e.g. the process hasn't ended yet so it hasn't set an end timestamp for the process), it'll fail to convert the protobuf time/duration type into the equivalent standard library time type.

* Handle nil timestamps/durations from gRPC.
* Minor fix to handle contexts better in CLI code.
* Minor updates to documentation.