### PR TITLE
EVG-13734 report OOM lines

### DIFF
--- a/mock/oom_tracker.go
+++ b/mock/oom_tracker.go
@@ -29,7 +29,7 @@ func (o *OOMTracker) Clear(context.Context) error {
 	return nil
 }
 
-// Report returns the value of the WasOOMKilled and PIDs fields.
+// Report returns the value of the Lines and PIDs fields.
 func (o *OOMTracker) Report() ([]string, []int) {
 	return o.Lines, o.PIDs
 }

--- a/mock/oom_tracker.go
+++ b/mock/oom_tracker.go
@@ -5,10 +5,10 @@ import "context"
 // OOMTracker provides a mock implementation of OOM detection for
 // testing.
 type OOMTracker struct {
-	PIDs         []int
-	WasOOMKilled bool
-	FailCheck    bool
-	FailClear    bool
+	PIDs      []int
+	Lines     []string
+	FailCheck bool
+	FailClear bool
 }
 
 // Check returns an error if FailCheck is set, nil otherwise.
@@ -30,6 +30,6 @@ func (o *OOMTracker) Clear(context.Context) error {
 }
 
 // Report returns the value of the WasOOMKilled and PIDs fields.
-func (o *OOMTracker) Report() (bool, []int) {
-	return o.WasOOMKilled, o.PIDs
+func (o *OOMTracker) Report() ([]string, []int) {
+	return o.Lines, o.PIDs
 }

--- a/oom_tracker_darwin.go
+++ b/oom_tracker_darwin.go
@@ -31,11 +31,11 @@ func (o *oomTrackerImpl) Check(ctx context.Context) error {
 		lineHasOOMKill: logContainsOOMKill,
 		extractPID:     getPIDFromLog,
 	}
-	wasOOMKilled, pids, err := analyzer.analyzeKernelLog(ctx)
+	lines, pids, err := analyzer.analyzeKernelLog(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error searching log")
 	}
-	o.WasOOMKilled = wasOOMKilled
+	o.Lines = lines
 	o.PIDs = pids
 	return nil
 }

--- a/oom_tracker_linux.go
+++ b/oom_tracker_linux.go
@@ -31,11 +31,11 @@ func (o *oomTrackerImpl) Check(ctx context.Context) error {
 		lineHasOOMKill: dmesgContainsOOMKill,
 		extractPID:     getPIDFromDmesg,
 	}
-	wasOOMKilled, pids, err := analyzer.analyzeKernelLog(ctx)
+	lines, pids, err := analyzer.analyzeKernelLog(ctx)
 	if err != nil {
 		return errors.Wrap(err, "error searching log")
 	}
-	o.WasOOMKilled = wasOOMKilled
+	o.Lines = lines
 	o.PIDs = pids
 	return nil
 }


### PR DESCRIPTION
Include the actual lines from dmesg so the agent can print them in the logs.
Continue to parse out the PIDs though, since they're sent back to the app server and displayed on the task page.