### PR TITLE
EVG-12926: add remote scripting tests

### DIFF
--- a/cli/scripting.go
+++ b/cli/scripting.go
@@ -19,7 +19,7 @@ const (
 	ScriptingCleanupCommand   = "cleanup"
 )
 
-// Scripting creates a cli.Command that supports running scripting environments
+// Scripting creates a cli.Command that supports managing scripting harnesses
 // in a remote interface.
 func Scripting() cli.Command {
 	return cli.Command{

--- a/mock/manager.go
+++ b/mock/manager.go
@@ -13,20 +13,20 @@ import (
 // Manager implements the Manager interface with exported fields to
 // configure and introspect the mock's behavior.
 type Manager struct {
-	FailCreate      bool
-	FailRegister    bool
-	FailList        bool
-	FailGroup       bool
-	FailGet         bool
-	FailClose       bool
-	NilLoggingCache bool
-	FailWriteFile   bool
-	Create          func(*options.Create) Process
-	CreateConfig    Process
-	ManagerID       string
-	Procs           []jasper.Process
-	ScriptingEnv    scripting.Harness
-	LoggingCacheVal jasper.LoggingCache
+	FailCreate       bool
+	FailRegister     bool
+	FailList         bool
+	FailGroup        bool
+	FailGet          bool
+	FailClose        bool
+	NilLoggingCache  bool
+	FailWriteFile    bool
+	Create           func(*options.Create) Process
+	CreateConfig     Process
+	ManagerID        string
+	Procs            []jasper.Process
+	ScriptingHarness scripting.Harness
+	LoggingCacheVal  jasper.LoggingCache
 
 	// WriteFile input
 	WriteFileOptions options.WriteFile

--- a/mock/remote.go
+++ b/mock/remote.go
@@ -137,20 +137,20 @@ func (c *RemoteManager) SendMessages(ctx context.Context, opts options.LoggingPa
 	return nil
 }
 
-// GetScripting returns a cached scripting environment. If FailGetScripting is
-// set, it returns an error.
+// GetScripting returns the ScriptingHarness field. If FailGetScripting is set,
+// it returns an error.
 func (c *RemoteManager) GetScripting(ctx context.Context, id string) (scripting.Harness, error) {
 	if c.FailGetScripting {
 		return nil, mockFail()
 	}
-	return c.ScriptingEnv, nil
+	return c.ScriptingHarness, nil
 }
 
-// CreateScripting constructs an attached scripting environment. If
-// FailCreateScripting is set, it returns an error.
+// CreateScripting returns the ScriptingHarness field. If FailCreateScripting is
+// set, it returns an error.
 func (c *RemoteManager) CreateScripting(ctx context.Context, opts options.ScriptingHarness) (scripting.Harness, error) {
 	if c.FailCreateScripting {
 		return nil, mockFail()
 	}
-	return c.ScriptingEnv, nil
+	return c.ScriptingHarness, nil
 }

--- a/options/scripting.go
+++ b/options/scripting.go
@@ -4,11 +4,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ScriptingHarness defines the interface for all types that
-// define a scripting environment.
+// ScriptingHarness defines the interface for all options that create a
+// scripting harness.
 type ScriptingHarness interface {
 	// ID should return a unique hash of the implementation of
-	// ScrptingEnvironment. This can be cached, and should change
+	// ScriptingHarness. This can be cached, and should change
 	// if any of the dependencies change.
 	ID() string
 	// Type returns the name of the environment, and is useful to
@@ -40,14 +40,14 @@ func AllScriptingHarnesses() map[string]func() ScriptingHarness {
 	}
 }
 
-// NewScriptingHarness provides a factory to generate concrete
-// implementations of the ScriptingEnvironment interface for use in
-// marshaling arbitrary values for a known environment.
+// NewScriptingHarness provides a factory to generate concrete implementations
+// of the ScriptingHarness interface for use in marshaling arbitrary values for
+// a known environment.
 func NewScriptingHarness(se string) (ScriptingHarness, error) {
 	for harnessName, makeHarness := range AllScriptingHarnesses() {
 		if harnessName == se {
 			return makeHarness(), nil
 		}
 	}
-	return nil, errors.Errorf("no supported scripting environment named '%s'", se)
+	return nil, errors.Errorf("no supported scripting harness named '%s'", se)
 }

--- a/options/scripting_golang.go
+++ b/options/scripting_golang.go
@@ -33,11 +33,11 @@ type ScriptingGolang struct {
 	cachedHash string
 }
 
-// NewGolangScriptingEnvironment generates a ScriptingEnvironment
+// NewGolangScriptingHarness generates a scripting.Harness
 // based on the arguments provided. Use this function for
 // simple cases when you do not need or want to set as many aspects of
 // the environment configuration.
-func NewGolangScriptingEnvironment(gopath, goroot string, packages ...string) ScriptingHarness {
+func NewGolangScriptingHarness(gopath, goroot string, packages ...string) ScriptingHarness {
 	return &ScriptingGolang{
 		Gopath:         gopath,
 		Goroot:         goroot,
@@ -46,16 +46,13 @@ func NewGolangScriptingEnvironment(gopath, goroot string, packages ...string) Sc
 	}
 }
 
-// Type is part of the options.ScriptingEnvironment interface and
-// returns the type of the interface.
+// Type returns the type of the interface.
 func (opts *ScriptingGolang) Type() string { return GolangScriptingType }
 
-// Interpreter is part of the options.ScriptingEnvironment interface
-// and returns the path to the interpreter or binary that runs scripts.
+// Interpreter returns the path to the binary that will run scripts.
 func (opts *ScriptingGolang) Interpreter() string { return filepath.Join(opts.Goroot, "bin", "go") }
 
-// Validate is part of the options.ScriptingEnvironment interface and
-// both ensures that the values are permissible and sets, where
+// Validate both ensures that the values are permissible and sets, where
 // possible, good defaults.
 func (opts *ScriptingGolang) Validate() error {
 	if opts.Goroot == "" {

--- a/options/scripting_python.go
+++ b/options/scripting_python.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// ScriptingPython defines the configuration of a python environment.
+// ScriptingPython defines the configuration of a Python environment.
 type ScriptingPython struct {
 	VirtualEnvPath string `bson:"virtual_env_path" json:"virtual_env_path" yaml:"virtual_env_path"`
 	// InterpreterBinary is the global python binary interpreter.
@@ -40,11 +40,11 @@ type ScriptingPython struct {
 	cachedHash          string
 }
 
-// NewPythonScriptingEnvironment generates a ScriptingEnvironment for python 3
+// NewPythonScriptingHarness generates a ScriptingHarness for python 3
 // based on the arguments provided. Use this function for
 // simple cases when you do not need or want to set as many aspects of
 // the environment configuration.
-func NewPythonScriptingEnvironment(path, reqtxt string, packages ...string) ScriptingHarness {
+func NewPythonScriptingHarness(path, reqtxt string, packages ...string) ScriptingHarness {
 	return &ScriptingPython{
 		CachedDuration:    time.Hour,
 		InterpreterBinary: "python3",
@@ -54,8 +54,7 @@ func NewPythonScriptingEnvironment(path, reqtxt string, packages ...string) Scri
 	}
 }
 
-// Type is part of the options.ScriptingEnvironment interface and
-// returns the type of the interface.
+// Type returns the type of the interface.
 func (opts *ScriptingPython) Type() string {
 	if opts.LegacyPython {
 		return Python2ScriptingType
@@ -63,14 +62,12 @@ func (opts *ScriptingPython) Type() string {
 	return Python3ScriptingType
 }
 
-// Interpreter is part of the options.ScriptingEnvironment interface
-// and returns the path to the binary that will run scripts.
+// Interpreter returns the path to the binary that will run scripts.
 func (opts *ScriptingPython) Interpreter() string {
 	return filepath.Join(opts.VirtualEnvPath, "bin", "python")
 }
 
-// Validate is part of the options.ScriptingEnvironment interface and
-// both ensures that the values are permissible and sets, where
+// Validate both ensures that the values are permissible and sets, where
 // possible, good defaults.
 func (opts *ScriptingPython) Validate() error {
 	if opts.CachedDuration == 0 {

--- a/options/scripting_roswell.go
+++ b/options/scripting_roswell.go
@@ -13,7 +13,7 @@ import (
 
 // ScriptingRoswell describes the options needed to configure Roswell,
 // a Common Lisp-based scripting and environment management tool, as
-// a jasper.ScriptingEnvironment. Roswell uses Quicklip and must be
+// a ScriptingHarness. Roswell uses Quicklip and must be
 // installed on your systems to use with jasper.
 type ScriptingRoswell struct {
 	Path           string            `bson:"path" json:"path" yaml:"path"`
@@ -27,11 +27,10 @@ type ScriptingRoswell struct {
 	cachedHash string
 }
 
-// NewRoswellScriptingEnvironment generates a ScriptingEnvironment
-// based on the arguments provided. Use this function for
-// simple cases when you do not need or want to set as many aspects of
-// the environment configuration.
-func NewRoswellScriptingEnvironment(path string, systems ...string) ScriptingHarness {
+// NewRoswellScriptingHarness generates a ScriptingHarness based on the
+// arguments provided. Use this function for simple cases when you do not need
+// or want to set as many aspects of the environment configuration.
+func NewRoswellScriptingHarness(path string, systems ...string) ScriptingHarness {
 	return &ScriptingRoswell{
 		Path:           path,
 		Systems:        systems,
@@ -40,16 +39,13 @@ func NewRoswellScriptingEnvironment(path string, systems ...string) ScriptingHar
 	}
 }
 
-// Type is part of the options.ScriptingEnvironment interface and
-// returns the type of the interface.
+// Type returns the type of the interface.
 func (opts *ScriptingRoswell) Type() string { return RoswellScriptingType }
 
-// Interpreter is part of the options.ScriptingEnvironment interface
-// and returns the path to the interpreter or binary that runs scripts.
+// Interpreter returns the path to the interpreter or binary that runs scripts.
 func (opts *ScriptingRoswell) Interpreter() string { return "ros" }
 
-// Validate is part of the options.ScriptingEnvironment interface and
-// both ensures that the values are permissible and sets, where
+// Validate both ensures that the values are permissible and sets, where
 // possible, good defaults.
 func (opts *ScriptingRoswell) Validate() error {
 	if opts.CachedDuration == 0 {

--- a/remote/internal/service.go
+++ b/remote/internal/service.go
@@ -533,7 +533,7 @@ func (s *jasperService) ScriptingHarnessCreate(ctx context.Context, opts *Script
 
 	sh, err := s.scripting.Create(s.manager, xopts)
 	if err != nil {
-		return nil, newGRPCError(codes.Internal, errors.Wrap(err, "generating scripting environment"))
+		return nil, newGRPCError(codes.Internal, errors.Wrap(err, "generating scripting harness"))
 	}
 
 	return &ScriptingHarnessID{Id: sh.ID()}, nil

--- a/remote/internal/service.go
+++ b/remote/internal/service.go
@@ -531,99 +531,85 @@ func (s *jasperService) ScriptingHarnessCreate(ctx context.Context, opts *Script
 		return nil, newGRPCError(codes.InvalidArgument, errors.Wrap(err, "invalid scripting options"))
 	}
 
-	se, err := s.scripting.Create(s.manager, xopts)
+	sh, err := s.scripting.Create(s.manager, xopts)
 	if err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrap(err, "generating scripting environment"))
 	}
 
-	return &ScriptingHarnessID{Id: se.ID()}, nil
+	return &ScriptingHarnessID{Id: sh.ID()}, nil
 }
 func (s *jasperService) ScriptingHarnessGet(ctx context.Context, id *ScriptingHarnessID) (*OperationOutcome, error) {
-	se, err := s.scripting.Get(id.Id)
+	sh, err := s.scripting.Get(id.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", id.Id))
 	}
 
 	return &OperationOutcome{
 		Success: true,
-		Text:    se.ID(),
+		Text:    sh.ID(),
 	}, nil
 }
 
 func (s *jasperService) ScriptingHarnessSetup(ctx context.Context, id *ScriptingHarnessID) (*OperationOutcome, error) {
-	se, err := s.scripting.Get(id.Id)
+	sh, err := s.scripting.Get(id.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", id.Id))
 	}
 
-	if err = se.Setup(ctx); err != nil {
+	if err = sh.Setup(ctx); err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrapf(err, "setting up scripting harness"))
 	}
 
-	return &OperationOutcome{
-		Success: true,
-		Text:    se.ID(),
-	}, nil
+	return &OperationOutcome{Success: true}, nil
 }
 
 func (s *jasperService) ScriptingHarnessCleanup(ctx context.Context, id *ScriptingHarnessID) (*OperationOutcome, error) {
-	se, err := s.scripting.Get(id.Id)
+	sh, err := s.scripting.Get(id.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", id.Id))
 	}
 
-	if err = se.Cleanup(ctx); err != nil {
+	if err = sh.Cleanup(ctx); err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrapf(err, "cleaning up scripting harness"))
 	}
 
-	return &OperationOutcome{
-		Success:  true,
-		Text:     se.ID(),
-		ExitCode: 0,
-	}, nil
+	return &OperationOutcome{Success: true}, nil
 }
 
 func (s *jasperService) ScriptingHarnessRun(ctx context.Context, args *ScriptingHarnessRunArgs) (*OperationOutcome, error) {
-	se, err := s.scripting.Get(args.Id)
+	sh, err := s.scripting.Get(args.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", args.Id))
 	}
 
-	err = se.Run(ctx, args.Args)
-	if err != nil {
+	if err = sh.Run(ctx, args.Args); err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrapf(err, "running scripting command"))
 	}
 
-	return &OperationOutcome{
-		Success: true,
-		Text:    se.ID(),
-	}, nil
+	return &OperationOutcome{Success: true}, nil
 }
 
 func (s *jasperService) ScriptingHarnessRunScript(ctx context.Context, args *ScriptingHarnessRunScriptArgs) (*OperationOutcome, error) {
-	se, err := s.scripting.Get(args.Id)
+	sh, err := s.scripting.Get(args.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", args.Id))
 	}
 
-	err = se.RunScript(ctx, args.Script)
+	err = sh.RunScript(ctx, args.Script)
 	if err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrapf(err, "running script"))
 	}
 
-	return &OperationOutcome{
-		Success: true,
-		Text:    se.ID(),
-	}, nil
+	return &OperationOutcome{Success: true}, nil
 }
 
 func (s *jasperService) ScriptingHarnessBuild(ctx context.Context, args *ScriptingHarnessBuildArgs) (*ScriptingHarnessBuildResponse, error) {
-	se, err := s.scripting.Get(args.Id)
+	sh, err := s.scripting.Get(args.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", args.Id))
 	}
 
-	path, err := se.Build(ctx, args.Directory, args.Args)
+	path, err := sh.Build(ctx, args.Directory, args.Args)
 	if err != nil {
 		return nil, newGRPCError(codes.Internal, errors.Wrapf(err, "running build"))
 	}
@@ -632,12 +618,11 @@ func (s *jasperService) ScriptingHarnessBuild(ctx context.Context, args *Scripti
 		Path: path,
 		Outcome: &OperationOutcome{
 			Success: true,
-			Text:    se.ID(),
 		}}, nil
 }
 
 func (s *jasperService) ScriptingHarnessTest(ctx context.Context, args *ScriptingHarnessTestArgs) (*ScriptingHarnessTestResponse, error) {
-	se, err := s.scripting.Get(args.Id)
+	sh, err := s.scripting.Get(args.Id)
 	if err != nil {
 		return nil, newGRPCError(codes.NotFound, errors.Wrapf(err, "getting scripting harness with id '%s'", args.Id))
 	}
@@ -648,7 +633,7 @@ func (s *jasperService) ScriptingHarnessTest(ctx context.Context, args *Scriptin
 	}
 
 	var testErr error
-	res, err := se.Test(ctx, args.Directory, exportedArgs...)
+	res, err := sh.Test(ctx, args.Directory, exportedArgs...)
 	if err != nil {
 		testErr = err
 	}

--- a/remote/mdb_service_scripting.go
+++ b/remote/mdb_service_scripting.go
@@ -129,7 +129,7 @@ func (s *mdbService) scriptingTest(ctx context.Context, w io.Writer, msg mongowi
 
 func (s *mdbService) serviceScriptingRequest(ctx context.Context, w io.Writer, msg mongowire.Message, req interface{}, command string) bool {
 	if s.harnessCache == nil {
-		shell.WriteErrorResponse(ctx, w, mongowire.OP_REPLY, errors.New("scripting environment is not supported"), command)
+		shell.WriteErrorResponse(ctx, w, mongowire.OP_REPLY, errors.New("scripting harness is not supported"), command)
 		return false
 	}
 

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -943,7 +943,7 @@ func (s *Service) scriptingCreate(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	se, err := s.harnesses.Create(s.manager, seopt)
+	sh, err := s.harnesses.Create(s.manager, seopt)
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -955,7 +955,7 @@ func (s *Service) scriptingCreate(rw http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(rw, struct {
 		ID string `json:"id"`
 	}{
-		ID: se.ID(),
+		ID: sh.ID(),
 	})
 }
 
@@ -975,7 +975,7 @@ func (s *Service) scriptingCheck(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingSetup(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -984,7 +984,7 @@ func (s *Service) scriptingSetup(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := se.Setup(ctx); err != nil {
+	if err := sh.Setup(ctx); err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    err.Error(),
@@ -998,7 +998,7 @@ func (s *Service) scriptingSetup(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingRun(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -1018,7 +1018,7 @@ func (s *Service) scriptingRun(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := se.Run(ctx, args.Args); err != nil {
+	if err := sh.Run(ctx, args.Args); err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),
@@ -1032,7 +1032,7 @@ func (s *Service) scriptingRun(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingRunScript(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -1050,7 +1050,7 @@ func (s *Service) scriptingRunScript(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := se.RunScript(ctx, string(data)); err != nil {
+	if err := sh.RunScript(ctx, string(data)); err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    err.Error(),
@@ -1064,7 +1064,7 @@ func (s *Service) scriptingRunScript(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingBuild(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -1084,7 +1084,7 @@ func (s *Service) scriptingBuild(rw http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	path, err := se.Build(ctx, args.Directory, args.Args)
+	path, err := sh.Build(ctx, args.Directory, args.Args)
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -1103,7 +1103,7 @@ func (s *Service) scriptingBuild(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingTest(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -1124,7 +1124,7 @@ func (s *Service) scriptingTest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var errOut string
-	res, err := se.Test(ctx, args.Directory, args.Options...)
+	res, err := sh.Test(ctx, args.Directory, args.Options...)
 	if err != nil {
 		errOut = err.Error()
 	}
@@ -1141,7 +1141,7 @@ func (s *Service) scriptingTest(rw http.ResponseWriter, r *http.Request) {
 func (s *Service) scriptingCleanup(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	se, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
+	sh, err := s.harnesses.Get(gimlet.GetVars(r)["id"])
 	if err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
@@ -1150,7 +1150,7 @@ func (s *Service) scriptingCleanup(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := se.Cleanup(ctx); err != nil {
+	if err := sh.Cleanup(ctx); err != nil {
 		writeError(rw, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    err.Error(),

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -14,11 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type scriptingTestCase struct {
-	Name string
-	Case func(ctx context.Context, t *testing.T, client Manager, tmpDir string)
-}
-
 func TestScripting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -40,7 +40,7 @@ func TestScripting(t *testing.T) {
 					Case: func(ctx context.Context, t *testing.T, client Manager, tmpDir string) {
 						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 						require.NoError(t, os.Chmod(tmpDir, 0111))
-						require.Error(t, harness.Setup(ctx))
+						assert.Error(t, harness.Setup(ctx))
 						require.NoError(t, os.Chmod(tmpDir, 0777))
 					},
 				},
@@ -57,7 +57,7 @@ func TestScripting(t *testing.T) {
 						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 						require.NoError(t, harness.Setup(ctx))
 						require.NoError(t, os.Chmod(tmpDir, 0111))
-						require.Error(t, harness.Cleanup(ctx))
+						assert.Error(t, harness.Cleanup(ctx))
 						require.NoError(t, os.Chmod(tmpDir, 0777))
 					},
 				},

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/k0kubun/pp"
 	"github.com/mongodb/jasper/scripting"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestScripting(t *testing.T) {
 		t.Run(managerName, func(t *testing.T) {
 			for _, test := range []clientTestCase{
 				{
-					Name: "ScriptingSetupSucceeds",
+					Name: "SetupSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -36,7 +37,22 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingCleanupSucceeds",
+					Name: "SetupFails",
+					Case: func(ctx context.Context, t *testing.T, client Manager) {
+						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
+						require.NoError(t, err)
+						defer func() {
+							assert.NoError(t, os.RemoveAll(tmpDir))
+						}()
+						pp.Println(tmpDir)
+						harness := createTestScriptingHarness(ctx, t, client, tmpDir)
+						require.NoError(t, os.Chmod(tmpDir, 0111))
+						assert.Error(t, harness.Setup(ctx))
+						require.NoError(t, os.Chmod(tmpDir, 0777))
+					},
+				},
+				{
+					Name: "CleanupSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -48,7 +64,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingRunSucceeds",
+					Name: "RunSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -64,7 +80,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingRunErrors",
+					Name: "RunFails",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -79,7 +95,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingRunScriptSucceeds",
+					Name: "RunScriptSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -91,7 +107,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingRunScriptErrors",
+					Name: "RunScriptFails",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -104,7 +120,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingBuildSucceeds",
+					Name: "BuildSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -127,7 +143,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingBuildErrors",
+					Name: "BuildFails",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -150,7 +166,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingTestSucceeds",
+					Name: "TestSucceeds",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)
@@ -168,7 +184,7 @@ func TestScripting(t *testing.T) {
 					},
 				},
 				{
-					Name: "ScriptingTestErrors",
+					Name: "TestFails",
 					Case: func(ctx context.Context, t *testing.T, client Manager) {
 						tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 						require.NoError(t, err)

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -50,6 +50,12 @@ func TestScripting(t *testing.T) {
 					assert.NoError(t, harness.Cleanup(ctx))
 				},
 				"CleanupFails": func(ctx context.Context, t *testing.T, client Manager, tmpDir string) {
+					if os.Geteuid() == 0 {
+						t.Skip("running as root will prevent setup from failing")
+					}
+					if runtime.GOOS == "windows" {
+						t.Skip("chmod does not work on Windows")
+					}
 					harness := createTestScriptingHarness(ctx, t, client, tmpDir)
 					require.NoError(t, harness.Setup(ctx))
 					require.NoError(t, os.Chmod(tmpDir, 0555))

--- a/scripting/scripting.go
+++ b/scripting/scripting.go
@@ -8,10 +8,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Harness provides an interface to execute code in a
-// scripting environment such as a python virtual
-// environment. Implementations should be make it possible to execute
-// either locally or on remote systems.
+// Harness provides an interface to execute code in a scripting environment such
+// as a Python virtual environment. Implementations should be make it possible
+// to execute either locally or on remote systems.
 type Harness interface {
 	// ID returns a unique ID for the underlying environment. This
 	// should match the ID produced by the underlying options

--- a/scripting/scripting_golang.go
+++ b/scripting/scripting_golang.go
@@ -45,11 +45,9 @@ func (e *golangEnvironment) Setup(ctx context.Context) error {
 		}
 	}
 
-	cmd.PostHook(func(res error) error {
-		if res == nil {
-			e.isConfigured = true
-		}
-		return nil
+	cmd.PostHook(func(err error) error {
+		e.isConfigured = err == nil
+		return err
 	})
 
 	return cmd.SetOutputOptions(e.opts.Output).Run(ctx)

--- a/scripting/scripting_golang.go
+++ b/scripting/scripting_golang.go
@@ -45,12 +45,11 @@ func (e *golangEnvironment) Setup(ctx context.Context) error {
 		}
 	}
 
-	cmd.PostHook(func(err error) error {
-		e.isConfigured = err == nil
-		return err
-	})
+	if err := cmd.SetOutputOptions(e.opts.Output).Run(ctx); err != nil {
+		return errors.Wrap(err, "setup")
+	}
 
-	return cmd.SetOutputOptions(e.opts.Output).Run(ctx)
+	return nil
 }
 
 func (e *golangEnvironment) Run(ctx context.Context, args []string) error {

--- a/scripting/scripting_golang.go
+++ b/scripting/scripting_golang.go
@@ -48,6 +48,7 @@ func (e *golangEnvironment) Setup(ctx context.Context) error {
 	if err := cmd.SetOutputOptions(e.opts.Output).Run(ctx); err != nil {
 		return errors.Wrap(err, "setup")
 	}
+	e.isConfigured = true
 
 	return nil
 }

--- a/scripting/scripting_python.go
+++ b/scripting/scripting_python.go
@@ -54,14 +54,13 @@ func (e *pythonEnvironment) Setup(ctx context.Context) error {
 		cmd.Add(args)
 	}
 
-	cmd.PostHook(func(res error) error {
-		if res == nil {
-			e.isConfigured = true
-		}
-		return nil
-	})
+	if err := cmd.SetOutputOptions(e.opts.Output).Run(ctx); err != nil {
+		return errors.Wrap(err, "setup")
+	}
 
-	return cmd.SetOutputOptions(e.opts.Output).Run(ctx)
+	e.isConfigured = true
+
+	return nil
 }
 
 func (e *pythonEnvironment) venvMod() string {

--- a/scripting/scripting_test.go
+++ b/scripting/scripting_test.go
@@ -25,7 +25,7 @@ func isInPath(binary string) bool {
 	return err == nil
 }
 
-func makeScriptingEnv(ctx context.Context, t *testing.T, mgr jasper.Manager, opts options.ScriptingHarness) Harness {
+func makeScriptingHarness(ctx context.Context, t *testing.T, mgr jasper.Manager, opts options.ScriptingHarness) Harness {
 	se, err := NewHarness(mgr, opts)
 	require.NoError(t, err)
 	return se
@@ -66,7 +66,7 @@ func TestScriptingHarness(t *testing.T) {
 		Case func(*testing.T, options.ScriptingHarness)
 	}
 
-	for _, env := range []struct {
+	for _, harnessType := range []struct {
 		Name           string
 		Supported      bool
 		DefaultOptions options.ScriptingHarness
@@ -91,21 +91,21 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "HelloWorldScript",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.RunScript(ctx, `(defun main () (print "hello world"))`))
 					},
 				},
 				{
 					Name: "RunHelloWorld",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.Run(ctx, []string{`(print "hello world")`}))
 					},
 				},
 				{
 					Name: "ScriptExitError",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.Error(t, sh.RunScript(ctx, `(sb-ext:exit :code 42)`))
 					},
 				},
@@ -132,21 +132,21 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "HelloWorldScript",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.RunScript(ctx, `print("hello world")`))
 					},
 				},
 				{
 					Name: "RunHelloWorld",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.Run(ctx, []string{"-c", `print("hello world")`}))
 					},
 				},
 				{
 					Name: "ScriptExitError",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.Error(t, sh.RunScript(ctx, `exit(42)`))
 					},
 				},
@@ -174,21 +174,21 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "HelloWorldScript",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.RunScript(ctx, `print("hello world")`))
 					},
 				},
 				{
 					Name: "RunHelloWorld",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.Run(ctx, []string{"-c", `print("hello world")`}))
 					},
 				},
 				{
 					Name: "ScriptExitError",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.Error(t, sh.RunScript(ctx, `exit(42)`))
 					},
 				},
@@ -216,21 +216,21 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "HelloWorldScript",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.NoError(t, sh.RunScript(ctx, testutil.GolangMainSuccess()))
 					},
 				},
 				{
 					Name: "ScriptExitError",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						require.Error(t, sh.RunScript(ctx, testutil.GolangMainFail()))
 					},
 				},
 				{
 					Name: "Dependencies",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						tmpFile := filepath.Join(tmpdir, "fake_script.go")
 						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(`package main; import ("fmt"; "github.com/pkg/errors"); func main() { fmt.Println(errors.New("error")) }`), 0755))
 						defer func() {
@@ -243,7 +243,7 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "RunFile",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						tmpFile := filepath.Join(tmpdir, "fake_script.go")
 						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
 						defer func() {
@@ -256,7 +256,7 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "Build",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						sh := makeScriptingEnv(ctx, t, manager, opts)
+						sh := makeScriptingHarness(ctx, t, manager, opts)
 						tmpFile := filepath.Join(tmpdir, "fake_script.go")
 						require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
 						defer func() {
@@ -274,21 +274,21 @@ func TestScriptingHarness(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(env.Name, func(t *testing.T) {
-			if !env.Supported {
-				t.Skipf("%s is not supported in the current system", env.Name)
+		t.Run(harnessType.Name, func(t *testing.T) {
+			if !harnessType.Supported {
+				t.Skipf("%s is not supported in the current system", harnessType.Name)
 				return
 			}
-			require.NoError(t, env.DefaultOptions.Validate())
+			require.NoError(t, harnessType.DefaultOptions.Validate())
 			t.Run("Config", func(t *testing.T) {
 				start := time.Now()
-				sh := makeScriptingEnv(ctx, t, manager, env.DefaultOptions)
+				sh := makeScriptingHarness(ctx, t, manager, harnessType.DefaultOptions)
 				require.NoError(t, sh.Setup(ctx))
 				dur := time.Since(start)
 				require.NotNil(t, sh)
 
 				t.Run("ID", func(t *testing.T) {
-					require.Equal(t, env.DefaultOptions.ID(), sh.ID())
+					require.Equal(t, harnessType.DefaultOptions.ID(), sh.ID())
 					assert.Len(t, sh.ID(), 40)
 				})
 				t.Run("Caching", func(t *testing.T) {
@@ -301,19 +301,19 @@ func TestScriptingHarness(t *testing.T) {
 						time.Since(start), dur)
 				})
 			})
-			for _, test := range env.Tests {
+			for _, test := range harnessType.Tests {
 				t.Run(test.Name, func(t *testing.T) {
-					test.Case(t, env.DefaultOptions)
+					test.Case(t, harnessType.DefaultOptions)
 				})
 			}
 			t.Run("Testing", func(t *testing.T) {
-				sh := makeScriptingEnv(ctx, t, manager, env.DefaultOptions)
+				sh := makeScriptingHarness(ctx, t, manager, harnessType.DefaultOptions)
 				res, err := sh.Test(ctx, tmpdir)
 				require.NoError(t, err)
 				require.Len(t, res, 0)
 			})
 			t.Run("Cleanup", func(t *testing.T) {
-				sh := makeScriptingEnv(ctx, t, manager, env.DefaultOptions)
+				sh := makeScriptingHarness(ctx, t, manager, harnessType.DefaultOptions)
 				require.NoError(t, sh.Cleanup(ctx))
 			})
 

--- a/scripting/scripting_test.go
+++ b/scripting/scripting_test.go
@@ -154,9 +154,10 @@ func TestScriptingHarness(t *testing.T) {
 			},
 		},
 		// TODO (EVG-13209): fix tests for Windows.
+		// TODO (EVG-13212): fix tests for Arch (race detector).
 		{
 			Name:      "Python2",
-			Supported: isInPath("python2") && runtime.GOOS != "windows",
+			Supported: isInPath("python2") && runtime.GOOS != "windows" && !strings.Contains(os.Getenv("EVR_TASK_ID"), "race"),
 			DefaultOptions: &options.ScriptingPython{
 				VirtualEnvPath:    filepath.Join(tmpdir, "python2"),
 				LegacyPython:      true,
@@ -168,7 +169,7 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "Options",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						require.True(t, strings.HasSuffix(opts.Interpreter(), "python"))
+						require.True(t, strings.HasSuffix(opts.Interpreter(), "python2"))
 						require.NotZero(t, opts.ID())
 					},
 				},

--- a/scripting/scripting_test.go
+++ b/scripting/scripting_test.go
@@ -112,9 +112,10 @@ func TestScriptingHarness(t *testing.T) {
 			},
 		},
 		// TODO (EVG-13209): fix tests for Windows.
+		// TODO (EVG-13210): fix tests for Ubuntu.
 		{
 			Name:      "Python3",
-			Supported: isInPath("python3"),
+			Supported: isInPath("python3") && !strings.Contains(os.Getenv("EVR_TASK_ID"), "ubuntu"),
 			DefaultOptions: &options.ScriptingPython{
 				VirtualEnvPath:    filepath.Join(tmpdir, "python3"),
 				LegacyPython:      false,

--- a/scripting/scripting_test.go
+++ b/scripting/scripting_test.go
@@ -169,7 +169,7 @@ func TestScriptingHarness(t *testing.T) {
 				{
 					Name: "Options",
 					Case: func(t *testing.T, opts options.ScriptingHarness) {
-						require.True(t, strings.HasSuffix(opts.Interpreter(), "python2"))
+						require.True(t, strings.HasSuffix(opts.Interpreter(), "python"))
 						require.NotZero(t, opts.ID())
 					},
 				},

--- a/testutil/options.go
+++ b/testutil/options.go
@@ -63,7 +63,7 @@ func ValidMongoDBDownloadOptions() options.MongoDBDownload {
 }
 
 // ValidPythonScriptingHarnessOptions returns valid options for creating a
-// Python scripting environment.
+// Python scripting harness.
 func ValidPythonScriptingHarnessOptions(dir string) options.ScriptingHarness {
 	return &options.ScriptingPython{
 		VirtualEnvPath: dir,
@@ -72,7 +72,7 @@ func ValidPythonScriptingHarnessOptions(dir string) options.ScriptingHarness {
 }
 
 // ValidGolangScriptingHarnessOptions returns valid options for creating a
-// Golang scripting environment.
+// Golang scripting harness.
 func ValidGolangScriptingHarnessOptions(dir string) options.ScriptingHarness {
 	return &options.ScriptingGolang{
 		Gopath: filepath.Join(dir, "gopath"),


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12926

* Add more test coverage for remote scripting harness interface.
* Fix bug where `Setup()` suppresses errors for Golang and Python scripting environments.
* Clean up dead code in RPC scripting service.
* Minor renaming across tests to use "sh" variable name instead of "se".