### PR TITLE
EVG-13684: write tests for executor interface

### DIFF
--- a/benchmarks/harness.go
+++ b/benchmarks/harness.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 )
 
@@ -87,7 +88,7 @@ func runIteration(ctx context.Context, makeProc makeProcess, opts *options.Creat
 }
 
 func makeCreateOpts(timeout time.Duration, logger options.LoggerConfig) *options.Create {
-	opts := testutil.YesCreateOpts(timeout)
+	opts := testoptions.YesCreateOpts(timeout)
 	opts.Output.Loggers = []*options.LoggerConfig{&logger}
 	return opts
 }

--- a/cli/manager_test.go
+++ b/cli/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mongodb/jasper/mock"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,7 +171,7 @@ func TestCLIManager(t *testing.T) {
 					}()
 
 					resp := &InfoResponse{}
-					input, err := json.Marshal(testutil.TrueCreateOpts())
+					input, err := json.Marshal(testoptions.TrueCreateOpts())
 					require.NoError(t, err)
 					require.NoError(t, execCLICommandInputOutput(t, c, managerCreateProcess(), input, resp))
 					require.True(t, resp.Successful())

--- a/cli/process_test.go
+++ b/cli/process_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,7 +184,7 @@ func TestCLIProcess(t *testing.T) {
 					}()
 
 					resp := &InfoResponse{}
-					input, err := json.Marshal(testutil.SleepCreateOpts(1))
+					input, err := json.Marshal(testoptions.SleepCreateOpts(1))
 					require.NoError(t, err)
 					require.NoError(t, execCLICommandInputOutput(t, c, managerCreateProcess(), input, resp))
 					require.True(t, resp.Successful())

--- a/cli/remote_test.go
+++ b/cli/remote_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestCLIRemote(t *testing.T) {
 						assert.NoError(t, os.RemoveAll(tmpDir))
 					}()
 
-					opts := testutil.ValidMongoDBDownloadOptions()
+					opts := testoptions.ValidMongoDBDownloadOptions()
 					opts.Path = tmpDir
 					input, err := json.Marshal(opts)
 					require.NoError(t, err)
@@ -75,7 +76,7 @@ func TestCLIRemote(t *testing.T) {
 				"GetLogStreamSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context) {
 					logger, err := jasper.NewInMemoryLogger(10)
 					require.NoError(t, err)
-					opts := testutil.TrueCreateOpts()
+					opts := testoptions.TrueCreateOpts()
 					opts.Output.Loggers = []*options.LoggerConfig{logger}
 					createInput, err := json.Marshal(opts)
 					require.NoError(t, err)
@@ -90,7 +91,7 @@ func TestCLIRemote(t *testing.T) {
 					assert.True(t, resp.Successful())
 				},
 				"CreateScriptingSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context) {
-					opts := testutil.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory())
+					opts := testoptions.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory())
 					convertedOpts, err := BuildScriptingCreateInput(opts)
 					require.NoError(t, err)
 					input, err := json.Marshal(convertedOpts)
@@ -100,7 +101,7 @@ func TestCLIRemote(t *testing.T) {
 					assert.NotZero(t, resp.ID)
 				},
 				"GetScriptingSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context) {
-					opts := testutil.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory())
+					opts := testoptions.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory())
 					convertedOpts, err := BuildScriptingCreateInput(opts)
 					require.NoError(t, err)
 					createInput, err := json.Marshal(convertedOpts)

--- a/cli/scripting_test.go
+++ b/cli/scripting_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestCLIScripting(t *testing.T) {
 		t.Run(remoteType, func(t *testing.T) {
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string){
 				"SetupSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 				},
 				"SetupWithEmptyIDFails": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
@@ -43,7 +44,7 @@ func TestCLIScripting(t *testing.T) {
 					assert.False(t, resp.Successful())
 				},
 				"RunSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 					tmpFile := filepath.Join(tmpDir, "main.go")
 					require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
@@ -74,7 +75,7 @@ func TestCLIScripting(t *testing.T) {
 					assert.False(t, resp.Successful())
 				},
 				"RunScriptSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 					input, err := json.Marshal(ScriptingRunScriptInput{
 						ID:     id,
@@ -103,7 +104,7 @@ func TestCLIScripting(t *testing.T) {
 					assert.False(t, resp.Successful())
 				},
 				"BuildSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 					tmpFile := filepath.Join(tmpDir, "main.go")
 					require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangMainSuccess()), 0755))
@@ -136,7 +137,7 @@ func TestCLIScripting(t *testing.T) {
 					assert.False(t, resp.Successful())
 				},
 				"TestSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 					tmpFile := filepath.Join(tmpDir, "main.go")
 					require.NoError(t, ioutil.WriteFile(tmpFile, []byte(testutil.GolangTestSuccess()), 0755))
@@ -169,7 +170,7 @@ func TestCLIScripting(t *testing.T) {
 					assert.False(t, resp.Successful())
 				},
 				"CleanupSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, tmpDir string) {
-					id := createScriptingFromCLI(t, c, testutil.ValidGolangScriptingHarnessOptions(tmpDir))
+					id := createScriptingFromCLI(t, c, testoptions.ValidGolangScriptingHarnessOptions(tmpDir))
 					setupScriptingFromCLI(t, c, id)
 					input, err := json.Marshal(IDInput{ID: id})
 					require.NoError(t, err)

--- a/cli/ssh_client_test.go
+++ b/cli/ssh_client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/jasper/mock"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -393,7 +394,7 @@ func TestSSHClient(t *testing.T) {
 				&inputChecker,
 				makeOutcomeResponse(nil),
 			)
-			opts := testutil.ValidMongoDBDownloadOptions()
+			opts := testoptions.ValidMongoDBDownloadOptions()
 			opts.Path = "/foo"
 			require.NoError(t, client.DownloadMongoDB(ctx, opts))
 
@@ -406,13 +407,13 @@ func TestSSHClient(t *testing.T) {
 				nil,
 				invalidResponse(),
 			)
-			opts := testutil.ValidMongoDBDownloadOptions()
+			opts := testoptions.ValidMongoDBDownloadOptions()
 			opts.Path = "/foo"
 			assert.Error(t, client.DownloadMongoDB(ctx, opts))
 		},
 		"DownloadMongoDBFailsIfBaseManagerCreateFails": func(ctx context.Context, t *testing.T, client *sshClient, baseManager *mock.Manager) {
 			baseManager.FailCreate = true
-			opts := testutil.ValidMongoDBDownloadOptions()
+			opts := testoptions.ValidMongoDBDownloadOptions()
 			opts.Path = "/foo"
 			assert.Error(t, client.DownloadMongoDB(ctx, opts))
 		},
@@ -518,13 +519,13 @@ func TestSSHClient(t *testing.T) {
 				&inputChecker,
 				resp,
 			)
