### PR TITLE
EVG-13592: exit goroutines when context cancels in integration test

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -122,21 +122,21 @@ func TestMongod(t *testing.T) {
 				expectError bool
 			}{
 				{
-					id:          "WithSingleMongod",
+					id:          "WithSingleMongodAndSIGKILL",
 					numProcs:    1,
 					signal:      syscall.SIGKILL,
 					sleep:       0,
 					expectError: true,
 				},
 				{
-					id:          "With10MongodsAndSigkill",
+					id:          "With10MongodsAndSIGKILL",
 					numProcs:    10,
 					signal:      syscall.SIGKILL,
 					sleep:       2 * time.Second,
 					expectError: true,
 				},
 				{
-					id:          "With30MongodsAndSigkill",
+					id:          "With30MongodsAndSIGKILL",
 					numProcs:    30,
 					signal:      syscall.SIGKILL,
 					sleep:       3 * time.Second,
@@ -161,32 +161,37 @@ func TestMongod(t *testing.T) {
 					for _, proc := range procs {
 						go func(proc Process) {
 							_, err := proc.Wait(ctx)
-							waitError <- err
+							select {
+							case waitError <- err:
+							case <-ctx.Done():
+							}
 						}(proc)
 					}
 
 					// Signal to stop mongods
 					time.Sleep(test.sleep)
 					for _, proc := range procs {
-						err := proc.Signal(ctx, test.signal)
-						require.NoError(t, err)
+						assert.NoError(t, proc.Signal(ctx, test.signal))
 					}
 
-					// Check that the processes all received signal
+					// Wait for all processes to exit after receiving the
+					// signal.
 					for i := 0; i < test.numProcs; i++ {
-						err := <-waitError
-						if test.expectError {
-							assert.Error(t, err)
-						} else {
-							assert.NoError(t, err)
+						select {
+						case err := <-waitError:
+							if test.expectError {
+								assert.Error(t, err)
+							} else {
+								assert.NoError(t, err)
+							}
+						case <-ctx.Done():
+							require.FailNow(t, "could not check process wait result", ctx.Err().Error())
 						}
 					}
 
 					// Check that the processes have all noted a unsuccessful run
 					for _, proc := range procs {
-						if test.expectError {
-							assert.False(t, proc.Info(ctx).Successful)
-						}
+						assert.Equal(t, !test.expectError, proc.Info(ctx).Successful)
 					}
 				})
 			}

--- a/interface.go
+++ b/interface.go
@@ -133,6 +133,6 @@ type ProcessInfo struct {
 	Complete   bool           `json:"complete" bson:"complete"`
 	Timeout    bool           `json:"timeout" bson:"timeout"`
 	Options    options.Create `json:"options" bson:"options"`
-	StartAt    time.Time      `json:"start_at" bson:"start_at"`
-	EndAt      time.Time      `json:"end_at" bson:"end_at"`
+	StartAt    time.Time      `json:"start_at,omitempty" bson:"start_at,omitempty"`
+	EndAt      time.Time      `json:"end_at,omitempty" bson:"end_at,omitempty"`
 }

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -120,7 +120,10 @@ func (p *blockingProcess) reactor(ctx context.Context, deadline time.Time, exec 
 	signal := make(chan error)
 	go func() {
 		defer close(signal)
-		signal <- exec.Wait()
+		select {
+		case signal <- exec.Wait():
+		case <-ctx.Done():
+		}
 	}()
 	defer close(p.complete)
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13592

The integration test has an occasional flaky run on Windows only when run in CI for unknown reasons (on a spawn host, i can't reproduce it). While I don't know if this will fix it completely, this should make it slightly less likely to flake by reducing the chance of resource leaks. I ran it ~20 times in CI and it didn't fail.

* Ensure goroutines exit when context cancels to avoid leaking goroutines in tests.
* Use omitempty for process info since it shouldn't show the process start/end time when it's unset.