### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -33,7 +33,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/jasper
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "DOCKER_IMAGE", "GO_BIN_PATH", "GOROOT"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "DOCKER_IMAGE", "GO_BIN_PATH", "GOROOT", "SKIP_DOCKER_TESTS"]
       env:
         GOPATH: ${workdir}/gopath
   parse-results:

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -139,7 +139,7 @@ task_groups:
       - func: run-make
         vars: { target: "docker-setup" }
         variants:
-          - ubuntu1604
+          - ubuntu
     teardown_task:
       - func: parse-results
       - func: run-make
@@ -148,7 +148,7 @@ task_groups:
       - func: run-make
         vars: { target: "docker-cleanup" }
         variants:
-          - ubuntu1604
+          - ubuntu
 
 #######################################
 #           Buildvariants             #
@@ -180,7 +180,7 @@ buildvariants:
     tasks: 
       - name: lint_group
 
-  - name: ubuntu1604
+  - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -32,8 +32,8 @@ functions:
     params:
       working_dir: gopath/src/github.com/mongodb/jasper
       binary: make
-      args: ["${make_args|}", "${target}"]
-      add_expansions_to_env: true
+      args: ["${target}"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "DOCKER_IMAGE", "GO_BIN_PATH", "GOROOT"]
       env:
         GOPATH: ${workdir}/gopath
   parse-results:
@@ -74,13 +74,6 @@ tasks:
   - <<: *run-build
     tags: ["test"]
     name: test-scripting
-
-  - name: compile-base
-    tags: ["legacy-check"]
-    commands:
-      - func: get-project
-      - func: run-make
-        vars: { target: "${task_name}" }
 
   - <<: *run-build
     tags: ["report"]
@@ -165,11 +158,10 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.13
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       RACE_DETECTOR: true
       SKIP_DOCKER_TESTS: true
-      make_args: -k
     run_on:
       - archlinux-new-small
       - archlinux-new-large
@@ -180,9 +172,8 @@ buildvariants:
     display_name: Lint (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.13
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      make_args: -k
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - archlinux-new-small
       - archlinux-new-large
@@ -190,39 +181,24 @@ buildvariants:
       - name: lint_group
 
   - name: ubuntu1604
-    display_name: Ubuntu 16.04
+    display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.11
-      GO_BIN_PATH: /opt/golang/go1.11/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       DOCKER_IMAGE: ubuntu
-      make_args: -k
     run_on:
-      - ubuntu1604-test
-      - ubuntu1604-build
+      - ubuntu1804-small
+      - ubuntu1804-large
     tasks:
       - name: test_group
-
-  - name: ubuntu1604-go1.9
-    display_name: Ubuntu 16.04 (go1.9)
-    expansions:
-      DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.9
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      make_args: -k
-    run_on:
-      - ubuntu1604-test
-      - ubuntu1604-build
-    tasks:
-      - name: ".legacy-check"
 
   - name: macos
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.11
-      GO_BIN_PATH: /opt/golang/go1.11/bin/go
-      make_args: -k
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - macos-1014
     tasks:
@@ -237,8 +213,7 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: C:/golang/go1.11
-      GO_BIN_PATH: /cygdrive/c/golang/go1.11/bin/go
-      make_args: -k
+      GOROOT: C:/golang/go1.16
+      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
     tasks:
       - name: test_group

--- a/makefile
+++ b/makefile
@@ -57,7 +57,7 @@ lint-%: $(buildDir)/output.%.lint
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets

--- a/makefile
+++ b/makefile
@@ -24,6 +24,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 
@@ -40,8 +41,6 @@ coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(targ
 
 compile $(buildDir): $(srcFiles)
 	$(gobin) build $(_compilePackages)
-compile-base:
-	$(gobin) build ./
 
 # convenience targets for runing tests and coverage tasks on a
 # specific package.


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.