### PR TITLE
EVG-13672: return error message from Wait() in REST service

### DIFF
--- a/remote/rest_client_process.go
+++ b/remote/rest_client_process.go
@@ -65,16 +65,14 @@ func (p *restProcess) Wait(ctx context.Context) (int, error) {
 	}
 	defer resp.Body.Close()
 
-	// TODO (EVG-13672): REST service should return both exit code and error
-	// text.
-	var exitCode int
-	if err = gimlet.GetJSON(resp.Body, &exitCode); err != nil {
-		return -1, errors.Wrap(err, "failed to read exit code from response")
+	var waitResp restWaitResponse
+	if err = gimlet.GetJSON(resp.Body, &waitResp); err != nil {
+		return -1, errors.Wrap(err, "reading response from wait")
 	}
-	if exitCode != 0 {
-		return exitCode, errors.New("operation failed")
+	if waitResp.Error != "" {
+		return waitResp.ExitCode, errors.New(waitResp.Error)
 	}
-	return exitCode, nil
+	return waitResp.ExitCode, nil
 }
 
 func (p *restProcess) Respawn(ctx context.Context) (jasper.Process, error) {

--- a/remote/rest_service.go
+++ b/remote/rest_service.go
@@ -415,6 +415,11 @@ func (s *Service) addProcessTag(rw http.ResponseWriter, r *http.Request) {
 	gimlet.WriteJSON(rw, struct{}{})
 }
 
+type restWaitResponse struct {
+	Error    string `json:"error,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
+}
+
 func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["id"]
 	ctx := r.Context()
@@ -428,15 +433,15 @@ func (s *Service) waitForProcess(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	exitCode, err := proc.Wait(ctx)
-	if err != nil && exitCode == -1 {
-		writeError(rw, gimlet.ErrorResponse{
-			StatusCode: http.StatusBadRequest,
-			Message:    err.Error(),
+	if err != nil {
+		gimlet.WriteJSON(rw, restWaitResponse{
+			Error:    err.Error(),
+			ExitCode: exitCode,
 		})
 		return
 	}
 
-	gimlet.WriteJSON(rw, exitCode)
+	gimlet.WriteJSON(rw, restWaitResponse{ExitCode: exitCode})
 }
 
 func (s *Service) respawnProcess(rw http.ResponseWriter, r *http.Request) {

--- a/remote/rest_service_test.go
+++ b/remote/rest_service_test.go
@@ -176,7 +176,6 @@ func TestRESTService(t *testing.T) {
 			assert.Contains(t, err.Error(), "problem building request")
 		},
 		"ProcessRequestsFailWithBadURL": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-
 			client.prefix = strings.Replace(client.prefix, "http://", "http;//", 1)
 
 			proc := &restProcess{
@@ -338,7 +337,6 @@ func TestRESTService(t *testing.T) {
 
 			err := proc.Signal(ctx, syscall.SIGTERM)
 			assert.NoError(t, err)
-
 		},
 		"SignalFailsToParsePID": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			req, err := http.NewRequest(http.MethodPatch, client.getURL("/process/%s/signal/f", "foo"), nil)
@@ -362,20 +360,6 @@ func TestRESTService(t *testing.T) {
 			rw := httptest.NewRecorder()
 			srv.downloadFile(rw, req)
 			assert.Equal(t, http.StatusBadRequest, rw.Code)
-		},
-		"GetLogStreamFailsWithoutInMemoryLogger": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			opts := &options.Create{Args: []string{"echo", "foo"}}
-
-			proc, err := client.CreateProcess(ctx, opts)
-			require.NoError(t, err)
-			require.NotNil(t, proc)
-
-			_, err = proc.Wait(ctx)
-			require.NoError(t, err)
-
-			stream, err := client.GetLogStream(ctx, proc.ID(), 1)
-			assert.Error(t, err)
-			assert.Zero(t, stream)
 		},
 		"InitialCacheOptionsMatchDefault": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
 			assert.Equal(t, jasper.DefaultMaxCacheSize, srv.cacheOpts.MaxSize)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13672

The REST service used to just return the exit code, which is not as useful as getting the original error text as well from `Wait`. This makes the REST interface behave the same as the other interfaces.