-			sh, err := client.CreateScripting(ctx, testutil.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
+			sh, err := client.CreateScripting(ctx, testoptions.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
 			require.NoError(t, err)
 			assert.Equal(t, resp.ID, sh.ID())
 		},
 		"CreateScriptingFailsIfBaseManagerCreateFails": func(ctx context.Context, t *testing.T, client *sshClient, baseManager *mock.Manager) {
 			baseManager.FailCreate = true
-			sh, err := client.CreateScripting(ctx, testutil.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
+			sh, err := client.CreateScripting(ctx, testoptions.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
 			assert.Error(t, err)
 			assert.Zero(t, sh)
 		},
@@ -535,7 +536,7 @@ func TestSSHClient(t *testing.T) {
 				nil,
 				invalidResponse(),
 			)
-			sh, err := client.CreateScripting(ctx, testutil.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
+			sh, err := client.CreateScripting(ctx, testoptions.ValidPythonScriptingHarnessOptions(testutil.BuildDirectory()))
 			assert.Error(t, err)
 			assert.Zero(t, sh)
 		},

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/remote"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -119,7 +120,7 @@ func TestCLICommon(t *testing.T) {
 			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, c *cli.Context, client remote.Manager) error{
 				"CreateProcessWithConnection": func(ctx context.Context, t *testing.T, c *cli.Context, client remote.Manager) error {
 					return withConnection(ctx, c, func(client remote.Manager) error {
-						proc, err := client.CreateProcess(ctx, testutil.TrueCreateOpts())
+						proc, err := client.CreateProcess(ctx, testoptions.TrueCreateOpts())
 						require.NoError(t, err)
 						require.NotNil(t, proc)
 						assert.NotZero(t, proc.Info(ctx).PID)

--- a/command_test.go
+++ b/command_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/mongodb/jasper/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -527,7 +528,7 @@ func TestCommandImplementation(t *testing.T) {
 }
 
 func TestRunParallelRunsInParallel(t *testing.T) {
-	sleepCmd := testutil.SleepCreateOpts(3).Args
+	sleepCmd := testoptions.SleepCreateOpts(3).Args
 	cmd := NewCommand().Extend([][]string{sleepCmd, sleepCmd, sleepCmd})
 	threePointFiveSeconds := time.Second*3 + time.Millisecond*500
 	maxRunTimeAllowed := threePointFiveSeconds

--- a/download_test.go
+++ b/download_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ func TestSetupDownloadMongoDBReleasesWithInvalidPath(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 	defer cancel()
 
-	opts := testutil.ValidMongoDBDownloadOptions()
+	opts := testoptions.ValidMongoDBDownloadOptions()
 	_, path, _, ok := runtime.Caller(0)
 	require.True(t, ok)
 	absPath, err := filepath.Abs(path)
@@ -58,7 +59,7 @@ func TestSetupDownloadMongoDBReleasesWithInvalidArtifactsFeed(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	opts := testutil.ValidMongoDBDownloadOptions()
+	opts := testoptions.ValidMongoDBDownloadOptions()
 	absDir, err := filepath.Abs(dir)
 	require.NoError(t, err)
 	opts.Path = filepath.Join(absDir, "full.json")

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -132,11 +132,10 @@ task_groups:
     max_hosts: 2
     setup_group:
       - func: get-project
-    setup_task:
-      - func: run-make
-        vars: { target: "clean-results" }
     teardown_task:
       - func: parse-results
+      - func: run-make
+        vars: { target: "clean-results" }
   - name: testGroup
     tasks: [ ".test"]
     max_hosts: 2
@@ -146,7 +145,8 @@ task_groups:
         vars: { target: "docker-setup" }
         variants:
           - ubuntu1604
-    setup_task:
+    teardown_task:
+      - func: parse-results
       - func: run-make
         vars: { target: "clean-results" }
     teardown_group:
@@ -154,7 +154,6 @@ task_groups:
         vars: { target: "docker-cleanup" }
         variants:
           - ubuntu1604
-      - func: parse-results
 
 #######################################
 #           Buildvariants             #

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -141,6 +141,7 @@ task_groups:
     max_hosts: 2
     setup_group:
       - func: get-project
+    setup_task:
       - func: run-make
         vars: { target: "docker-setup" }
         variants:
@@ -149,7 +150,6 @@ task_groups:
       - func: parse-results
       - func: run-make
         vars: { target: "clean-results" }
-    teardown_group:
       - func: run-make
         vars: { target: "docker-cleanup" }
         variants:

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -149,7 +149,7 @@ task_groups:
     setup_task:
       - func: run-make
         vars: { target: "clean-results" }
-    teardown_task:
+    teardown_group:
       - func: run-make
         vars: { target: "docker-cleanup" }
         variants:

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -57,11 +57,15 @@ tasks:
 
   - <<: *run-build
     tags: ["test"]
-    name: test-options
+    name: test-internal-executor
 
   - <<: *run-build
     tags: ["test"]
     name: test-mock
+
+  - <<: *run-build
+    tags: ["test"]
+    name: test-options
 
   - <<: *run-build
     tags: ["test"]

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -127,21 +127,22 @@ tasks:
     name: lint-util
 
 task_groups:
-  - name: lintGroup
+  - name: lint_group
     tasks: [ ".report"]
-    max_hosts: 2
+    max_hosts: 3
+    share_processes: true
     setup_group:
       - func: get-project
     teardown_task:
       - func: parse-results
       - func: run-make
         vars: { target: "clean-results" }
-  - name: testGroup
+  - name: test_group
     tasks: [ ".test"]
-    max_hosts: 2
+    max_hosts: 3
+    share_processes: true   # This ensure that the Docker image pulled in the setup_group is shared between tasks.
     setup_group:
       - func: get-project
-    setup_task:
       - func: run-make
         vars: { target: "docker-setup" }
         variants:
@@ -150,6 +151,7 @@ task_groups:
       - func: parse-results
       - func: run-make
         vars: { target: "clean-results" }
+    teardown_group:
       - func: run-make
         vars: { target: "docker-cleanup" }
         variants:
@@ -172,7 +174,7 @@ buildvariants:
       - archlinux-test
       - archlinux-build
     tasks:
-      - name: "testGroup"
+      - name: test_group
 
   - name: lint
     display_name: Lint (Arch Linux)
@@ -185,7 +187,7 @@ buildvariants:
       - archlinux-test
       - archlinux-build
     tasks: 
-      - name: "lintGroup"
+      - name: lint_group
 
   - name: ubuntu1604
     display_name: Ubuntu 16.04
@@ -199,7 +201,7 @@ buildvariants:
       - ubuntu1604-test
       - ubuntu1604-build
     tasks:
-      - name: "testGroup"
+      - name: test_group
 
   - name: ubuntu1604-go1.9
     display_name: Ubuntu 16.04 (go1.9)
@@ -224,7 +226,7 @@ buildvariants:
     run_on:
       - macos-1014
     tasks:
-      - name: "testGroup"
+      - name: test_group
 
   - name: windows
     display_name: Windows
@@ -239,4 +241,4 @@ buildvariants:
       GO_BIN_PATH: /cygdrive/c/golang/go1.11/bin/go
       make_args: -k
     tasks:
-      - name: "testGroup"
+      - name: test_group

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -43,10 +43,6 @@ type docker struct {
 	signal   syscall.Signal
 }
 
-type DockerOptions struct {
-	Client *client.Client
-}
-
 // NewDocker returns an Executor that creates a process within a Docker
 // container. Callers are expected to clean up resources by calling Close.
 func NewDocker(ctx context.Context, client *client.Client, platform, image string, args []string) Executor {

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -43,6 +43,10 @@ type docker struct {
 	signal   syscall.Signal
 }
 
+type DockerOptions struct {
+	Client *client.Client
+}
+
 // NewDocker returns an Executor that creates a process within a Docker
 // container. Callers are expected to clean up resources by calling Close.
 func NewDocker(ctx context.Context, client *client.Client, platform, image string, args []string) Executor {
@@ -118,6 +122,8 @@ func (e *docker) Start() error {
 	}
 
 	e.setStatus(Running)
+
+	_ = e.getPID()
 
 	return nil
 }
@@ -264,28 +270,40 @@ func (e *docker) Wait() error {
 
 	containerID := e.getContainerID()
 
+	handleContextError := func() (handled bool) {
+		// If the Docker container is killed because the context is done,
+		// treat it the same as the exec implementation that kills it with a
+		// signal.
+		if e.ctx.Err() == nil {
+			return false
+		}
+		e.exitErr = e.ctx.Err()
+		e.signal = syscall.SIGKILL
+		e.setStatus(Exited)
+		return true
+	}
+
 	waitDone, errs := e.client.ContainerWait(e.ctx, containerID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errs:
-		return errors.Wrap(err, "error waiting for container to finish running")
-	case <-e.ctx.Done():
-		if e.ctx.Err() == context.DeadlineExceeded {
-			// If the Docker container is killed by exceeding the process
-			// timeout, treat it the same as a timed-out process that was
-			// killed by a signal.
-			e.exitErr = e.ctx.Err()
-			e.exitCode = int(syscall.SIGKILL)
-			e.signal = syscall.SIGKILL
-			e.setStatus(Exited)
+		if handled := handleContextError(); handled {
 			return e.exitErr
 		}
-		return e.ctx.Err()
+		e.exitErr = err
+		e.setStatus(Exited)
+		return errors.Wrap(err, "error waiting for container to finish running")
+	case <-e.ctx.Done():
+		_ = handleContextError()
+		return e.exitErr
 	case waitResult := <-waitDone:
+		if handled := handleContextError(); handled {
+			return e.exitErr
+		}
 		if waitResult.Error != nil && waitResult.Error.Message != "" {
 			e.exitErr = errors.New(waitResult.Error.Message)
 		} else if waitResult.StatusCode != 0 {
-			// In order to maintain the same semantics as exec.Command, we have to
-			// return an error for non-zero exit codes.
+			// In order to maintain the same semantics as exec.Command, we have
+			// to return an error for non-zero exit codes.
 			e.exitErr = errors.Errorf("exit status %d", waitResult.StatusCode)
 		}
 		e.exitCode = int(waitResult.StatusCode)
@@ -321,6 +339,12 @@ func (e *docker) PID() int {
 		return e.pid
 	}
 
+	return e.getPID()
+}
+
+// getPID makes a request to get the process's runtime PID, which is only
+// available while the container is running.
+func (e *docker) getPID() int {
 	state, err := e.getProcessState()
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
@@ -329,6 +353,7 @@ func (e *docker) PID() int {
 			"container": e.getContainerID(),
 			"executor":  "docker",
 		}))
+		return -1
 	}
 
 	e.pid = state.Pid
@@ -341,6 +366,9 @@ func (e *docker) PID() int {
 func (e *docker) ExitCode() int {
 	if e.exitCode > -1 || !e.getStatus().BetweenInclusive(Running, Exited) {
 		return e.exitCode
+	}
+	if e.getStatus() == Running {
+		return -1
 	}
 
 	state, err := e.getProcessState()

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -269,7 +269,7 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "SignallingProcessPopulatesSignalInfo",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
-				if runtime.GOOS == "windows" && execType == "StandardExec" {
+				if runtime.GOOS == "windows" {
 					t.Skip("The standard library implementation of exec does not support signal detection.")
 				}
 				exec, err := makeExec(ctx, []string{"sleep", "1"})
@@ -304,7 +304,7 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "ProcessThatExitsDueToContextCancellationIsTreatedAsSIGKILLed",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
-				if runtime.GOOS == "windows" && execType == "StandardExec" {
+				if runtime.GOOS == "windows" {
 					t.Skip("The standard library implementation of exec does not support signal detection.")
 				}
 				cctx, ccancel := context.WithCancel(ctx)
@@ -327,7 +327,7 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "ProcessThatExitsDueToContextTimeoutIsTreatedAsSIGKILLed",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
-				if runtime.GOOS == "windows" && execType == "StandardExec" {
+				if runtime.GOOS == "windows" {
 					t.Skip("The standard library implementation of exec does not support signal detection.")
 				}
 				tctx, tcancel := context.WithTimeout(ctx, 500*time.Millisecond)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,358 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/client"
+	"github.com/mongodb/jasper/testutil"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type executorConstructor func(ctx context.Context, args []string) (Executor, error)
+
+func executorTypes() map[string]executorConstructor {
+	return map[string]executorConstructor{
+		"StandardExec": func(ctx context.Context, args []string) (Executor, error) {
+			return NewLocal(ctx, args), nil
+		},
+		"Docker": func(ctx context.Context, args []string) (Executor, error) {
+			client, err := client.NewClientWithOpts(
+				client.WithAPIVersionNegotiation(),
+			)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			image := os.Getenv("DOCKER_IMAGE")
+			if image == "" {
+				image = testutil.DefaultDockerImage
+			}
+			return NewDocker(ctx, client, runtime.GOOS, image, args), nil
+		},
+	}
+}
+
+type executorTestCase struct {
+	Name string
+	Case func(ctx context.Context, t *testing.T, makeExec executorConstructor)
+}
+
+func executorTestCases() []executorTestCase {
+	return []executorTestCase{
+		{
+			Name: "SetAndGetCommandArgsWorkAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				args := []string{"echo", "hello"}
+				exec, err := makeExec(ctx, args)
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				assert.Equal(t, args, exec.Args())
+			},
+		},
+		{
+			Name: "SetAndGetEnvWorkAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"env"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				assert.Empty(t, exec.Env())
+
+				env := []string{"foo=bar", "bat=baz"}
+				exec.SetEnv(env)
+				assert.Equal(t, env, exec.Env())
+				stdout := &bytes.Buffer{}
+				exec.SetStdout(stdout)
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				for _, envVar := range env {
+					assert.Contains(t, stdout.String(), envVar)
+				}
+			},
+		},
+		{
+			Name: "SetAndGetWorkingDirWorkAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				assert.Empty(t, exec.Dir())
+				dir := "/some/dir"
+				exec.SetDir(dir)
+				assert.Equal(t, dir, exec.Dir())
+			},
+		},
+		{
+			Name: "SetAndGetStdoutWorkAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				output := "hello"
+				exec, err := makeExec(ctx, []string{"echo", "-n", output})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				stdout := &bytes.Buffer{}
+				exec.SetStdout(stdout)
+				require.Equal(t, stdout, exec.Stdout())
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				assert.Equal(t, output, stdout.String())
+			},
+		},
+		{
+			Name: "SetStdinWorksAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"tee"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				input := "hello"
+				stdin := bytes.NewBufferString(input)
+				exec.SetStdin(stdin)
+				stdout := &bytes.Buffer{}
+				exec.SetStdout(stdout)
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				assert.Equal(t, input, stdout.String())
+			},
+		},
+		{
+			Name: "SetAndGetStderrWorkAsExpected",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				output := "hello"
+				exec, err := makeExec(ctx, []string{"bash", "-c", fmt.Sprintf("echo -n %s 1>&2", output)})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				stderr := &bytes.Buffer{}
+				exec.SetStderr(stderr)
+				require.Equal(t, stderr, exec.Stderr())
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				assert.Equal(t, output, stderr.String())
+			},
+		},
+		{
+			Name: "RuntimeFieldsAreInvalidBeforeProcessHasRun",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				assert.Equal(t, -1, exec.PID())
+				assert.False(t, exec.Success())
+				assert.Equal(t, -1, exec.ExitCode())
+			},
+		},
+		{
+			Name: "StartBeginsProcessExecution",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"sleep", "1"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				assert.True(t, exec.PID() > 0)
+				assert.False(t, exec.Success())
+				assert.Equal(t, -1, exec.ExitCode())
+			},
+		},
+		{
+			Name: "WaitFailsWithUnstartedProcess",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				assert.Error(t, exec.Wait())
+			},
+		},
+		{
+			Name: "WaitBlocksUntilProcessCompletes",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				assert.True(t, exec.PID() > 0)
+				assert.True(t, exec.Success())
+				assert.Zero(t, exec.ExitCode())
+			},
+		},
+		{
+			Name: "NonZeroExitCodeIsUnsuccessfulProcess",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"false"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				require.Error(t, exec.Wait())
+				assert.False(t, exec.Success())
+				assert.NotZero(t, exec.ExitCode())
+			},
+		},
+		{
+			Name: "ProcessIsUnsignaledByDefault",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				sig, signaled := exec.SignalInfo()
+				assert.False(t, signaled)
+				assert.EqualValues(t, -1, sig)
+			},
+		},
+		{
+			Name: "SignallingProcessPopulatesSignalInfo",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"sleep", "1"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				expected := syscall.SIGKILL
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Signal(expected))
+				assert.Error(t, exec.Wait())
+				sig, signaled := exec.SignalInfo()
+				require.True(t, signaled)
+				assert.Equal(t, expected, sig)
+			},
+		},
+		{
+			Name: "ContextDoneDoesNotCauseCloseToError",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				cctx, ccancel := context.WithCancel(ctx)
+				ccancel()
+				exec, err := makeExec(cctx, []string{"true"})
+				require.NoError(t, err)
+				assert.NoError(t, exec.Close())
+			},
+		},
+		{
+			Name: "StartFailsWhenContextIsDone",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				cctx, ccancel := context.WithCancel(ctx)
+				defer ccancel()
+				exec, err := makeExec(cctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				ccancel()
+				assert.Error(t, exec.Start())
+			},
+		},
+		{
+			Name: "WaitFailsWhenContextIsDone",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				cctx, ccancel := context.WithCancel(ctx)
+				defer ccancel()
+				exec, err := makeExec(cctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				ccancel()
+				assert.Error(t, exec.Wait())
+			},
+		},
+		{
+			Name: "ProcessThatExitsDueToContextCancellationIsTreatedAsSIGKILLed",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				cctx, ccancel := context.WithCancel(ctx)
+				defer ccancel()
+				exec, err := makeExec(cctx, []string{"sleep", "1"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				ccancel()
+				assert.Error(t, exec.Wait())
+				sig, signaled := exec.SignalInfo()
+				assert.True(t, signaled)
+				assert.Equal(t, syscall.SIGKILL, sig)
+			},
+		},
+		{
+			Name: "ProcessThatExitsDueToContextTimeoutIsTreatedAsSIGKILLed",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				tctx, tcancel := context.WithTimeout(ctx, 500*time.Millisecond)
+				defer tcancel()
+				exec, err := makeExec(tctx, []string{"sleep", "1"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				assert.Error(t, exec.Wait())
+				sig, signaled := exec.SignalInfo()
+				assert.True(t, signaled)
+				assert.Equal(t, syscall.SIGKILL, sig)
+			},
+		},
+		{
+			Name: "ProcessCannotBeSignalledAfterCompletion",
+			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				exec, err := makeExec(ctx, []string{"true"})
+				require.NoError(t, err)
+				defer func() {
+					assert.NoError(t, exec.Close())
+				}()
+				require.NoError(t, exec.Start())
+				require.NoError(t, exec.Wait())
+				assert.Error(t, exec.Signal(syscall.SIGKILL))
+				sig, signaled := exec.SignalInfo()
+				assert.False(t, signaled)
+				assert.EqualValues(t, -1, sig)
+			},
+		},
+	}
+}
+
+func TestExecutor(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for execType, makeExec := range executorTypes() {
+		if testutil.IsDockerCase(execType) {
+			testutil.SkipDockerIfUnsupported(t)
+		}
+		t.Run(execType, func(t *testing.T) {
+			for _, testCase := range executorTestCases() {
+				t.Run(testCase.Name, func(t *testing.T) {
+					tctx, tcancel := context.WithTimeout(ctx, testutil.ExecutorTestTimeout)
+					defer tcancel()
+					testCase.Case(tctx, t, makeExec)
+				})
+			}
+		})
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -279,7 +279,7 @@ func executorTestCases() []executorTestCase {
 				require.NoError(t, exec.Signal(expected))
 				assert.Error(t, exec.Wait())
 				sig, signaled := exec.SignalInfo()
-				require.True(t, signaled)
+				assert.True(t, signaled)
 				assert.Equal(t, expected, sig)
 			},
 		},

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -269,6 +269,9 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "SignallingProcessPopulatesSignalInfo",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				if runtime.GOOS == "windows" && execType == "StandardExec" {
+					t.Skip("The standard library implementation of exec does not support signal detection.")
+				}
 				exec, err := makeExec(ctx, []string{"sleep", "1"})
 				require.NoError(t, err)
 				defer func() {
@@ -301,6 +304,9 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "ProcessThatExitsDueToContextCancellationIsTreatedAsSIGKILLed",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				if runtime.GOOS == "windows" && execType == "StandardExec" {
+					t.Skip("The standard library implementation of exec does not support signal detection.")
+				}
 				cctx, ccancel := context.WithCancel(ctx)
 				defer ccancel()
 				exec, err := makeExec(cctx, []string{"sleep", "1"})
@@ -321,6 +327,9 @@ func executorTestCases() []executorTestCase {
 		{
 			Name: "ProcessThatExitsDueToContextTimeoutIsTreatedAsSIGKILLed",
 			Case: func(ctx context.Context, t *testing.T, makeExec executorConstructor) {
+				if runtime.GOOS == "windows" && execType == "StandardExec" {
+					t.Skip("The standard library implementation of exec does not support signal detection.")
+				}
 				tctx, tcancel := context.WithTimeout(ctx, 500*time.Millisecond)
 				defer tcancel()
 				exec, err := makeExec(tctx, []string{"sleep", "1"})

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -330,9 +330,9 @@ func executorTestCases() []executorTestCase {
 				if runtime.GOOS == "windows" {
 					t.Skip("The standard library implementation of exec does not support signal detection.")
 				}
-				tctx, tcancel := context.WithTimeout(ctx, 500*time.Millisecond)
+				tctx, tcancel := context.WithTimeout(ctx, 2*time.Second)
 				defer tcancel()
-				exec, err := makeExec(tctx, []string{"sleep", "1"})
+				exec, err := makeExec(tctx, []string{"sleep", "10"})
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, exec.Close())

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -112,7 +112,10 @@ func (e *local) ExitCode() int {
 	if e.cmd.ProcessState == nil {
 		return -1
 	}
-	return e.cmd.ProcessState.ExitCode()
+	// TODO: this can be just replaced with ProcessState.ExitCode, but requires
+	// go1.12.
+	status := e.cmd.ProcessState.Sys().(syscall.WaitStatus)
+	return status.ExitStatus()
 }
 
 // Success returns whether or not the process ran successfully.

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -77,7 +77,7 @@ func (e *local) SetStderr(stderr io.Writer) {
 }
 
 func (e *local) Stderr() io.Writer {
-	return e.cmd.Stdout
+	return e.cmd.Stderr
 }
 
 // Start begins running the process.

--- a/internal/executor/local.go
+++ b/internal/executor/local.go
@@ -112,8 +112,7 @@ func (e *local) ExitCode() int {
 	if e.cmd.ProcessState == nil {
 		return -1
 	}
-	status := e.cmd.ProcessState.Sys().(syscall.WaitStatus)
-	return status.ExitStatus()
+	return e.cmd.ProcessState.ExitCode()
 }
 
 // Success returns whether or not the process ran successfully.

--- a/makefile
+++ b/makefile
@@ -2,8 +2,8 @@ name := jasper
 buildDir := build
 srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
 testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-testPackages := $(name) cli remote options mock  scripting
-allPackages := $(testPackages) internal-executor remote-internal testutil benchmarks util
+testPackages := $(name) cli remote options mock scripting internal-executor
+allPackages := $(testPackages) remote-internal testutil benchmarks util
 lintPackages := $(allPackages)
 projectPath := github.com/mongodb/jasper
 

--- a/makefile
+++ b/makefile
@@ -133,12 +133,12 @@ ifeq ($(docker_image),)
 endif
 
 docker-setup:
-ifeq (,$(SKIP_DOCKER_TESTS))
+ifneq (true,$(SKIP_DOCKER_TESTS))
 	docker pull $(docker_image)
 endif
 
 docker-cleanup:
-ifeq (,$(SKIP_DOCKER_TESTS))
+ifneq (true,$(SKIP_DOCKER_TESTS))
 	docker rm -f $(docker ps -a -q)
 	docker rmi -f $(docker_image)
 endif

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,7 +95,7 @@ func TestBasicManagerWithTrackedProcesses(t *testing.T) {
 					manager := makeManager(tctx, t)
 					tracker, ok := manager.tracker.(*windowsProcessTracker)
 					require.True(t, ok)
-					testCase(tctx, t, manager, tracker, testutil.SleepCreateOpts(1))
+					testCase(tctx, t, manager, tracker, testoptions.SleepCreateOpts(1))
 				})
 			}
 		})

--- a/options/docker.go
+++ b/options/docker.go
@@ -12,13 +12,13 @@ import (
 
 // Docker encapsulates options related to connecting to a Docker daemon.
 type Docker struct {
-	Host       string
-	Port       int
-	APIVersion string
-	Image      string
+	Host       string `bson:"host,omitempty" json:"host,omitempty" yaml:"host,omitempty"`
+	Port       int    `bson:"port,omitempty" json:"port,omitempty" yaml:"port,omitempty"`
+	APIVersion string `bson:"api_version,omitempty" json:"api_version,omitempty" yaml:"api_version,omitempty"`
+	Image      string `bson:"image,omitempty" json:"image,omitempty" yaml:"image,omitempty"`
 	// Platform refers to the major operating system on which the Docker
 	// container runs.
-	Platform string
+	Platform string `bson:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
 }
 
 // Validate checks whether all the required fields are set and sets defaults if

--- a/process_blocking_test.go
+++ b/process_blocking_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper/internal/executor"
 	"github.com/mongodb/jasper/options"
-	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,7 +191,7 @@ func TestBlockingProcess(t *testing.T) {
 					<-signal
 				},
 				"WaitSomeBeforeCanceling": func(ctx context.Context, t *testing.T, proc *blockingProcess) {
-					proc.info.Options = *testutil.SleepCreateOpts(10)
+					proc.info.Options = *testoptions.SleepCreateOpts(10)
 					proc.complete = make(chan struct{})
 					cctx, cancel := context.WithTimeout(ctx, 600*time.Millisecond)
 					defer cancel()

--- a/process_test.go
+++ b/process_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,9 +39,9 @@ func TestProcessImplementations(t *testing.T) {
 		},
 	} {
 		t.Run(pname, func(t *testing.T) {
-			for optsTestName, modifyOpts := range map[string]testutil.ModifyOpts{
-				"Local": func(opts *options.Create) *options.Create { return opts },
-				"Docker": func(opts *options.Create) *options.Create {
+			for optsTestName, modifyOpts := range map[string]testoptions.ModifyOpts{
+				"LocalExecutor": func(opts *options.Create) *options.Create { return opts },
+				"DockerExecutor": func(opts *options.Create) *options.Create {
 					image := os.Getenv("DOCKER_IMAGE")
 					if image == "" {
 						image = testutil.DefaultDockerImage
@@ -73,7 +74,7 @@ func TestProcessImplementations(t *testing.T) {
 							pctx, pcancel := context.WithTimeout(ctx, 5*time.Second)
 							defer pcancel()
 							startAt := time.Now()
-							opts := testutil.SleepCreateOpts(20)
+							opts := testoptions.SleepCreateOpts(20)
 							proc, err := makep(pctx, opts)
 							require.NoError(t, err)
 							require.NotNil(t, proc)
@@ -112,7 +113,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "WaitGivesProperExitCodeOnSignalAbort",
 						Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-							proc, err := makeProc(ctx, testutil.SleepCreateOpts(5))
+							proc, err := makeProc(ctx, testoptions.SleepCreateOpts(5))
 							require.NoError(t, err)
 							require.NotNil(t, proc)
 							sig := syscall.SIGABRT
@@ -129,7 +130,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "SignalTriggerRunsBeforeSignal",
 						Case: func(ctx context.Context, t *testing.T, _ *options.Create, makep ProcessConstructor) {
-							proc, err := makep(ctx, testutil.SleepCreateOpts(1))
+							proc, err := makep(ctx, testoptions.SleepCreateOpts(1))
 							require.NoError(t, err)
 
 							expectedSig := syscall.SIGKILL
@@ -156,7 +157,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "SignalTriggerCanSkipSignal",
 						Case: func(ctx context.Context, t *testing.T, _ *options.Create, makep ProcessConstructor) {
-							proc, err := makep(ctx, testutil.SleepCreateOpts(1))
+							proc, err := makep(ctx, testoptions.SleepCreateOpts(1))
 							require.NoError(t, err)
 
 							expectedSig := syscall.SIGKILL
@@ -325,7 +326,7 @@ func TestProcessImplementations(t *testing.T) {
 						Name: "TriggersFireOnRespawnedProcessExit",
 						Case: func(ctx context.Context, t *testing.T, _ *options.Create, makep ProcessConstructor) {
 							count := 0
-							opts := testutil.SleepCreateOpts(2)
+							opts := testoptions.SleepCreateOpts(2)
 							proc, err := makep(ctx, opts)
 							require.NoError(t, err)
 							require.NotNil(t, proc)

--- a/remote/client_test.go
+++ b/remote/client_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,8 +83,8 @@ func TestManagerImplementations(t *testing.T) {
 	testCases := append(jasper.ManagerTests(), []jasper.ManagerTestCase{
 		{
 			Name: "WaitingOnNonexistentProcessErrors",
-			Case: func(ctx context.Context, t *testing.T, mngr jasper.Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr jasper.Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
@@ -102,7 +103,7 @@ func TestManagerImplementations(t *testing.T) {
 		},
 		{
 			Name: "RegisterProcessAlwaysErrors",
-			Case: func(ctx context.Context, t *testing.T, mngr jasper.Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr jasper.Manager, modifyOpts testoptions.ModifyOpts) {
 				proc, err := mngr.CreateProcess(ctx, &options.Create{Args: []string{"ls"}})
 				assert.NotNil(t, proc)
 				require.NoError(t, err)
@@ -117,7 +118,7 @@ func TestManagerImplementations(t *testing.T) {
 		t.Run(managerName, func(t *testing.T) {
 			for _, testCase := range testCases {
 				t.Run(testCase.Name, func(t *testing.T) {
-					for optsTestCase, modifyOpts := range map[string]testutil.ModifyOpts{
+					for optsTestCase, modifyOpts := range map[string]testoptions.ModifyOpts{
 						"BlockingProcess": func(opts *options.Create) *options.Create {
 							opts.Implementation = options.ProcessImplementationBlocking
 							return opts
@@ -551,7 +552,7 @@ func TestClientImplementations(t *testing.T) {
 				{
 					Name: "RegisterSignalTriggerIDChecksForInvalidTriggerID",
 					Case: func(ctx context.Context, t *testing.T, mngr Manager) {
-						opts := testutil.SleepCreateOpts(1)
+						opts := testoptions.SleepCreateOpts(1)
 						proc, err := mngr.CreateProcess(ctx, opts)
 						require.NoError(t, err)
 						assert.True(t, proc.Running(ctx))
@@ -564,7 +565,7 @@ func TestClientImplementations(t *testing.T) {
 				{
 					Name: "RegisterSignalTriggerIDPassesWithValidArgs",
 					Case: func(ctx context.Context, t *testing.T, mngr Manager) {
-						opts := testutil.SleepCreateOpts(1)
+						opts := testoptions.SleepCreateOpts(1)
 						proc, err := mngr.CreateProcess(ctx, opts)
 						require.NoError(t, err)
 						assert.True(t, proc.Running(ctx))

--- a/remote/process_test.go
+++ b/remote/process_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestProcessImplementations(t *testing.T) {
 		{
 			Name: "RegisterTriggerFails",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc jasper.ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(3).Args
+				opts.Args = testoptions.SleepCreateOpts(3).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				assert.Error(t, proc.RegisterTrigger(ctx, func(jasper.ProcessInfo) {}))
@@ -34,7 +35,7 @@ func TestProcessImplementations(t *testing.T) {
 		{
 			Name: "RegisterSignalTriggerFails",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc jasper.ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(3).Args
+				opts.Args = testoptions.SleepCreateOpts(3).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				assert.Error(t, proc.RegisterSignalTrigger(ctx, func(jasper.ProcessInfo, syscall.Signal) bool {
@@ -99,7 +100,7 @@ func TestProcessImplementations(t *testing.T) {
 		},
 	} {
 		t.Run(procName, func(t *testing.T) {
-			for optsTestName, modifyOpts := range map[string]testutil.ModifyOpts{
+			for optsTestName, modifyOpts := range map[string]testoptions.ModifyOpts{
 				"BlockingProcess": func(opts *options.Create) *options.Create {
 					opts.Implementation = options.ProcessImplementationBlocking
 					return opts

--- a/remote/rest_service_test.go
+++ b/remote/rest_service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mongodb/jasper/mock"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -253,7 +254,7 @@ func TestRESTService(t *testing.T) {
 			assert.Error(t, proc.Signal(ctx, syscall.SIGTERM))
 		},
 		"SignalErrorsWithInvalidSyscall": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			proc, err := client.CreateProcess(ctx, testutil.SleepCreateOpts(10))
+			proc, err := client.CreateProcess(ctx, testoptions.SleepCreateOpts(10))
 			require.NoError(t, err)
 
 			assert.Error(t, proc.Signal(ctx, syscall.Signal(-1)))
@@ -274,7 +275,7 @@ func TestRESTService(t *testing.T) {
 		},
 		"CreateFailPropagatesErrors": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			srv.manager = &mock.Manager{FailCreate: true}
-			proc, err := client.CreateProcess(ctx, testutil.TrueCreateOpts())
+			proc, err := client.CreateProcess(ctx, testoptions.TrueCreateOpts())
 			assert.Error(t, err)
 			assert.Nil(t, proc)
 			assert.Contains(t, err.Error(), "problem submitting request")
@@ -283,7 +284,7 @@ func TestRESTService(t *testing.T) {
 			srv.manager = &mock.Manager{
 				CreateConfig: mock.Process{FailRegisterTrigger: true},
 			}
-			proc, err := client.CreateProcess(ctx, testutil.TrueCreateOpts())
+			proc, err := client.CreateProcess(ctx, testoptions.TrueCreateOpts())
 			require.Error(t, err)
 			assert.Nil(t, proc)
 			assert.Contains(t, err.Error(), "problem registering trigger")
@@ -438,7 +439,7 @@ func TestRESTService(t *testing.T) {
 			absDir, err := filepath.Abs(dir)
 			require.NoError(t, err)
 
-			opts := testutil.ValidMongoDBDownloadOptions()
+			opts := testoptions.ValidMongoDBDownloadOptions()
 			opts.Path = absDir
 
 			err = client.DownloadMongoDB(ctx, opts)

--- a/remote/scripting_test.go
+++ b/remote/scripting_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/jasper/scripting"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -149,7 +150,7 @@ func TestScripting(t *testing.T) {
 }
 
 func createTestScriptingHarness(ctx context.Context, t *testing.T, client Manager, dir string) scripting.Harness {
-	opts := testutil.ValidGolangScriptingHarnessOptions(dir)
+	opts := testoptions.ValidGolangScriptingHarnessOptions(dir)
 	sh, err := client.CreateScripting(ctx, opts)
 	require.NoError(t, err)
 	return sh

--- a/testcase.go
+++ b/testcase.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,7 +91,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "InfoHasTimeoutWhenProcessTimesOut",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(5).Args
+				opts.Args = testoptions.SleepCreateOpts(5).Args
 				opts.Timeout = time.Second
 				opts.TimeoutSecs = 1
 				proc, err := makeProc(ctx, opts)
@@ -161,7 +162,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "WaitReturnsErrorWithCanceledContext",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(20).Args
+				opts.Args = testoptions.SleepCreateOpts(20).Args
 				pctx, pcancel := context.WithCancel(ctx)
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
@@ -210,7 +211,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "RegisterSignalTriggerIDFailsWithInvalidTriggerID",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(3).Args
+				opts.Args = testoptions.SleepCreateOpts(3).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				assert.Error(t, proc.RegisterSignalTriggerID(ctx, SignalTriggerID("foo")))
@@ -219,7 +220,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "RegisterSignalTriggerIDPassesWithValidTriggerID",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(3).Args
+				opts.Args = testoptions.SleepCreateOpts(3).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				assert.NoError(t, proc.RegisterSignalTriggerID(ctx, CleanTerminationSignalTrigger))
@@ -278,7 +279,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "RespawningRunningProcessIsOK",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(2).Args
+				opts.Args = testoptions.SleepCreateOpts(2).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				require.NotNil(t, proc)
@@ -294,7 +295,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "RespawnShowsConsistentStateValues",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.SleepCreateOpts(2).Args
+				opts.Args = testoptions.SleepCreateOpts(2).Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				require.NotNil(t, proc)
@@ -312,7 +313,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "WaitGivesSuccessfulExitCode",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.TrueCreateOpts().Args
+				opts.Args = testoptions.TrueCreateOpts().Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				require.NotNil(t, proc)
@@ -324,7 +325,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "WaitGivesFailureExitCode",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				opts.Args = testutil.FalseCreateOpts().Args
+				opts.Args = testoptions.FalseCreateOpts().Args
 				proc, err := makeProc(ctx, opts)
 				require.NoError(t, err)
 				require.NotNil(t, proc)
@@ -336,7 +337,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "WaitGivesProperExitCodeOnSignalTerminate",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				proc, err := makeProc(ctx, testutil.SleepCreateOpts(5))
+				proc, err := makeProc(ctx, testoptions.SleepCreateOpts(5))
 				require.NoError(t, err)
 				require.NotNil(t, proc)
 				sig := syscall.SIGTERM
@@ -353,7 +354,7 @@ func ProcessTests() []ProcessTestCase {
 		{
 			Name: "WaitGivesNegativeOneOnAlternativeError",
 			Case: func(ctx context.Context, t *testing.T, opts *options.Create, makeProc ProcessConstructor) {
-				proc, err := makeProc(ctx, testutil.SleepCreateOpts(5))
+				proc, err := makeProc(ctx, testoptions.SleepCreateOpts(5))
 				require.NoError(t, err)
 				require.NotNil(t, proc)
 
@@ -395,10 +396,10 @@ func ProcessTests() []ProcessTestCase {
 }
 
 // ManagerTestCase represents a test case including a manager and
-// testutil.ModifyOpts to modify process creation options.
+// options.ModifyOpts to modify process creation options.
 type ManagerTestCase struct {
 	Name string
-	Case func(context.Context, *testing.T, Manager, testutil.ModifyOpts)
+	Case func(context.Context, *testing.T, Manager, testoptions.ModifyOpts)
 }
 
 // ManagerTests returns the common test suite for the Manager interface. This
@@ -407,7 +408,7 @@ func ManagerTests() []ManagerTestCase {
 	return []ManagerTestCase{
 		{
 			Name: "ValidateFixture",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				assert.NotNil(t, ctx)
 				assert.NotNil(t, mngr)
 				assert.NotNil(t, mngr.LoggingCache(ctx))
@@ -415,14 +416,14 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "IDReturnsNonempty",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				assert.NotEmpty(t, mngr.ID())
 			},
 		},
 		{
 			Name: "ProcEnvVarMatchesManagerID",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 				info := proc.Info(ctx)
@@ -432,7 +433,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CreateProcessFailsWithEmptyOptions",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				opts := modifyOpts(&options.Create{})
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.Error(t, err)
@@ -441,8 +442,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CreateSimpleProcess",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 				assert.NotNil(t, proc)
@@ -452,7 +453,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListWithoutResultsDoesNotError",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				procs, err := mngr.List(ctx, options.All)
 				require.NoError(t, err)
 				assert.Len(t, procs, 0)
@@ -460,8 +461,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListAllProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				created, err := createProcs(ctx, opts, mngr, 10)
 				require.NoError(t, err)
 				assert.Len(t, created, 10)
@@ -472,8 +473,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListAllErrorsWithCanceledContext",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				created, err := createProcs(ctx, opts, mngr, 10)
 				require.NoError(t, err)
 				assert.Len(t, created, 10)
@@ -487,8 +488,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "LongRunningProcessesAreListedAsRunning",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.SleepCreateOpts(20))
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.SleepCreateOpts(20))
 				procs, err := createProcs(ctx, opts, mngr, 10)
 				require.NoError(t, err)
 				assert.Len(t, procs, 10)
@@ -508,8 +509,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListReturnsOneSuccessfulProcess",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
@@ -526,8 +527,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListReturnsOneFailedProcess",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.FalseCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.FalseCreateOpts())
 
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
@@ -543,7 +544,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ListErrorsWithInvalidFilter",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				procs, err := mngr.List(ctx, options.Filter("foo"))
 				assert.Error(t, err)
 				assert.Empty(t, procs)
@@ -551,7 +552,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "GetProcessErrorsWithNonexistentProcess",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				proc, err := mngr.Get(ctx, "foo")
 				require.Error(t, err)
 				assert.Nil(t, proc)
@@ -559,8 +560,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "GetProcessReturnsMatchingProcess",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 
@@ -571,7 +572,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "GroupWithoutResultsDoesNotError",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				procs, err := mngr.Group(ctx, "foo")
 				require.NoError(t, err)
 				assert.Len(t, procs, 0)
@@ -579,8 +580,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "GroupErrorsWithCanceledContext",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				_, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 
@@ -593,8 +594,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "GroupReturnsMatchingProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 				proc.Tag("foo")
@@ -607,14 +608,14 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CloseEmptyManagerNoops",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, moidfyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, moidfyOpts testoptions.ModifyOpts) {
 				assert.NoError(t, mngr.Close(ctx))
 			},
 		},
 		{
 			Name: "CloseErrorsWithCanceledContext",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.SleepCreateOpts(5))
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.SleepCreateOpts(5))
 				_, err := createProcs(ctx, opts, mngr, 10)
 				require.NoError(t, err)
 
@@ -626,8 +627,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CloseSucceedsWithTerminatedProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				procs, err := createProcs(ctx, opts, mngr, 10)
 				for _, proc := range procs {
 					_, err = proc.Wait(ctx)
@@ -640,11 +641,11 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CloseSucceedsOnRunningProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				if runtime.GOOS == "windows" {
 					t.Skip("manager close tests will error due to process termination on Windows")
 				}
-				opts := modifyOpts(testutil.SleepCreateOpts(5))
+				opts := modifyOpts(testoptions.SleepCreateOpts(5))
 
 				_, err := createProcs(ctx, opts, mngr, 10)
 				require.NoError(t, err)
@@ -653,8 +654,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ClearCausesDeletionOfCompletedProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.TrueCreateOpts())
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 
@@ -673,8 +674,8 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ClearIsANoopForRunningProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				opts := modifyOpts(testutil.SleepCreateOpts(5))
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				opts := modifyOpts(testoptions.SleepCreateOpts(5))
 				proc, err := mngr.CreateProcess(ctx, opts)
 				require.NoError(t, err)
 
@@ -686,12 +687,12 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "ClearSelectivelyDeletesOnlyCompletedProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
-				trueOpts := modifyOpts(testutil.TrueCreateOpts())
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
+				trueOpts := modifyOpts(testoptions.TrueCreateOpts())
 				trueProc, err := mngr.CreateProcess(ctx, trueOpts)
 				require.NoError(t, err)
 
-				sleepOpts := modifyOpts(testutil.SleepCreateOpts(5))
+				sleepOpts := modifyOpts(testoptions.SleepCreateOpts(5))
 				sleepProc, err := mngr.CreateProcess(ctx, sleepOpts)
 				require.NoError(t, err)
 
@@ -713,18 +714,18 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "CreateCommandPasses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				cmd := mngr.CreateCommand(ctx)
-				args := testutil.TrueCreateOpts().Args
+				args := testoptions.TrueCreateOpts().Args
 				cmd.ApplyFromOpts(modifyOpts(&options.Create{})).Add(args)
 				assert.NoError(t, cmd.Run(ctx))
 			},
 		},
 		{
 			Name: "RunningCommandCreatesNewProcesses",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				cmd := mngr.CreateCommand(ctx)
-				trueCmd := testutil.TrueCreateOpts().Args
+				trueCmd := testoptions.TrueCreateOpts().Args
 				subCmds := [][]string{trueCmd, trueCmd, trueCmd}
 				cmd.ApplyFromOpts(modifyOpts(&options.Create{})).Extend(subCmds)
 				require.NoError(t, cmd.Run(ctx))
@@ -738,9 +739,9 @@ func ManagerTests() []ManagerTestCase {
 		{
 
 			Name: "CommandProcessIDsMatchManagedProcessIDs",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				cmd := mngr.CreateCommand(ctx)
-				trueCmd := testutil.TrueCreateOpts().Args
+				trueCmd := testoptions.TrueCreateOpts().Args
 				subCmds := [][]string{trueCmd, trueCmd, trueCmd}
 				cmd.ApplyFromOpts(modifyOpts(&options.Create{})).Extend(subCmds)
 				require.NoError(t, cmd.Run(ctx))
@@ -764,7 +765,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileSucceeds",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
@@ -783,7 +784,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileAcceptsContentFromReader",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
@@ -803,7 +804,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileSucceedsWithLargeContent",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
@@ -823,7 +824,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileSucceedsWithLargeContentFromReader",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
@@ -844,7 +845,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileSucceedsWithNoContent",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				path := filepath.Join(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, os.RemoveAll(path))
 				defer func() {
@@ -862,7 +863,7 @@ func ManagerTests() []ManagerTestCase {
 		},
 		{
 			Name: "WriteFileFailsWithInvalidPath",
-			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testutil.ModifyOpts) {
+			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
 				opts := options.WriteFile{Content: []byte("foo")}
 				assert.Error(t, mngr.WriteFile(ctx, opts))
 			},

--- a/testutil/constants.go
+++ b/testutil/constants.go
@@ -4,9 +4,10 @@ import "time"
 
 // Constants for test timeouts.
 const (
-	TestTimeout        = 5 * time.Second
-	RPCTestTimeout     = 30 * time.Second
-	ProcessTestTimeout = 15 * time.Second
-	ManagerTestTimeout = 5 * TestTimeout
-	LongTestTimeout    = 100 * time.Second
+	TestTimeout         = 5 * time.Second
+	RPCTestTimeout      = 30 * time.Second
+	ProcessTestTimeout  = 15 * time.Second
+	ManagerTestTimeout  = 5 * TestTimeout
+	ExecutorTestTimeout = 5 * time.Second
+	LongTestTimeout     = 100 * time.Second
 )

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -19,7 +19,10 @@ func IsDockerCase(testName string) bool {
 // SkipDockerIfUnsupported skips the test if the platform is not Linux or the
 // SKIP_DOCKER_TESTS environment variable is explicitly set.
 func SkipDockerIfUnsupported(t *testing.T) {
-	skip, _ := strconv.ParseBool(os.Getenv("SKIP_DOCKER_TESTS"))
+	skip, err := strconv.ParseBool(os.Getenv("SKIP_DOCKER_TESTS"))
+	if err == nil && !skip {
+		return
+	}
 	if runtime.GOOS != "linux" || skip {
 		t.Skip("skipping Docker tests on non-Linux platforms since testing CI infrastructure only supports Docker on Linux currently")
 	}

--- a/testutil/options/options.go
+++ b/testutil/options/options.go
@@ -1,4 +1,4 @@
-package testutil
+package options
 
 import (
 	"fmt"

--- a/tracker_linux_test.go
+++ b/tracker_linux_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -125,7 +126,7 @@ func TestLinuxProcessTrackerWithCgroups(t *testing.T) {
 					require.NoError(t, tracker.Add(proc.Info(ctx)))
 					require.NoError(t, tracker.Cleanup())
 
-					newProc, err := makeProc(ctx, testutil.SleepCreateOpts(1))
+					newProc, err := makeProc(ctx, testoptions.SleepCreateOpts(1))
 					require.NoError(t, err)
 
 					require.NoError(t, tracker.Add(newProc.Info(ctx)))
@@ -139,7 +140,7 @@ func TestLinuxProcessTrackerWithCgroups(t *testing.T) {
 					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 
-					opts := testutil.SleepCreateOpts(1)
+					opts := testoptions.SleepCreateOpts(1)
 					proc, err := makeProc(ctx, opts)
 					require.NoError(t, err)
 
@@ -222,7 +223,7 @@ func TestLinuxProcessTrackerWithEnvironmentVariables(t *testing.T) {
 					// Override default cgroup behavior.
 					linuxTracker.cgroup = nil
 
-					testCase(ctx, t, linuxTracker, testutil.SleepCreateOpts(1), ManagerEnvironID, envVarValue)
+					testCase(ctx, t, linuxTracker, testoptions.SleepCreateOpts(1), ManagerEnvironID, envVarValue)
 				})
 			}
 		})
@@ -249,7 +250,7 @@ func TestManagerSetsEnvironmentVariables(t *testing.T) {
 		t.Run(managerName, func(t *testing.T) {
 			for testName, testCase := range map[string]func(context.Context, *testing.T, *basicProcessManager){
 				"CreateProcessSetsManagerEnvironmentVariables": func(ctx context.Context, t *testing.T, manager *basicProcessManager) {
-					proc, err := manager.CreateProcess(ctx, testutil.SleepCreateOpts(1))
+					proc, err := manager.CreateProcess(ctx, testoptions.SleepCreateOpts(1))
 					require.NoError(t, err)
 
 					env := proc.Info(ctx).Options.Environment

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -122,7 +123,7 @@ func TestWindowsProcessTracker(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, tracker)
 
-			testCase(ctx, t, tracker, testutil.SleepCreateOpts(1))
+			testCase(ctx, t, tracker, testoptions.SleepCreateOpts(1))
 		})
 	}
 }

--- a/triggers_test.go
+++ b/triggers_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/mongodb/jasper/options"
-	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,12 +21,12 @@ func TestDefaultTrigger(t *testing.T) {
 			out, err := mngr.List(ctx, options.All)
 			require.NoError(t, err)
 			assert.Empty(t, out)
-			assert.NotNil(t, makeDefaultTrigger(ctx, mngr, testutil.TrueCreateOpts(), parentID))
+			assert.NotNil(t, makeDefaultTrigger(ctx, mngr, testoptions.TrueCreateOpts(), parentID))
 			assert.NotNil(t, makeDefaultTrigger(ctx, mngr, nil, ""))
 		},
 		"OneOnFailure": func(ctx context.Context, t *testing.T, mngr Manager) {
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnFailure = append(opts.OnFailure, tcmd)
 			trigger := makeDefaultTrigger(ctx, mngr, opts, parentID)
 			trigger(ProcessInfo{})
@@ -40,8 +40,8 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.True(t, info.IsRunning || info.Complete)
 		},
 		"OneOnSuccess": func(ctx context.Context, t *testing.T, mngr Manager) {
-			opts := testutil.TrueCreateOpts()
-			tcmd := testutil.FalseCreateOpts()
+			opts := testoptions.TrueCreateOpts()
+			tcmd := testoptions.FalseCreateOpts()
 			opts.OnSuccess = append(opts.OnSuccess, tcmd)
 			trigger := makeDefaultTrigger(ctx, mngr, opts, parentID)
 			trigger(ProcessInfo{Successful: true})
@@ -55,8 +55,8 @@ func TestDefaultTrigger(t *testing.T) {
 		"FailureTriggerDoesNotWorkWithCanceledContext": func(ctx context.Context, t *testing.T, mngr Manager) {
 			cctx, cancel := context.WithCancel(ctx)
 			cancel()
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnFailure = append(opts.OnFailure, tcmd)
 			trigger := makeDefaultTrigger(cctx, mngr, opts, parentID)
 			trigger(ProcessInfo{})
@@ -68,8 +68,8 @@ func TestDefaultTrigger(t *testing.T) {
 		"SuccessTriggerDoesNotWorkWithCanceledContext": func(ctx context.Context, t *testing.T, mngr Manager) {
 			cctx, cancel := context.WithCancel(ctx)
 			cancel()
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnSuccess = append(opts.OnSuccess, tcmd)
 			trigger := makeDefaultTrigger(cctx, mngr, opts, parentID)
 			trigger(ProcessInfo{Successful: true})
@@ -79,22 +79,22 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.Empty(t, out)
 		},
 		"SuccessOutcomeWithNoTriggers": func(ctx context.Context, t *testing.T, mngr Manager) {
-			trigger := makeDefaultTrigger(ctx, mngr, testutil.TrueCreateOpts(), parentID)
+			trigger := makeDefaultTrigger(ctx, mngr, testoptions.TrueCreateOpts(), parentID)
 			trigger(ProcessInfo{})
 			out, err := mngr.List(ctx, options.All)
 			require.NoError(t, err)
 			assert.Empty(t, out)
 		},
 		"FailureOutcomeWithNoTriggers": func(ctx context.Context, t *testing.T, mngr Manager) {
-			trigger := makeDefaultTrigger(ctx, mngr, testutil.TrueCreateOpts(), parentID)
+			trigger := makeDefaultTrigger(ctx, mngr, testoptions.TrueCreateOpts(), parentID)
 			trigger(ProcessInfo{Successful: true})
 			out, err := mngr.List(ctx, options.All)
 			require.NoError(t, err)
 			assert.Empty(t, out)
 		},
 		"TimeoutWithTimeout": func(ctx context.Context, t *testing.T, mngr Manager) {
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnTimeout = append(opts.OnTimeout, tcmd)
 
 			tctx, cancel := context.WithTimeout(ctx, time.Second)
@@ -111,8 +111,8 @@ func TestDefaultTrigger(t *testing.T) {
 			assert.True(t, info.IsRunning || info.Complete)
 		},
 		"TimeoutWithoutTimeout": func(ctx context.Context, t *testing.T, mngr Manager) {
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnTimeout = append(opts.OnTimeout, tcmd)
 
 			trigger := makeDefaultTrigger(ctx, mngr, opts, parentID)
@@ -130,8 +130,8 @@ func TestDefaultTrigger(t *testing.T) {
 			cctx, cancel := context.WithCancel(ctx)
 			cancel()
 
-			opts := testutil.FalseCreateOpts()
-			tcmd := testutil.TrueCreateOpts()
+			opts := testoptions.FalseCreateOpts()
+			tcmd := testoptions.TrueCreateOpts()
 			opts.OnTimeout = append(opts.OnTimeout, tcmd)
 
 			trigger := makeDefaultTrigger(cctx, mngr, opts, parentID)

--- a/triggers_windows_test.go
+++ b/triggers_windows_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
+	testoptions "github.com/mongodb/jasper/testutil/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestCleanTerminationSignalTrigger(t *testing.T) {
 					assert.NoError(t, proc.Signal(ctx, syscall.SIGKILL))
 				},
 				"CleanTerminationFailsForExitedProcess": func(ctx context.Context, opts *options.Create, makep ProcessConstructor) {
-					opts = testutil.TrueCreateOpts()
+					opts = testoptions.TrueCreateOpts()
 					proc, err := makep(ctx, opts)
 					require.NoError(t, err)
 
@@ -59,7 +60,7 @@ func TestCleanTerminationSignalTrigger(t *testing.T) {
 					ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 					defer cancel()
 
-					testCase(ctx, testutil.SleepCreateOpts(1), makeProc)
+					testCase(ctx, testoptions.SleepCreateOpts(1), makeProc)
 				})
 			}
 		})


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13684

* Write tests for executor interface (which is the layer below the `jasper.Process` implementations).
* Fix some discrepancies in behavior between the standard library exec library and Docker library executors.
* Move around some testutil options into a new package to avoid circular dependencies.