### PR TITLE
EVG-13532: send SIGKILL in Linux process tracker cleanup

### DIFF
--- a/remote/mdb_service.go
+++ b/remote/mdb_service.go
@@ -33,7 +33,7 @@ type mdbService struct {
 // StartMDBService wraps an existing Jasper manager in a MongoDB wire protocol
 // service and starts it. The caller is responsible for closing the connection
 // using the returned jasper.CloseFunc.
-func StartMDBService(ctx context.Context, m jasper.Manager, addr net.Addr) (util.CloseFunc, error) { //nolint: interfacer
+func StartMDBService(ctx context.Context, m jasper.Manager, addr net.Addr) (util.CloseFunc, error) {
 	host, p, err := net.SplitHostPort(addr.String())
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid address")

--- a/remote/process_test.go
+++ b/remote/process_test.go
@@ -177,7 +177,7 @@ func addBasicProcessTests(tests ...processTestCase) []processTestCase {
 				opts := testutil.SleepCreateOpts(3)
 				proc, err := makep(ctx, opts)
 				require.NoError(t, err)
-				assert.Error(t, proc.RegisterSignalTriggerID(ctx, jasper.SignalTriggerID(-1)))
+				assert.Error(t, proc.RegisterSignalTriggerID(ctx, jasper.SignalTriggerID("")))
 			},
 		},
 		{

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -65,9 +65,9 @@ func WaitForRESTService(ctx context.Context, url string) error {
 	}
 }
 
-// WaitForWireService waits unti either the wire service becomes available to
-// serve requests or the context times ou t.
-func WaitForWireService(ctx context.Context, addr net.Addr) error { //nolint: interfacer
+// WaitForWireService waits until either the wire service becomes available to
+// serve requests or the context times out.
+func WaitForWireService(ctx context.Context, addr net.Addr) error {
 	// Block until the service comes up
 	timeoutInterval := 10 * time.Millisecond
 	timer := time.NewTimer(timeoutInterval)

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -141,12 +141,13 @@ func (t *linuxProcessTracker) doCleanupByEnvironmentVariable() error {
 // already terminated, this will not return an error.
 func cleanupProcess(pid int) error {
 	// A process returns syscall.ESRCH if it already terminated.
-	catcher := grip.NewBasicCatcher()
-	err := syscall.Kill(pid, syscall.SIGTERM)
-	catcher.AddWhen(err != syscall.ESRCH, errors.Wrapf(err, "sending sigterm to process with PID '%d'", pid))
-	err = syscall.Kill(pid, syscall.SIGKILL)
-	catcher.AddWhen(err != syscall.ESRCH, errors.Wrapf(err, "sending sigkill to process with PID '%d'", pid))
-	return catcher.Resolve()
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
+		catcher := grip.NewBasicCatcher()
+		catcher.Add(errors.Wrapf(err, "sending sigterm to process with PID '%d'", pid))
+		catcher.Add(errors.Wrapf(syscall.Kill(pid, syscall.SIGKILL), "sending sigkill to process with PID '%d'", pid))
+		return catcher.Resolve()
+	}
+	return nil
 }
 
 // Cleanup kills all tracked processes. If cgroups is available, it kills all

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -137,15 +137,12 @@ func (t *linuxProcessTracker) doCleanupByEnvironmentVariable() error {
 	return catcher.Resolve()
 }
 
-// cleanupProcess terminates the process given by its PID. If the process has
-// already terminated, this will not return an error.
+// cleanupProcess kills the process given by its PID. If the process has already
+// killed, this will not return an error.
 func cleanupProcess(pid int) error {
 	// A process returns syscall.ESRCH if it already terminated.
-	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil && err != syscall.ESRCH {
-		catcher := grip.NewBasicCatcher()
-		catcher.Add(errors.Wrapf(err, "sending sigterm to process with PID '%d'", pid))
-		catcher.Add(errors.Wrapf(syscall.Kill(pid, syscall.SIGKILL), "sending sigkill to process with PID '%d'", pid))
-		return catcher.Resolve()
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return errors.Wrapf(err, "sending sigkill to process with PID '%d'")
 	}
 	return nil
 }

--- a/tracker_linux.go
+++ b/tracker_linux.go
@@ -142,7 +142,7 @@ func (t *linuxProcessTracker) doCleanupByEnvironmentVariable() error {
 func cleanupProcess(pid int) error {
 	// A process returns syscall.ESRCH if it already terminated.
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
-		return errors.Wrapf(err, "sending sigkill to process with PID '%d'")
+		return errors.Wrapf(err, "sending sigkill to process with PID '%d'", pid)
 	}
 	return nil
 }


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13532

* Only send SIGKILL if SIGTERM fails when cleaning up tracked Linux processes.
* Minor fix for converting int (i.e. char) to string since go1.15 will complain.
* Minor doc comment fixes.