### PR TITLE
EVG-13309: add support for precondition checks before starting service

### DIFF
--- a/cli/service.go
+++ b/cli/service.go
@@ -1,20 +1,16 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/evergreen-ci/service"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
@@ -47,8 +43,9 @@ const (
 	quietFlagName            = "quiet"
 	userFlagName             = "user"
 	passwordFlagName         = "password"
-	forceInteractiveFlagName = "interactive"
+	interactiveFlagName      = "interactive"
 	envFlagName              = "env"
+	preconditionCmdsFlagName = "precondition"
 
 	logNameFlagName  = "log_name"
 	defaultLogName   = "jasper"
@@ -86,25 +83,6 @@ func Service() cli.Command {
 	}
 }
 
-// handleDaemonSignals shuts down the daemon by cancelling the context, either
-// when the context is done, it receives a terminate signal, or when it
-// receives a signal to exit the daemon.
-func handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, exit chan struct{}) {
-	defer recovery.LogStackTraceAndContinue("graceful shutdown")
-	defer cancel()
-	sig := make(chan os.Signal, 2)
-	signal.Notify(sig, syscall.SIGTERM, os.Interrupt)
-
-	select {
-	case <-sig:
-		grip.Debug("received signal")
-	case <-ctx.Done():
-		grip.Debug("context canceled")
-	case <-exit:
-		grip.Debug("received daemon exit signal")
-	}
-}
-
 func serviceFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
@@ -120,13 +98,17 @@ func serviceFlags() []cli.Flag {
 			Usage:  "The password for the user running the service.",
 			EnvVar: "JASPER_USER_PASSWORD",
 		},
+		cli.BoolFlag{
+			Name:  interactiveFlagName,
+			Usage: "Force the service to run in an interactive session.",
+		},
 		cli.StringSliceFlag{
 			Name:  envFlagName,
 			Usage: "The service environment variables (format: key=value).",
 		},
-		cli.BoolFlag{
-			Name:  forceInteractiveFlagName,
-			Usage: "Force the service to run in an interactive session.",
+		cli.StringSliceFlag{
+			Name:  preconditionCmdsFlagName,
+			Usage: "Execute command(s) that must be run and must succeed before the Jasper service can start.",
 		},
 		cli.StringFlag{
 			Name:  logNameFlagName,
@@ -243,15 +225,6 @@ func makeLogger(c *cli.Context) *options.LoggerConfig {
 	return logger
 }
 
-// setupLogger creates a logger and sets it as the global logging back end.
-func setupLogger(opts *options.LoggerConfig) error {
-	sender, err := opts.Resolve()
-	if err != nil {
-		return errors.Wrap(err, "could not configure logging")
-	}
-	return errors.Wrap(grip.SetSender(sender), "could not set grip logger")
-}
-
 // buildRunCommand builds the command arguments to run the Jasper service with
 // the flags set in the cli.Context.
 func buildRunCommand(c *cli.Context, serviceType string) []string {
@@ -323,7 +296,7 @@ func serviceConfig(serviceType string, c *cli.Context, args []string) *service.C
 		Arguments:        args,
 		Environment:      makeUserEnvironment(c.String(userFlagName), c.StringSlice(envFlagName)),
 		UserName:         c.String(userFlagName),
-		ForceInteractive: c.Bool(forceInteractiveFlagName),
+		ForceInteractive: c.Bool(interactiveFlagName),
 		Option:           serviceOptions(c),
 	}
 }

--- a/cli/service_base.go
+++ b/cli/service_base.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/recovery"
+	"github.com/mongodb/jasper"
+	"github.com/mongodb/jasper/options"
+	"github.com/pkg/errors"
+)
+
+// daemonOptions represent common options to initialize a daemon service.
+type daemonOptions struct {
+	host             string
+	port             int
+	manager          jasper.Manager
+	logger           *options.LoggerConfig
+	preconditionCmds []string
+}
+
+// baseDaemon represents common functionality for a daemon service.
+type baseDaemon struct {
+	daemonOptions
+	exit chan struct{}
+}
+
+// newBaseDaemon initializes a base daemon service.
+func newBaseDaemon(opts daemonOptions) baseDaemon {
+	return baseDaemon{
+		daemonOptions: opts,
+		exit:          make(chan struct{}),
+	}
+}
+
+// setup performs required setup to prepare to run the service daemon.
+func (d *baseDaemon) setup(ctx context.Context, cancel context.CancelFunc) error {
+	if d.logger != nil {
+		if err := d.setupLogger(d.logger); err != nil {
+			return errors.Wrap(err, "setting up logging")
+		}
+	}
+
+	if d.manager == nil {
+		var err error
+		if d.manager, err = jasper.NewSynchronizedManager(false); err != nil {
+			return errors.Wrap(err, "initializing process manager")
+		}
+	}
+
+	if err := d.checkPreconditions(ctx); err != nil {
+		return errors.Wrap(err, "precondition(s) failed")
+	}
+
+	go handleDaemonSignals(ctx, cancel, d.exit)
+
+	return nil
+}
+
+// setupLogger creates a logger and sets it as the global logger.
+func (d *baseDaemon) setupLogger(opts *options.LoggerConfig) error {
+	sender, err := opts.Resolve()
+	if err != nil {
+		return errors.Wrap(err, "could not configure logging")
+	}
+	return errors.Wrap(grip.SetSender(sender), "could not set grip logger")
+}
+
+// checkPreconditions runs the daemon's precondition commands.
+func (d *baseDaemon) checkPreconditions(ctx context.Context) error {
+	catcher := grip.NewBasicCatcher()
+	for _, cmd := range d.preconditionCmds {
+		catcher.Wrapf(d.checkPrecondition(ctx, cmd), "file '%s'", cmd)
+	}
+	return catcher.Resolve()
+}
+
+// checkPrecondition runs a single precondition command.
+func (d *baseDaemon) checkPrecondition(ctx context.Context, cmd string) error {
+	if err := d.manager.CreateCommand(ctx).Append(cmd).Run(ctx); err != nil {
+		return errors.Wrap(err, "executing precondition")
+	}
+
+	return nil
+}
+
+// handleDaemonSignals shuts down the daemon by cancelling the context, either
+// when the context is done, it receives a terminate signal, or when it
+// receives a signal to exit the daemon.
+func (d *baseDaemon) handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, exit chan struct{}) {
+	defer recovery.LogStackTraceAndContinue("graceful shutdown")
+	defer cancel()
+	sig := make(chan os.Signal, 2)
+	signal.Notify(sig, syscall.SIGTERM, os.Interrupt)
+
+	select {
+	case <-sig:
+		grip.Debug("received signal")
+	case <-ctx.Done():
+		grip.Debug("context canceled")
+	case <-exit:
+		grip.Debug("received daemon exit signal")
+	}
+}

