### PR TITLE
EVG-14467 Add M1 Mac build variant

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -228,6 +228,18 @@ buildvariants:
     tasks:
       - name: test_group
 
+  - name: macos-1100-arm64
+    display_name: macOS 11.00 Arm64
+    expansions:
+      DISABLE_COVERAGE: true
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      make_args: -k
+    run_on:
+      - macos-1100-arm64
+    tasks:
+      - name: test_group
+
   - name: windows
     display_name: Windows
     run_on:


### PR DESCRIPTION
This is for the new M1 Macs thee BUILD team received. 
I can't create a patch in Evergreen because these hosts can't be added yet (no Jasper for M1 yet)