### PR TITLE
EVG-9288: use utility HTTP clients

### DIFF
--- a/cli/service_test.go
+++ b/cli/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/evergreen-ci/service"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/remote"
@@ -120,7 +121,9 @@ func TestDaemon(t *testing.T) {
 			svc, err := service.New(daemon, &service.Config{Name: "foo"})
 			require.NoError(t, err)
 			require.NoError(t, daemon.Start(svc))
-			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
+			httpClient := utility.GetHTTPClient()
+			defer utility.PutHTTPClient(httpClient)
+			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port), httpClient))
 
 			client, err := newRemoteManager(ctx, RESTService, "localhost", port, "")
 			require.NoError(t, err)
@@ -145,7 +148,9 @@ func TestDaemon(t *testing.T) {
 			svc, err := service.New(daemon, &service.Config{Name: "foo"})
 			require.NoError(t, err)
 			require.NoError(t, daemon.Start(svc))
-			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", restOpts.port)))
+			httpClient := utility.GetHTTPClient()
+			defer utility.PutHTTPClient(httpClient)
+			require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", restOpts.port), httpClient))
 
 			client, err := newRemoteManager(ctx, RESTService, "localhost", restOpts.port, "")
 			require.NoError(t, err)

--- a/cli/util_for_test.go
+++ b/cli/util_for_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/remote"
 	"github.com/mongodb/jasper/testutil"
@@ -120,7 +121,9 @@ func execCLICommandOutput(t *testing.T, c *cli.Context, cmd cli.Command, output 
 func makeTestRESTService(ctx context.Context, t *testing.T, port int, manager jasper.Manager) util.CloseFunc {
 	closeService, err := newRESTService(ctx, "localhost", port, manager)
 	require.NoError(t, err)
-	require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port)))
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
+	require.NoError(t, testutil.WaitForHTTPService(ctx, fmt.Sprintf("http://localhost:%d/jasper/v1", port), httpClient))
 	return closeService
 }
 

--- a/download_test.go
+++ b/download_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/evergreen-ci/bond/recall"
 	"github.com/evergreen-ci/lru"
+	"github.com/evergreen-ci/utility"
 	"github.com/mholt/archiver"
 	"github.com/mongodb/amboy/queue"
 	"github.com/mongodb/grip"
@@ -141,7 +142,9 @@ func TestProcessDownloadJobs(t *testing.T) {
 	}()
 
 	baseURL := fmt.Sprintf("http://%s", fileServerAddr)
-	require.NoError(t, testutil.WaitForHTTPService(ctx, baseURL))
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
+	require.NoError(t, testutil.WaitForHTTPService(ctx, baseURL, httpClient))
 
 	job, err := recall.NewDownloadJob(fmt.Sprintf("%s/%s", baseURL, fileName), downloadDir, true)
 	require.NoError(t, err)

--- a/options/download.go
+++ b/options/download.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/bond"
+	"github.com/evergreen-ci/utility"
 	"github.com/mholt/archiver"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -43,8 +44,8 @@ func (opts Download) Download() error {
 		return errors.Wrap(err, "problem building request")
 	}
 