--- a/cli/service_base.go
+++ b/cli/service_base.go
@@ -55,7 +55,7 @@ func (d *baseDaemon) setup(ctx context.Context, cancel context.CancelFunc) error
 		return errors.Wrap(err, "precondition(s) failed")
 	}
 
-	go handleDaemonSignals(ctx, cancel, d.exit)
+	go d.handleSignals(ctx, cancel, d.exit)
 
 	return nil
 }
@@ -87,10 +87,10 @@ func (d *baseDaemon) checkPrecondition(ctx context.Context, cmd string) error {
 	return nil
 }
 
-// handleDaemonSignals shuts down the daemon by cancelling the context, either
+// handleSignals shuts down the daemon by cancelling the context, either
 // when the context is done, it receives a terminate signal, or when it
 // receives a signal to exit the daemon.
-func (d *baseDaemon) handleDaemonSignals(ctx context.Context, cancel context.CancelFunc, exit chan struct{}) {
+func (d *baseDaemon) handleSignals(ctx context.Context, cancel context.CancelFunc, exit chan struct{}) {
 	defer recovery.LogStackTraceAndContinue("graceful shutdown")
 	defer cancel()
 	sig := make(chan os.Signal, 2)

--- a/cli/service_combined.go
+++ b/cli/service_combined.go
@@ -65,9 +65,23 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 				return errors.Wrap(err, "error creating combined manager")
 			}
 
+			restOpts := daemonOptions{
+				host:             c.String(restHostFlagName),
+				port:             c.Int(restPortFlagName),
+				manager:          manager,
+				logger:           makeLogger(c),
+				preconditionCmds: c.StringSlice(preconditionCmdsFlagName),
+			}
+			rpcOpts := daemonOptions{
+				host:             c.String(rpcHostFlagName),
+				port:             c.Int(rpcPortFlagName),
+				manager:          manager,
+				logger:           makeLogger(c),
+				preconditionCmds: c.StringSlice(preconditionCmdsFlagName),
+			}
 			daemon := newCombinedDaemon(
-				newRESTDaemon(c.String(restHostFlagName), c.Int(restPortFlagName), manager, makeLogger(c)),
-				newRPCDaemon(c.String(rpcHostFlagName), c.Int(rpcPortFlagName), manager, c.String(rpcCredsFilePathFlagName), makeLogger(c)),
+				newRESTDaemon(restOpts),
+				newRPCDaemon(rpcOpts, c.String(rpcCredsFilePathFlagName)),
 			)
 
 			config := serviceConfig(CombinedService, c, buildRunCommand(c, CombinedService))
@@ -81,27 +95,27 @@ func serviceCommandCombined(cmd string, operation serviceOperation) cli.Command 
 }
 
 type combinedDaemon struct {
-	RESTDaemon *restDaemon
-	RPCDaemon  *rpcDaemon
+	*restDaemon
+	*rpcDaemon
 }
 
 func newCombinedDaemon(rest *restDaemon, rpc *rpcDaemon) *combinedDaemon {
 	return &combinedDaemon{
-		RESTDaemon: rest,
-		RPCDaemon:  rpc,
+		restDaemon: rest,
+		rpcDaemon:  rpc,
 	}
 }
 
 func (d *combinedDaemon) Start(s service.Service) error {
 	catcher := grip.NewBasicCatcher()
-	catcher.Add(errors.Wrap(d.RPCDaemon.Start(s), "error starting RPC service"))
-	catcher.Add(errors.Wrap(d.RESTDaemon.Start(s), "error starting REST service"))
+	catcher.Add(errors.Wrap(d.rpcDaemon.Start(s), "error starting RPC service"))
+	catcher.Add(errors.Wrap(d.restDaemon.Start(s), "error starting REST service"))
 	return catcher.Resolve()
 }
 
 func (d *combinedDaemon) Stop(s service.Service) error {
 	catcher := grip.NewBasicCatcher()
-	catcher.Add(errors.Wrap(d.RPCDaemon.Stop(s), "error stopping RPC service"))
-	catcher.Add(errors.Wrap(d.RESTDaemon.Stop(s), "error stopping REST service"))
+	catcher.Add(errors.Wrap(d.rpcDaemon.Stop(s), "error stopping RPC service"))
+	catcher.Add(errors.Wrap(d.restDaemon.Stop(s), "error stopping REST service"))
 	return catcher.Resolve()
 }

