### PR TITLE
EVG-12920: add remote LoggingCache tests and split up remote tests by interface

### DIFF
--- a/logging_cache.go
+++ b/logging_cache.go
@@ -9,6 +9,7 @@ import (
 )
 
 // LoggingCache provides an interface to a cache of loggers.
+// TODO (EVG-13100): most of these methods should return errors.
 type LoggingCache interface {
 	// Create creates and caches a new logger based on the given output options.
 	Create(id string, opts *options.Output) (*options.CachedLogger, error)
@@ -25,6 +26,7 @@ type LoggingCache interface {
 	// Len returns the number of loggers. Implementations should return
 	// -1 if the length cannot be retrieved successfully.
 	Len() int
+	// TODO (EVG-13101): support closing of senders within cache.
 }
 
 // NewLoggingCache produces a thread-safe implementation of a local logging

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -1171,7 +1171,7 @@ func TestManagerImplementations(t *testing.T) {
 						clientTestCase{
 							Name: "SendMessagesSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								if runtime.GOOS == "window" {
+								if runtime.GOOS == "windows" {
 									// TODO (EVG-13101): do not skip this test
 									t.Skip("Windows will fail because of the leaked file handle from not closing the sender in the remote service")
 								}

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
-	"github.com/mongodb/jasper/scripting"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -451,6 +450,49 @@ func addBasicClientTests(modify testutil.OptsModify, tests ...clientTestCase) []
 	}, tests...)
 }
 