-	client := bond.GetHTTPClient()
-	defer bond.PutHTTPClient(client)
+	client := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(client)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/remote/client_windows_test.go
+++ b/remote/client_windows_test.go
@@ -2,11 +2,11 @@ package remote
 
 import (
 	"context"
-	"fmt"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +14,8 @@ import (
 )
 
 func TestWindowsEvents(t *testing.T) {
-	httpClient := testutil.GetHTTPClient()
-	defer testutil.PutHTTPClient(httpClient)
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
 
 	for clientName, makeClient := range map[string]func(ctx context.Context, t *testing.T) Manager{
 		"RPC": func(ctx context.Context, t *testing.T) Manager {
@@ -26,13 +26,10 @@ func TestWindowsEvents(t *testing.T) {
 			return client
 		},
 		"REST": func(ctx context.Context, t *testing.T) Manager {
-			_, port, err := startRESTService(ctx, httpClient)
+			mngr, err := jasper.NewSynchronizedManager(false)
 			require.NoError(t, err)
-
-			client := &restClient{
-				prefix: fmt.Sprintf("http://localhost:%d/jasper/v1", port),
-				client: httpClient,
-			}
+			_, client, err := makeRESTServiceAndClient(ctx, mngr, httpClient)
+			require.NoError(t, err)
 			return client
 		},
 	} {

--- a/remote/logging_cache_test.go
+++ b/remote/logging_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/stretchr/testify/assert"
@@ -15,8 +16,8 @@ func TestLoggingCache(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	httpClient := testutil.GetHTTPClient()
-	defer testutil.PutHTTPClient(httpClient)
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
 
 	for managerName, makeManager := range remoteManagerTestCases(httpClient) {
 		t.Run(managerName, func(t *testing.T) {
@@ -189,9 +190,6 @@ func TestLoggingCache(t *testing.T) {
 					tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
 					defer cancel()
 					client := makeManager(tctx, t)
-					defer func() {
-						assert.NoError(t, client.CloseConnection())
-					}()
 					test.Case(tctx, t, client)
 				})
 			}

--- a/remote/rest_util_test.go
+++ b/remote/rest_util_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// kim: TODO: modify this to use tryStartRPCService
 func makeRESTServiceAndClient(ctx context.Context, mngr jasper.Manager, httpClient *http.Client) (*Service, Manager, error) {
 tryStartService:
 	for {

--- a/remote/rest_util_test.go
+++ b/remote/rest_util_test.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -12,17 +13,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func startRESTService(ctx context.Context, client *http.Client) (*Service, int, error) {
+// kim: TODO: modify this to use tryStartRPCService
+func makeRESTServiceAndClient(ctx context.Context, mngr jasper.Manager, httpClient *http.Client) (*Service, Manager, error) {
 tryStartService:
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, -1, errors.WithStack(ctx.Err())
+			return nil, nil, errors.WithStack(ctx.Err())
 		default:
-			mngr, err := jasper.NewSynchronizedManager(false)
-			if err != nil {
-				return nil, -1, errors.WithStack(err)
-			}
 			srv := NewRESTService(mngr)
 			app := srv.App(ctx)
 			app.SetPrefix("jasper")
@@ -50,23 +48,27 @@ tryStartService:
 				}
 			}()
 
-			url := fmt.Sprintf("http://localhost:%d/jasper/v1/", port)
-			if err := tryConnectToRESTService(ctx, url); err != nil {
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
+			if err != nil {
+				continue
+			}
+			url := fmt.Sprintf("http://%s/jasper/v1/", addr)
+			if err := tryConnectToRESTService(ctx, url, httpClient); err != nil {
 				close(failedToConnect)
 				continue
 			}
-			return srv, port, nil
+			return srv, newTestRESTClient(ctx, addr, httpClient), nil
 		}
 	}
 }
 
-func tryConnectToRESTService(ctx context.Context, url string) error {
+func tryConnectToRESTService(ctx context.Context, url string, httpClient *http.Client) error {
 	maxAttempts := 10
 	for attempt := 0; attempt < 10; attempt++ {
 		err := func() error {
 			connCtx, connCancel := context.WithTimeout(ctx, time.Second)
 			defer connCancel()
-			if err := testutil.WaitForHTTPService(connCtx, url); err != nil {
+			if err := testutil.WaitForHTTPService(connCtx, url, httpClient); err != nil {
 				return errors.WithStack(err)
 			}
 			return nil
@@ -77,4 +79,17 @@ func tryConnectToRESTService(ctx context.Context, url string) error {
 		return nil
 	}
 	return errors.Errorf("failed to connect after %d attempts", maxAttempts)
+}
+
+// newTestRESTClient establishes a client for testing purposes that closes when
+// the context is done.
+func newTestRESTClient(ctx context.Context, addr net.Addr, httpClient *http.Client) Manager {
+	client := NewRESTClientWithExistingClient(addr, httpClient)
+
+	go func() {
+		<-ctx.Done()
+		grip.Notice(client.CloseConnection())
+	}()
+
+	return client
 }

--- a/remote/rpc_util_test.go
+++ b/remote/rpc_util_test.go
@@ -25,16 +25,12 @@ func makeInsecureRPCServiceAndClient(ctx context.Context, mngr jasper.Manager) (
 }
 
 func tryStartRPCService(ctx context.Context, startService func(context.Context, net.Addr) error) (net.Addr, error) {
-	var addr net.Addr
-	var err error
-tryPort:
 	for {
 		select {
 		case <-ctx.Done():
-			err = ctx.Err()
-			break tryPort
+			return nil, ctx.Err()
 		default:
-			addr, err = net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", testutil.GetPortNumber()))
+			addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", testutil.GetPortNumber()))
 			if err != nil {
 				continue
 			}
@@ -43,10 +39,9 @@ tryPort:
 				continue
 			}
 
-			break tryPort
+			return addr, err
 		}
 	}
-	return addr, err
 }
 
 func makeTLSRPCServiceAndClient(ctx context.Context, mngr jasper.Manager) (Manager, error) {

--- a/remote/rpc_util_test.go
+++ b/remote/rpc_util_test.go
@@ -117,7 +117,7 @@ func startTestRPCService(ctx context.Context, mngr jasper.Manager, addr net.Addr
 	return nil
 }
 
-// newTestClient establishes a client for testing purposes that closes when
+// newTestRPCClient establishes a client for testing purposes that closes when
 // the context is done.
 func newTestRPCClient(ctx context.Context, addr net.Addr, creds *certdepot.Credentials) (Manager, error) {
 	client, err := NewRPCClient(ctx, addr, creds)

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper/scripting"
 	"github.com/mongodb/jasper/testutil"
 	"github.com/stretchr/testify/assert"
@@ -18,8 +19,8 @@ func TestScripting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	httpClient := testutil.GetHTTPClient()
-	defer testutil.PutHTTPClient(httpClient)
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
 
 	for managerName, makeManager := range remoteManagerTestCases(httpClient) {
 		t.Run(managerName, func(t *testing.T) {
@@ -134,9 +135,6 @@ func TestScripting(t *testing.T) {
 					tctx, cancel := context.WithTimeout(ctx, testutil.RPCTestTimeout)
 					defer cancel()
 					client := makeManager(tctx, t)
-					defer func() {
-						assert.NoError(t, client.CloseConnection())
-					}()
 					tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "scripting_tests")
 					require.NoError(t, err)
 					defer func() {


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-9288

* Use utility package instead of testutil/bond.
* Make a new HTTP client constructor to create REST clients that don't own the HTTP clients given to them.
* Fix an issue where an HTTP client would be freed back into the pool more than once, which caused REST tests to hang.