--- a/cli/service_rest.go
+++ b/cli/service_rest.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/jasper"
-	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
@@ -50,7 +49,14 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 				return errors.Wrap(err, "error creating REST manager")
 			}
 
-			daemon := newRESTDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, makeLogger(c))
+			opts := daemonOptions{
+				host:             c.String(hostFlagName),
+				port:             c.Int(portFlagName),
+				manager:          manager,
+				logger:           makeLogger(c),
+				preconditionCmds: c.StringSlice(preconditionCmdsFlagName),
+			}
+			daemon := newRESTDaemon(opts)
 
 			config := serviceConfig(RESTService, c, buildRunCommand(c, RESTService))
 
@@ -63,43 +69,21 @@ func serviceCommandREST(cmd string, operation serviceOperation) cli.Command {
 }
 
 type restDaemon struct {
-	Host    string
-	Port    int
-	Manager jasper.Manager
-	Logger  *options.LoggerConfig
-
-	exit chan struct{}
+	baseDaemon
 }
 
-func newRESTDaemon(host string, port int, manager jasper.Manager, logger *options.LoggerConfig) *restDaemon {
-	return &restDaemon{
-		Host:    host,
-		Port:    port,
-		Manager: manager,
-		Logger:  logger,
-	}
+func newRESTDaemon(opts daemonOptions) *restDaemon {
+	return &restDaemon{newBaseDaemon(opts)}
 }
 
 func (d *restDaemon) Start(s service.Service) error {
-	if d.Logger != nil {
-		if err := setupLogger(d.Logger); err != nil {
-			return errors.Wrap(err, "failed to set up logging")
-		}
-	}
-
-	d.exit = make(chan struct{})
-	if d.Manager == nil {
-		var err error
-		if d.Manager, err = jasper.NewSynchronizedManager(false); err != nil {
-			return errors.Wrap(err, "failed to construct REST manager")
-		}
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go handleDaemonSignals(ctx, cancel, d.exit)
+	if err := d.setup(ctx, cancel); err != nil {
+		return errors.Wrap(err, "setup")
+	}
 
 	go func(ctx context.Context, d *restDaemon) {
-		defer recovery.LogStackTraceAndContinue("rest service")
+		defer recovery.LogStackTraceAndContinue("REST service")
 		grip.Error(errors.Wrap(d.run(ctx), "error running REST service"))
 	}(ctx, d)
 
@@ -116,11 +100,11 @@ func (d *restDaemon) run(ctx context.Context) error {
 }
 
 func (d *restDaemon) newService(ctx context.Context) (util.CloseFunc, error) {
-	if d.Manager == nil {
+	if d.manager == nil {
 		return nil, errors.New("manager is not set on REST service")
 	}
-	grip.Infof("starting REST service at '%s:%d'", d.Host, d.Port)
-	return newRESTService(ctx, d.Host, d.Port, d.Manager)
+	grip.Infof("starting REST service at '%s:%d'", d.host, d.port)
+	return newRESTService(ctx, d.host, d.port, d.manager)
 }
 
 // newRESTService creates a REST service around the manager serving requests on
@@ -137,7 +121,7 @@ func newRESTService(ctx context.Context, host string, port int, manager jasper.M
 	}
 
 	go func() {
-		defer recovery.LogStackTraceAndContinue("rest service")
+		defer recovery.LogStackTraceAndContinue("REST service")
 		grip.Warning(errors.Wrap(app.Run(ctx), "error running REST app"))
 	}()
 

--- a/cli/service_rpc.go
+++ b/cli/service_rpc.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/jasper"
-	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
@@ -55,7 +54,14 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 				return errors.Wrap(err, "error creating RPC manager")
 			}
 
-			daemon := newRPCDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, c.String(credsFilePathFlagName), makeLogger(c))
+			opts := daemonOptions{
+				host:             c.String(hostFlagName),
+				port:             c.Int(portFlagName),
+				manager:          manager,
+				logger:           makeLogger(c),
+				preconditionCmds: c.StringSlice(preconditionCmdsFlagName),
+			}
+			daemon := newRPCDaemon(opts, c.String(credsFilePathFlagName))
 
 			config := serviceConfig(RPCService, c, buildRunCommand(c, RPCService))
 
@@ -68,45 +74,25 @@ func serviceCommandRPC(cmd string, operation serviceOperation) cli.Command {
 }
 
 type rpcDaemon struct {
-	Host          string
-	Port          int
-	CredsFilePath string
-	Manager       jasper.Manager
-	Logger        *options.LoggerConfig
-
-	exit chan struct{}
+	baseDaemon
+	credsFilePath string
 }
 
-func newRPCDaemon(host string, port int, manager jasper.Manager, credsFilePath string, logger *options.LoggerConfig) *rpcDaemon {
+func newRPCDaemon(opts daemonOptions, credsFilePath string) *rpcDaemon {
 	return &rpcDaemon{
-		Host:          host,
-		Port:          port,
-		CredsFilePath: credsFilePath,
-		Manager:       manager,
-		Logger:        logger,
+		baseDaemon:    newBaseDaemon(opts),
+		credsFilePath: credsFilePath,
 	}
 }
 
 func (d *rpcDaemon) Start(s service.Service) error {
-	if d.Logger != nil {
-		if err := setupLogger(d.Logger); err != nil {
-			return errors.Wrap(err, "")
-		}
-	}
-
-	d.exit = make(chan struct{})
-	if d.Manager == nil {
-		var err error
-		if d.Manager, err = jasper.NewSynchronizedManager(false); err != nil {
-			return errors.Wrap(err, "failed to construct RPC manager")
-		}
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go handleDaemonSignals(ctx, cancel, d.exit)
+	if err := d.setup(ctx, cancel); err != nil {
+		return errors.Wrap(err, "setup")
+	}
 
 	go func(ctx context.Context, d *rpcDaemon) {
-		defer recovery.LogStackTraceAndContinue("rpc service")
+		defer recovery.LogStackTraceAndContinue("RPC service")
 		grip.Error(errors.Wrap(d.run(ctx), "error running RPC service"))
 	}(ctx, d)
 
@@ -123,13 +109,13 @@ func (d *rpcDaemon) run(ctx context.Context) error {
 }
 
 func (d *rpcDaemon) newService(ctx context.Context) (util.CloseFunc, error) {
-	if d.Manager == nil {
+	if d.manager == nil {
 		return nil, errors.New("manager is not set on RPC service")
 	}
 
-	grip.Infof("starting RPC service at '%s:%d'", d.Host, d.Port)
+	grip.Infof("starting RPC service at '%s:%d'", d.host, d.port)
 
-	return newRPCService(ctx, d.Host, d.Port, d.Manager, d.CredsFilePath)
+	return newRPCService(ctx, d.host, d.port, d.manager, d.credsFilePath)
 }
 
 // newRPCService creates an RPC service around the manager serving requests on

--- a/cli/service_wire.go
+++ b/cli/service_wire.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/evergreen-ci/service"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/recovery"
 	"github.com/mongodb/jasper"
-	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
@@ -50,7 +50,14 @@ func serviceCommandWire(cmd string, operation serviceOperation) cli.Command {
 				return errors.Wrap(err, "error creating wire manager")
 			}
 
-			daemon := newWireDaemon(c.String(hostFlagName), c.Int(portFlagName), manager, makeLogger(c))
+			opts := daemonOptions{
+				host:             c.String(hostFlagName),
+				port:             c.Int(portFlagName),
+				manager:          manager,
+				logger:           makeLogger(c),
+				preconditionCmds: c.StringSlice(preconditionCmdsFlagName),
+			}
+			daemon := newWireDaemon(opts)
 
 			config := serviceConfig(WireService, c, buildRunCommand(c, WireService))
 
@@ -63,42 +70,21 @@ func serviceCommandWire(cmd string, operation serviceOperation) cli.Command {
 }
 
 type wireDaemon struct {
-	Host    string
-	Port    int
-	Manager jasper.Manager
-	Logger  *options.LoggerConfig
-
-	exit chan struct{}
+	baseDaemon
 }
 
-func newWireDaemon(host string, port int, manager jasper.Manager, logger *options.LoggerConfig) *wireDaemon {
-	return &wireDaemon{
-		Host:    host,
-		Port:    port,
-		Manager: manager,
-		Logger:  logger,
-	}
+func newWireDaemon(opts daemonOptions) *wireDaemon {
+	return &wireDaemon{newBaseDaemon(opts)}
 }
 
 func (d *wireDaemon) Start(s service.Service) error {
-	if d.Logger != nil {
-		if err := setupLogger(d.Logger); err != nil {
-			return errors.Wrap(err, "failed to set up logging")
-		}
-	}
-
-	d.exit = make(chan struct{})
-	if d.Manager == nil {
-		var err error
-		if d.Manager, err = jasper.NewSynchronizedManager(false); err != nil {
-			return errors.Wrap(err, "failed to construct wire manager")
-		}
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	go handleDaemonSignals(ctx, cancel, d.exit)
+	if err := d.setup(ctx, cancel); err != nil {
+		return errors.Wrap(err, "setup")
+	}
 
 	go func(ctx context.Context, d *wireDaemon) {
+		defer recovery.LogStackTraceAndContinue("wire service")
 		grip.Error(errors.Wrap(d.run(ctx), "error running wire service"))
 	}(ctx, d)
 
@@ -115,12 +101,12 @@ func (d *wireDaemon) run(ctx context.Context) error {
 }
 
 func (d *wireDaemon) newService(ctx context.Context) (util.CloseFunc, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", d.Host, d.Port))
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", d.host, d.port))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve wire address")
 	}
 
-	closeService, err := remote.StartMDBService(ctx, d.Manager, addr)
+	closeService, err := remote.StartMDBService(ctx, d.manager, addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "error starting wire service")
 	}

--- a/options/logger.go
+++ b/options/logger.go
@@ -274,21 +274,23 @@ func (lc *LoggerConfig) UnmarshalJSON(b []byte) error {
 }
 
 func (lc *LoggerConfig) resolveProducer() error {
-	if lc.producer == nil {
-		if err := lc.validate(); err != nil {
-			return errors.Wrap(err, "invalid logger config")
-		}
+	if lc.producer != nil {
+		return nil
+	}
 
-		factory, ok := lc.Registry.Resolve(lc.info.Type)
-		if !ok {
-			return errors.Errorf("unregistered logger type '%s'", lc.info.Type)
-		}
-		lc.producer = factory()
+	if err := lc.validate(); err != nil {
+		return errors.Wrap(err, "invalid logger config")
+	}
 
-		if len(lc.info.Config) > 0 {
-			if err := lc.info.Format.Unmarshal(lc.info.Config, lc.producer); err != nil {
-				return errors.Wrap(err, "problem unmarshalling data")
-			}
+	factory, ok := lc.Registry.Resolve(lc.info.Type)
+	if !ok {
+		return errors.Errorf("unregistered logger type '%s'", lc.info.Type)
+	}
+	lc.producer = factory()
+
+	if len(lc.info.Config) > 0 {
+		if err := lc.info.Format.Unmarshal(lc.info.Config, lc.producer); err != nil {
+			return errors.Wrap(err, "problem unmarshalling data")
 		}
 	}
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13294

* Add CLI flag to check commands as preconditions for starting the Jasper server. If it's not met, the daemon exits without starting the Jasper server. For example, if you pass it a shell script and the script returns an error, Jasper will not start. Because Jasper service files are written to restart whenever the daemon exits, the daemon will poll the precondition until it succeeds, at which point the Jasper service will begin running.
* Refactor service daemons slightly for code tidiness.