### PR TITLE
EVG-13187: try different ports to start the MDB service

### DIFF
--- a/cli/service_test.go
+++ b/cli/service_test.go
@@ -120,7 +120,7 @@ func TestDaemon(t *testing.T) {
 			svc, err := service.New(daemon, &service.Config{Name: "foo"})
 			require.NoError(t, err)
 			require.NoError(t, daemon.Start(svc))
-			require.NoError(t, testutil.WaitForRESTService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
+			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
 
 			client, err := newRemoteManager(ctx, RESTService, "localhost", port, "")
 			require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestDaemon(t *testing.T) {
 			svc, err := service.New(daemon, &service.Config{Name: "foo"})
 			require.NoError(t, err)
 			require.NoError(t, daemon.Start(svc))
-			require.NoError(t, testutil.WaitForRESTService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", restOpts.port)))
+			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", restOpts.port)))
 
 			client, err := newRemoteManager(ctx, RESTService, "localhost", restOpts.port, "")
 			require.NoError(t, err)

--- a/cli/util_for_test.go
+++ b/cli/util_for_test.go
@@ -120,7 +120,7 @@ func execCLICommandOutput(t *testing.T, c *cli.Context, cmd cli.Command, output 
 func makeTestRESTService(ctx context.Context, t *testing.T, port int, manager jasper.Manager) util.CloseFunc {
 	closeService, err := newRESTService(ctx, "localhost", port, manager)
 	require.NoError(t, err)
-	require.NoError(t, testutil.WaitForRESTService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
+	require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
 	return closeService
 }
 

--- a/download_test.go
+++ b/download_test.go
@@ -141,7 +141,7 @@ func TestProcessDownloadJobs(t *testing.T) {
 	}()
 
 	baseURL := fmt.Sprintf("http://%s", fileServerAddr)
-	require.NoError(t, testutil.WaitForRESTService(ctx, baseURL))
+	require.NoError(t, testutil.WaitForHTTPService(ctx, baseURL))
 
 	job, err := recall.NewDownloadJob(fmt.Sprintf("%s/%s", baseURL, fileName), downloadDir, true)
 	require.NoError(t, err)

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -849,7 +849,7 @@ func TestManagerImplementations(t *testing.T) {
 										}()
 
 										baseURL := fmt.Sprintf("http://%s", fileServerAddr)
-										require.NoError(t, testutil.WaitForRESTService(ctx, baseURL))
+										require.NoError(t, testutil.WaitForHTTPService(ctx, baseURL))
 
 										opts := options.Download{
 											URL:  fmt.Sprintf("%s/%s", baseURL, fileName),

--- a/remote/mdb_util_test.go
+++ b/remote/mdb_util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper"
@@ -12,30 +13,101 @@ import (
 )
 
 func makeTestMDBServiceAndClient(ctx context.Context, mngr jasper.Manager) (Manager, error) {
-	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", testutil.GetPortNumber()))
-	if err != nil {
-		return nil, errors.WithStack(err)
+	var (
+		addr   net.Addr
+		client Manager
+		err    error
+	)
+tryPort:
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrap(ctx.Err(), "starting MDB service")
+		default:
+			addr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", testutil.GetPortNumber()))
+			if err != nil {
+				continue tryPort
+			}
+
+			srvCtx, srvCancel := context.WithCancel(ctx)
+			closeService, err := StartMDBService(srvCtx, mngr, addr)
+			if err != nil {
+				srvCancel()
+				return nil, errors.WithStack(err)
+			}
+
+			failedToConnect := make(chan struct{})
+			go func() {
+				defer func() {
+					srvCancel()
+					grip.Notice(closeService())
+				}()
+				select {
+				case <-ctx.Done():
+				case <-failedToConnect:
+				}
+			}()
+
+			client, err = tryConnectToMDBService(ctx, addr)
+			if err != nil {
+				close(failedToConnect)
+				continue
+			}
+			break tryPort
+		}
 	}
 
-	closeService, err := StartMDBService(ctx, mngr, addr)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	go func() {
-		<-ctx.Done()
-		grip.Notice(closeService())
-	}()
-	if err = testutil.WaitForWireService(ctx, addr); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	client, err := NewMDBClient(ctx, addr, 0)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
 	go func() {
 		<-ctx.Done()
 		grip.Notice(client.CloseConnection())
 	}()
 	return client, nil
+}
+
+func tryConnectToMDBService(ctx context.Context, addr net.Addr) (Manager, error) {
+	maxAttempts := 10
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		client, err := func() (Manager, error) {
+			connCtx, connCancel := context.WithTimeout(ctx, time.Second)
+			defer connCancel()
+			client, err := waitForMDBService(connCtx, addr)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			return client, nil
+		}()
+		if err != nil {
+			continue
+		}
+		return client, nil
+	}
+	return nil, errors.Errorf("failed to connect after %d attempts", maxAttempts)
+}
+
+// waitForMDBService waits until either the MDB wire protocol service becomes
+// available to serve requests or the context times out.
+func waitForMDBService(ctx context.Context, addr net.Addr) (Manager, error) {
+	// Block until the service comes up
+	timeoutInterval := 10 * time.Millisecond
+	timer := time.NewTimer(timeoutInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.Wrap(ctx.Err(), "context done before connection could be established to service")
+		case <-timer.C:
+			client, err := NewMDBClient(ctx, addr, 0)
+			if err != nil {
+				timer.Reset(timeoutInterval)
+				continue
+			}
+			// Ensure that a client can connect to the service by verifying
+			// that it returns a manager ID.
+			if client.ID() == "" {
+				timer.Reset(timeoutInterval)
+				grip.Warning(client.CloseConnection())
+				continue
+			}
+			return client, nil
+		}
+	}
 }

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -2,12 +2,10 @@ package testutil
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
@@ -31,57 +29,34 @@ func PutHTTPClient(client *http.Client) {
 	httpClientPool.Put(client)
 }
 
-// WaitForRESTService waits until either the REST service becomes available to
-// serve requests or the context is done.
-func WaitForRESTService(ctx context.Context, url string) error {
+// WaitForHTTPService waits until either the HTTP service becomes available to
+// serve requests to the given URL or the context is done.
+func WaitForHTTPService(ctx context.Context, url string) error {
 	client := GetHTTPClient()
 	defer PutHTTPClient(client)
 
 	// Block until the service comes up
-	timeoutInterval := 10 * time.Millisecond
-	timer := time.NewTimer(timeoutInterval)
+	backoff := 10 * time.Millisecond
+	timer := time.NewTimer(backoff)
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.WithStack(ctx.Err())
+			return errors.Wrap(ctx.Err(), "context done before connection could be established to service")
 		case <-timer.C:
 			req, err := http.NewRequest(http.MethodGet, url, nil)
 			if err != nil {
-				timer.Reset(timeoutInterval)
+				timer.Reset(backoff)
 				continue
 			}
 			req = req.WithContext(ctx)
 			resp, err := client.Do(req)
 			if err != nil {
-				timer.Reset(timeoutInterval)
 				continue
 			}
 			if resp.StatusCode != http.StatusOK {
-				timer.Reset(timeoutInterval)
+				timer.Reset(backoff)
 				continue
 			}
-			return nil
-		}
-	}
-}
-
-// WaitForWireService waits until either the wire service becomes available to
-// serve requests or the context times out.
-func WaitForWireService(ctx context.Context, addr net.Addr) error {
-	// Block until the service comes up
-	timeoutInterval := 10 * time.Millisecond
-	timer := time.NewTimer(timeoutInterval)
-	for {
-		select {
-		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "context errored before connection could be established to service")
-		case <-timer.C:
-			conn, err := net.Dial("tcp", addr.String())
-			if err != nil {
-				timer.Reset(timeoutInterval)
-				continue
-			}
-			grip.Warning(conn.Close())
 			return nil
 		}
 	}

--- a/testutil/http.go
+++ b/testutil/http.go
@@ -51,6 +51,7 @@ func WaitForHTTPService(ctx context.Context, url string) error {
 			req = req.WithContext(ctx)
 			resp, err := client.Do(req)
 			if err != nil {
+				timer.Reset(backoff)
 				continue
 			}
 			if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13187

This fixes an issue where wire protocol tests occasionally fail because the service can't listen on the port we choose on Windows. I ran it a bunch of times and it seems to succeed consistently now.