### PR TITLE
EVG-13211: fix MacOS flaky tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -182,7 +182,7 @@ func TestMongod(t *testing.T) {
 						}
 					}
 
-					// Check that the processes have all noted an unsuccessful run
+					// Check that the processes have all noted a unsuccessful run
 					for _, proc := range procs {
 						if test.expectError {
 							assert.False(t, proc.Info(ctx).Successful)

--- a/integration_test.go
+++ b/integration_test.go
@@ -132,14 +132,14 @@ func TestMongod(t *testing.T) {
 					id:          "With10MongodsAndSigkill",
 					numProcs:    10,
 					signal:      syscall.SIGKILL,
-					sleep:       2000 * time.Millisecond,
+					sleep:       2 * time.Second,
 					expectError: true,
 				},
 				{
 					id:          "With30MongodsAndSigkill",
 					numProcs:    30,
 					signal:      syscall.SIGKILL,
-					sleep:       3000 * time.Millisecond,
+					sleep:       3 * time.Second,
 					expectError: true,
 				},
 			} {

--- a/options/create_test.go
+++ b/options/create_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -127,11 +127,10 @@ func TestCreate(t *testing.T) {
 			assert.NoError(t, opts.Validate())
 		},
 		"WorkingDirectoryShouldErrorForFiles": func(t *testing.T, opts *Create) {
-			gobin, err := exec.LookPath("go")
-			assert.NoError(t, err)
-			assert.NotZero(t, gobin)
+			_, path, _, ok := runtime.Caller(0)
+			require.True(t, ok)
 
-			opts.WorkingDirectory = gobin
+			opts.WorkingDirectory = path
 			assert.Error(t, opts.Validate())
 		},
 		"MustSpecifyValidOutput": func(t *testing.T, opts *Create) {

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -81,17 +81,17 @@ func newBlockingProcess(ctx context.Context, opts *options.Create) (Process, err
 	return p, nil
 }
 
-func (p *blockingProcess) setInfo(info ProcessInfo) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.info = info
-}
-
 func (p *blockingProcess) hasCompleteInfo() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
 	return p.info.Complete
+}
+
+func (p *blockingProcess) setInfo(info ProcessInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.info = info
 }
 
 func (p *blockingProcess) getInfo() ProcessInfo {
@@ -156,9 +156,17 @@ func (p *blockingProcess) reactor(ctx context.Context, deadline time.Time, exec 
 
 			p.mu.RLock()
 			p.triggers.Run(info)
+			info.Options = p.info.Options
 			p.mu.RUnlock()
 			p.setErr(err)
-			p.setInfo(info)
+			p.mu.Lock()
+			// Set the options now because our view of the process info may be
+			// stale. The options could have been modified in between the above
+			// info assignment and setting the information here (e.g. by calling
+			// ResetTags()).
+			info.Options = p.info.Options
+			p.info = info
+			p.mu.Unlock()
 			return
 		case <-ctx.Done():
 			// note, the process might take a moment to
@@ -172,7 +180,15 @@ func (p *blockingProcess) reactor(ctx context.Context, deadline time.Time, exec 
 			p.mu.RLock()
 			p.triggers.Run(info)
 			p.mu.RUnlock()
-			p.setInfo(info)
+			p.setErr(ctx.Err())
+			p.mu.Lock()
+			// Set the options now because our view of the process info may be
+			// stale. The options could have been modified in between the above
+			// info assignment and setting the information here (e.g. by calling
+			// ResetTags()).
+			info.Options = p.info.Options
+			p.info = info
+			p.mu.Unlock()
 
 			return
 		case op := <-p.ops:

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -189,10 +189,10 @@ func (p *blockingProcess) Info(ctx context.Context) ProcessInfo {
 		return p.getInfo()
 	}
 
-	out := make(chan ProcessInfo)
+	out := make(chan ProcessInfo, 1)
 	operation := func(exec executor.Executor) {
+		defer close(out)
 		out <- p.getInfo()
-		close(out)
 	}
 
 	select {
@@ -217,7 +217,7 @@ func (p *blockingProcess) Running(ctx context.Context) bool {
 		return false
 	}
 
-	out := make(chan bool)
+	out := make(chan bool, 1)
 	operation := func(exec executor.Executor) {
 		defer close(out)
 
@@ -260,7 +260,7 @@ func (p *blockingProcess) Signal(ctx context.Context, sig syscall.Signal) error 
 		return errors.New("cannot signal a process that has terminated")
 	}
 
-	out := make(chan error)
+	out := make(chan error, 1)
 	operation := func(exec executor.Executor) {
 		defer close(out)
 
@@ -342,7 +342,7 @@ func (p *blockingProcess) Wait(ctx context.Context) (int, error) {
 		return p.getInfo().ExitCode, p.getErr()
 	}
 
-	out := make(chan error)
+	out := make(chan error, 1)
 	waiter := func(exec executor.Executor) {
 		if !p.hasCompleteInfo() {
 			return

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -76,7 +76,7 @@ func (t *linuxProcessTracker) Add(info ProcessInfo) error {
 
 	proc := cgroups.Process{Subsystem: defaultSubsystem, Pid: info.PID}
 	if err := t.cgroup.Add(proc); err != nil {
-		return errors.Wrap(err, "failed to add process with pid '%d' to cgroup", info.PID)
+		return errors.Wrapf(err, "failed to add process with pid '%d' to cgroup", info.PID)
 	}
 	return nil
 }

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -76,7 +76,7 @@ func (t *linuxProcessTracker) Add(info ProcessInfo) error {
 
 	proc := cgroups.Process{Subsystem: defaultSubsystem, Pid: info.PID}
 	if err := t.cgroup.Add(proc); err != nil {
-		return errors.Wrap(err, "failed to add process with pid '%d' to cgroup")
+		return errors.Wrap(err, "failed to add process with pid '%d' to cgroup", info.PID)
 	}
 	return nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13211

* Some of the MacOS hosts don't have `go` in their `PATH`, so I changed the test so it does not rely on its existence.
* **Make the functions in the operations-processing channel in blocking process implementation non-blocking.** When we call process method (e.g. `Info()`), the blocking process implementation enqueues an operation in the process's operations channel, which is responsible for running the operation. However, if the process method does not receive the result from the operation (e.g. the context cancels so the process method returns early), it can cause the goroutine to hang, which causes a slow resource leak due to process methods returning without receiving from the operation they created up.
* **Fix an issue where the blocking process info might be stale and may overwrite new information when handling process completion.** When a process ends, blocking process takes the existing information, populates some fields,  releases the lock, then locks and sets the info indicating the process is complete. We have to release the lock in order to ensure that the process is not considered "complete" until all of its post-completion triggers have run. However, the creation options `ProcessInfo.Options` might have been modified by `ResetTags()` in the time between when the lock was released and the final process information was set.