+func remoteManagerTestCases(httpClient *http.Client) map[string]func(context.Context, *testing.T) Manager {
+	return map[string]func(context.Context, *testing.T) Manager{
+		"MDB": func(ctx context.Context, t *testing.T) Manager {
+			mngr, err := jasper.NewSynchronizedManager(false)
+			require.NoError(t, err)
+
+			client, err := makeTestMDBServiceAndClient(ctx, mngr)
+			require.NoError(t, err)
+			return client
+		},
+		"RPC/TLS": func(ctx context.Context, t *testing.T) Manager {
+			mngr, err := jasper.NewSynchronizedManager(false)
+			require.NoError(t, err)
+
+			client, err := makeTLSRPCServiceAndClient(ctx, mngr)
+			require.NoError(t, err)
+			return client
+		},
+		"RPC/Insecure": func(ctx context.Context, t *testing.T) Manager {
+			assert.NotPanics(t, func() {
+				newRPCClient(nil)
+			})
+
+			mngr, err := jasper.NewSynchronizedManager(false)
+			require.NoError(t, err)
+
+			client, err := makeInsecureRPCServiceAndClient(ctx, mngr)
+			require.NoError(t, err)
+			return client
+		},
+		"REST": func(ctx context.Context, t *testing.T) Manager {
+			_, port, err := startRESTService(ctx, httpClient)
+			require.NoError(t, err)
+
+			client := &restClient{
+				prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
+				client: httpClient,
+			}
+			return client
+		},
+	}
+}
+
 func TestManagerImplementations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -458,62 +500,8 @@ func TestManagerImplementations(t *testing.T) {
 	httpClient := testutil.GetHTTPClient()
 	defer testutil.PutHTTPClient(httpClient)
 
-	for _, factory := range []struct {
-		Name        string
-		Constructor func(context.Context, *testing.T) Manager
-	}{
-		{
-			Name: "MDB",
-			Constructor: func(ctx context.Context, t *testing.T) Manager {
-				mngr, err := jasper.NewSynchronizedManager(false)
-				require.NoError(t, err)
-
-				client, err := makeTestMDBServiceAndClient(ctx, mngr)
-				require.NoError(t, err)
-				return client
-			},
-		},
-		{
-			Name: "RPC/TLS",
-			Constructor: func(ctx context.Context, t *testing.T) Manager {
-				mngr, err := jasper.NewSynchronizedManager(false)
-				require.NoError(t, err)
-
-				client, err := makeTLSRPCServiceAndClient(ctx, mngr)
-				require.NoError(t, err)
-				return client
-			},
-		},
-		{
-			Name: "RPC/Insecure",
-			Constructor: func(ctx context.Context, t *testing.T) Manager {
-				assert.NotPanics(t, func() {
-					newRPCClient(nil)
-				})
-
-				mngr, err := jasper.NewSynchronizedManager(false)
-				require.NoError(t, err)
-
-				client, err := makeInsecureRPCServiceAndClient(ctx, mngr)
-				require.NoError(t, err)
-				return client
-			},
-		},
-		{
-			Name: "REST",
-			Constructor: func(ctx context.Context, t *testing.T) Manager {
-				_, port, err := startRESTService(ctx, httpClient)
-				require.NoError(t, err)
-
-				client := &restClient{
-					prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
-					client: httpClient,
-				}
-				return client
-			},
-		},
-	} {
-		t.Run(factory.Name, func(t *testing.T) {
+	for managerName, makeManager := range remoteManagerTestCases(httpClient) {
+		t.Run(managerName, func(t *testing.T) {
 			for _, modify := range []struct {
 				Name    string
 				Options testutil.OptsModify
@@ -1076,6 +1064,18 @@ func TestManagerImplementations(t *testing.T) {
 							},
 						},
 						clientTestCase{
+							Name: "LoggingCacheCreateFailsWithInvalidOptions",
+							Case: func(ctx context.Context, t *testing.T, client Manager) {
+								lc := client.LoggingCache(ctx)
+								logger, err := lc.Create("new_logger", &options.Output{
+									SendErrorToOutput: true,
+									SendOutputToError: true,
+								})
+								assert.Error(t, err)
+								assert.Zero(t, logger)
+							},
+						},
+						clientTestCase{
 							Name: "LoggingCachePutNotImplemented",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								lc := client.LoggingCache(ctx)
@@ -1125,6 +1125,8 @@ func TestManagerImplementations(t *testing.T) {
 								logger1, err := lc.Create("logger1", &options.Output{})
 								require.NoError(t, err)
 								require.NotNil(t, lc.Get(logger1.ID))
+								// We have to sleep to force this logger to be
+								// pruned.
 								time.Sleep(2 * time.Second)
 
 								logger2, err := lc.Create("logger2", &options.Output{})
@@ -1169,28 +1171,74 @@ func TestManagerImplementations(t *testing.T) {
 						clientTestCase{
 							Name: "SendMessagesSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
+								if runtime.GOOS == "window" {
+									// TODO (EVG-13101): do not skip this test
+									t.Skip("Windows will fail because of the leaked file handle from not closing the sender in the remote service")
+								}
 								lc := client.LoggingCache(ctx)
-								logger1, err := lc.Create("logger1", &options.Output{})
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "logging_cache")
+								require.NoError(t, err)
+								defer func() {
+									assert.NoError(t, os.RemoveAll(tmpDir))
+								}()
+								tmpFile := filepath.Join(tmpDir, "send_messages")
+
+								fileOpts := &options.FileLoggerOptions{
+									Filename: tmpFile,
+									Base: options.BaseOptions{
+										Format: options.LogFormatPlain,
+									},
+								}
+								config := &options.LoggerConfig{}
+								require.NoError(t, config.Set(fileOpts))
+
+								logger, err := lc.Create("logger", &options.Output{
+									Loggers: []*options.LoggerConfig{config},
+								})
 								require.NoError(t, err)
 
 								payload := options.LoggingPayload{
-									LoggerID: logger1.ID,
+									LoggerID: logger.ID,
 									Data:     "new log message",
-									Priority: level.Warning,
+									Priority: level.Info,
 									Format:   options.LoggingPayloadFormatString,
 								}
 								assert.NoError(t, client.SendMessages(ctx, payload))
+
+								content, err := ioutil.ReadFile(tmpFile)
+								require.NoError(t, err)
+								assert.Equal(t, payload.Data, strings.TrimSpace(string(content)))
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingGetWithNonexistentHarnessFails",
+							Name: "CreateScriptingSucceeds",
+							Case: func(ctx context.Context, t *testing.T, client Manager) {
+								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+								require.NoError(t, err)
+								defer func() {
+									assert.NoError(t, os.RemoveAll(tmpDir))
+								}()
+								sh := createTestScriptingHarness(ctx, t, client, tmpDir)
+								assert.NotZero(t, sh)
+							},
+						},
+						clientTestCase{
+							Name: "CreateScriptingFailsWithInvalidOptions",
+							Case: func(ctx context.Context, t *testing.T, client Manager) {
+								sh, err := client.CreateScripting(ctx, &options.ScriptingGolang{})
+								assert.Error(t, err)
+								assert.Zero(t, sh)
+							},
+						},
+						clientTestCase{
+							Name: "GetScriptingWithNonexistentHarnessFails",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								_, err := client.GetScripting(ctx, "nonexistent")
 								assert.Error(t, err)
 							},
 						},
 						clientTestCase{
-							Name: "ScriptingGetWithExistingHarnessSucceeds",
+							Name: "GetScriptingWithExistingHarnessSucceeds",
 							Case: func(ctx context.Context, t *testing.T, client Manager) {
 								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 								require.NoError(t, err)
@@ -1204,173 +1252,11 @@ func TestManagerImplementations(t *testing.T) {
 								assert.Equal(t, expectedHarness.ID(), harness.ID())
 							},
 						},
-						clientTestCase{
-							Name: "ScriptingSetupSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-								assert.NoError(t, harness.Setup(ctx))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingCleanupSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-								assert.NoError(t, harness.Cleanup(ctx))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingRunSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								require.NoError(t, err)
-								tmpFile := filepath.Join(tmpDir, "fake_script.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
-								assert.NoError(t, harness.Run(ctx, []string{tmpFile}))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingRunErrors",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								tmpFile := filepath.Join(tmpDir, "fake_script.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainFail()), 0755))
-								assert.Error(t, harness.Run(ctx, []string{tmpFile}))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingRunScriptSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-								assert.NoError(t, harness.RunScript(ctx, testutil.GolangMainSuccess()))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingRunScriptErrors",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-								require.Error(t, harness.RunScript(ctx, testutil.GolangMainFail()))
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingBuildSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								tmpFile := filepath.Join(tmpDir, "fake_script.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
-								buildFile := filepath.Join(tmpDir, "fake_script")
-								_, err = harness.Build(ctx, tmpDir, []string{
-									"-o",
-									buildFile,
-									tmpFile,
-								})
-								require.NoError(t, err)
-								_, err = os.Stat(buildFile)
-								require.NoError(t, err)
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingBuildErrors",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								tmpFile := filepath.Join(tmpDir, "fake_script.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; func main() { "bad syntax" }`), 0755))
-								buildFile := filepath.Join(tmpDir, "fake_script")
-								_, err = harness.Build(ctx, tmpDir, []string{
-									"-o",
-									buildFile,
-									tmpFile,
-								})
-								require.Error(t, err)
-								_, err = os.Stat(buildFile)
-								assert.Error(t, err)
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingTestSucceeds",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								tmpFile := filepath.Join(tmpDir, "fake_script_test.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangTestSuccess()), 0755))
-								results, err := harness.Test(ctx, tmpDir, scripting.TestOptions{Name: "dummy"})
-								require.NoError(t, err)
-								require.Len(t, results, 1)
-								assert.Equal(t, scripting.TestOutcomeSuccess, results[0].Outcome)
-							},
-						},
-						clientTestCase{
-							Name: "ScriptingTestErrors",
-							Case: func(ctx context.Context, t *testing.T, client Manager) {
-								tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
-								require.NoError(t, err)
-								defer func() {
-									assert.NoError(t, os.RemoveAll(tmpDir))
-								}()
-								harness := createTestScriptingHarness(ctx, t, client, tmpDir)
-
-								tmpFile := filepath.Join(tmpDir, "fake_script_test.go")
-								require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangTestFail()), 0755))
-								results, err := harness.Test(ctx, tmpDir, scripting.TestOptions{Name: "dummy"})
-								assert.Error(t, err)
-								require.Len(t, results, 1)
-								assert.Equal(t, scripting.TestOutcomeFailure, results[0].Outcome)
-							},
-						},
 					) {
 						t.Run(test.Name, func(t *testing.T) {
 							tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
 							defer cancel()
-							client := factory.Constructor(tctx, t)
+							client := makeManager(tctx, t)
 							defer func() {
 								assert.NoError(t, client.CloseConnection())
 							}()
@@ -1381,14 +1267,6 @@ func TestManagerImplementations(t *testing.T) {
 			}
 		})
 	}
-}
-
-func createTestScriptingHarness(ctx context.Context, t *testing.T, client Manager, dir string) scripting.Harness {
-	opts := options.NewGolangScriptingEnvironment(filepath.Join(dir, "gopath"), runtime.GOROOT())
-	harness, err := client.CreateScripting(ctx, opts)
-	require.NoError(t, err)
-
-	return harness
 }
 
 func createProcs(ctx context.Context, opts *options.Create, manager Manager, num int) ([]jasper.Process, error) {

--- a/remote/logging_cache_test.go
+++ b/remote/logging_cache_test.go
@@ -1,0 +1,164 @@
+package remote
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mongodb/jasper/options"
+	"github.com/mongodb/jasper/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingCache(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	httpClient := testutil.GetHTTPClient()
+	defer testutil.PutHTTPClient(httpClient)
+
+	for managerName, makeManager := range remoteManagerTestCases(httpClient) {
+		t.Run(managerName, func(t *testing.T) {
+			for _, test := range []clientTestCase{
+				{
+					Name: "LoggingCacheCreateSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						logger, err := lc.Create("new_logger", &options.Output{})
+						require.NoError(t, err)
+						assert.Equal(t, "new_logger", logger.ID)
+
+						// should fail with existing logger
+						_, err = lc.Create("new_logger", &options.Output{})
+						assert.Error(t, err)
+					},
+				},
+				{
+					Name: "LoggingCacheCreateFailsWithInvalidOptions",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						logger, err := lc.Create("new_logger", &options.Output{
+							SendErrorToOutput: true,
+							SendOutputToError: true,
+						})
+						assert.Error(t, err)
+						assert.Zero(t, logger)
+					},
+				},
+				{
+					Name: "LoggingCachePutNotImplemented",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						assert.Error(t, lc.Put("logger", &options.CachedLogger{ID: "logger"}))
+					},
+				},
+				{
+					Name: "LoggingCacheGetSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						expectedLogger, err := lc.Create("new_logger", &options.Output{})
+						require.NoError(t, err)
+
+						logger := lc.Get(expectedLogger.ID)
+						require.NotNil(t, logger)
+						assert.Equal(t, expectedLogger.ID, logger.ID)
+					},
+				},
+				{
+					Name: "LoggingCacheGetFailsWithNonexistentLogger",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						logger := lc.Get("nonexistent")
+						require.Nil(t, logger)
+					},
+				},
+				{
+					Name: "LoggingCacheRemoveSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						logger1, err := lc.Create("logger1", &options.Output{})
+						require.NoError(t, err)
+						logger2, err := lc.Create("logger2", &options.Output{})
+						require.NoError(t, err)
+
+						require.NotNil(t, lc.Get(logger1.ID))
+						require.NotNil(t, lc.Get(logger2.ID))
+						lc.Remove(logger2.ID)
+						require.NotNil(t, lc.Get(logger1.ID))
+						require.Nil(t, lc.Get(logger2.ID))
+					},
+				},
+				{
+					Name: "LoggingCacheRemoveNoopsForNonexistentLogger",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						_, err := lc.Create("logger", &options.Output{})
+						require.NoError(t, err)
+						require.Equal(t, 1, lc.Len())
+						lc.Remove("nonexistent")
+						assert.Equal(t, 1, lc.Len())
+					},
+				},
+				{
+					Name: "LoggingCachePruneSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						logger1, err := lc.Create("logger1", &options.Output{})
+						require.NoError(t, err)
+						require.NotNil(t, lc.Get(logger1.ID))
+						// We have to sleep to force this logger to be
+						// pruned.
+						time.Sleep(2 * time.Second)
+
+						logger2, err := lc.Create("logger2", &options.Output{})
+						require.NoError(t, err)
+
+						lc.Prune(time.Now().Add(-time.Second))
+						require.Nil(t, lc.Get(logger1.ID))
+						require.NotNil(t, lc.Get(logger2.ID))
+					},
+				},
+				{
+					Name: "LoggingCachePruneNoopsWithoutLoggers",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+
+						assert.Zero(t, lc.Len())
+						lc.Prune(time.Now())
+						assert.Zero(t, lc.Len())
+					},
+				},
+				{
+					Name: "LoggingCacheLenIsNonzeroWithCachedLoggers",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						_, err := lc.Create("logger1", &options.Output{})
+						require.NoError(t, err)
+						_, err = lc.Create("logger2", &options.Output{})
+						require.NoError(t, err)
+
+						assert.Equal(t, 2, lc.Len())
+					},
+				},
+				{
+					Name: "LoggingCacheLenIsZeroWithoutLoggers",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						lc := client.LoggingCache(ctx)
+						assert.Zero(t, lc.Len())
+					},
+				},
+			} {
+				t.Run(test.Name, func(t *testing.T) {
+					tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
+					defer cancel()
+					client := makeManager(tctx, t)
+					defer func() {
+						assert.NoError(t, client.CloseConnection())
+					}()
+					test.Case(tctx, t, client)
+				})
+			}
+		})
+	}
+}

--- a/remote/mdb_client_logging_cache.go
+++ b/remote/mdb_client_logging_cache.go
@@ -20,7 +20,7 @@ type mdbLoggingCache struct {
 func (lc *mdbLoggingCache) Create(id string, opts *options.Output) (*options.CachedLogger, error) {
 	r := &loggingCacheCreateRequest{}
 	r.Params.ID = id
-	r.Params.Options = opts
+	r.Params.Options = *opts
 	req, err := shell.RequestToMessage(mongowire.OP_QUERY, r)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create request")
@@ -39,7 +39,7 @@ func (lc *mdbLoggingCache) Create(id string, opts *options.Output) (*options.Cac
 		return nil, errors.Wrap(err, "error in response")
 	}
 
-	return resp.CachedLogger, nil
+	return &resp.CachedLogger, nil
 }
 
 func (lc *mdbLoggingCache) Put(_ string, _ *options.CachedLogger) error {
@@ -65,7 +65,7 @@ func (lc *mdbLoggingCache) Get(id string) *options.CachedLogger {
 		return nil
 	}
 
-	return resp.CachedLogger
+	return &resp.CachedLogger
 }
 
 func (lc *mdbLoggingCache) Remove(id string) {

--- a/remote/mdb_io.go
+++ b/remote/mdb_io.go
@@ -252,8 +252,8 @@ type loggingCacheSizeResponse struct {
 
 type loggingCacheCreateRequest struct {
 	Params struct {
-		ID      string          `bson:"id"`
-		Options *options.Output `bson:"options"`
+		ID      string         `bson:"id"`
+		Options options.Output `bson:"options"`
 	} `bson:"logging_cache_create"`
 }
 
@@ -267,11 +267,11 @@ type loggingCacheRemoveRequest struct {
 
 type loggingCacheCreateAndGetResponse struct {
 	shell.ErrorResponse `bson:"error_response,inline"`
-	CachedLogger        *options.CachedLogger `bson:"cached_logger"`
+	CachedLogger        options.CachedLogger `bson:"cached_logger"`
 }
 
-func makeLoggingCacheCreateAndGetResponse(l *options.CachedLogger) *loggingCacheCreateAndGetResponse {
-	return &loggingCacheCreateAndGetResponse{
+func makeLoggingCacheCreateAndGetResponse(l options.CachedLogger) loggingCacheCreateAndGetResponse {
+	return loggingCacheCreateAndGetResponse{
 		ErrorResponse: shell.MakeSuccessResponse(),
 		CachedLogger:  l,
 	}

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -847,7 +847,7 @@ func (s *Service) loggingCacheCreate(rw http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
-			Message:    errors.Wrap(err, "problem creating loggers").Error(),
+			Message:    errors.Wrap(err, "problem creating logger").Error(),
 		})
 		return
 	}

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -1,0 +1,209 @@
+package remote
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mongodb/jasper/scripting"
+	"github.com/mongodb/jasper/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScripting(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	httpClient := testutil.GetHTTPClient()
+	defer testutil.PutHTTPClient(httpClient)
+
+	for managerName, makeManager := range remoteManagerTestCases(httpClient) {
+		t.Run(managerName, func(t *testing.T) {
+			for _, test := range []clientTestCase{
+				{
+					Name: "ScriptingSetupSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+						assert.NoError(t, harness.Setup(ctx))
+					},
+				},
+				{
+					Name: "ScriptingCleanupSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+						assert.NoError(t, harness.Cleanup(ctx))
+					},
+				},
+				{
+					Name: "ScriptingRunSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						require.NoError(t, err)
+						tmpFile := filepath.Join(tmpDir, "fake_script.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
+						assert.NoError(t, harness.Run(ctx, []string{tmpFile}))
+					},
+				},
+				{
+					Name: "ScriptingRunErrors",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						tmpFile := filepath.Join(tmpDir, "fake_script.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainFail()), 0755))
+						assert.Error(t, harness.Run(ctx, []string{tmpFile}))
+					},
+				},
+				{
+					Name: "ScriptingRunScriptSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+						assert.NoError(t, harness.RunScript(ctx, testutil.GolangMainSuccess()))
+					},
+				},
+				{
+					Name: "ScriptingRunScriptErrors",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+						require.Error(t, harness.RunScript(ctx, testutil.GolangMainFail()))
+					},
+				},
+				{
+					Name: "ScriptingBuildSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						tmpFile := filepath.Join(tmpDir, "fake_script.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
+						buildFile := filepath.Join(tmpDir, "fake_script")
+						_, err = harness.Build(ctx, tmpDir, []string{
+							"-o",
+							buildFile,
+							tmpFile,
+						})
+						require.NoError(t, err)
+						_, err = os.Stat(buildFile)
+						require.NoError(t, err)
+					},
+				},
+				{
+					Name: "ScriptingBuildErrors",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						tmpFile := filepath.Join(tmpDir, "fake_script.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; func main() { "bad syntax" }`), 0755))
+						buildFile := filepath.Join(tmpDir, "fake_script")
+						_, err = harness.Build(ctx, tmpDir, []string{
+							"-o",
+							buildFile,
+							tmpFile,
+						})
+						require.Error(t, err)
+						_, err = os.Stat(buildFile)
+						assert.Error(t, err)
+					},
+				},
+				{
+					Name: "ScriptingTestSucceeds",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						tmpFile := filepath.Join(tmpDir, "fake_script_test.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangTestSuccess()), 0755))
+						results, err := harness.Test(ctx, tmpDir, scripting.TestOptions{Name: "dummy"})
+						require.NoError(t, err)
+						require.Len(t, results, 1)
+						assert.Equal(t, scripting.TestOutcomeSuccess, results[0].Outcome)
+					},
+				},
+				{
+					Name: "ScriptingTestErrors",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+
+						tmpFile := filepath.Join(tmpDir, "fake_script_test.go")
+						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangTestFail()), 0755))
+						results, err := harness.Test(ctx, tmpDir, scripting.TestOptions{Name: "dummy"})
+						assert.Error(t, err)
+						require.Len(t, results, 1)
+						assert.Equal(t, scripting.TestOutcomeFailure, results[0].Outcome)
+					},
+				},
+			} {
+				t.Run(test.Name, func(t *testing.T) {
+					tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
+					defer cancel()
+					client := makeManager(tctx, t)
+					defer func() {
+						assert.NoError(t, client.CloseConnection())
+					}()
+					test.Case(tctx, t, client)
+				})
+
+			}
+		})
+	}
+}
+
+func createTestScriptingHarness(ctx context.Context, t *testing.T, client Manager, dir string) scripting.Harness {
+	opts := testutil.ValidGolangScriptingHarnessOptions(dir)
+	sh, err := client.CreateScripting(ctx, opts)
+	require.NoError(t, err)
+	return sh
+}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12920

* Add more tests for remote LoggingCache. Some of them can't be written until [EVG-13100](https://jira.mongodb.org/browse/EVG-13100) and [EVG-13101](https://jira.mongodb.org/browse/EVG-13101) are done.
* Split up the test cases for tidiness.