### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -33,7 +33,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/jasper
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "DOCKER_IMAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR", "SKIP_DOCKER_TESTS"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "DOCKER_IMAGE", "GOROOT", "RACE_DETECTOR", "SKIP_DOCKER_TESTS"]
       env:
         GOPATH: ${workdir}/gopath
   parse-results:
@@ -159,7 +159,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       RACE_DETECTOR: true
       SKIP_DOCKER_TESTS: true
     run_on:
@@ -173,7 +172,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - archlinux-new-small
       - archlinux-new-large
@@ -185,7 +183,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       DOCKER_IMAGE: ubuntu
     run_on:
       - ubuntu1804-small
@@ -198,7 +195,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - macos-1014
     tasks:
@@ -214,6 +210,5 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
     tasks:
       - name: test_group

--- a/makefile
+++ b/makefile
@@ -1,58 +1,35 @@
+# start project configuration
 name := jasper
 buildDir := build
 srcFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "*\#*")
-testFiles := $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-testPackages := $(name) cli remote options mock scripting internal-executor
 allPackages := $(testPackages) remote-internal testutil benchmarks util
+compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(allPackages),./$(target))))
+testPackages := $(name) cli remote options mock scripting internal-executor
 lintPackages := $(allPackages)
 projectPath := github.com/mongodb/jasper
+# end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq ($(gobin),)
 gobin := go
-endif
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
-goroot := $(GOROOT)
-ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
-export GOROOT := $(goroot)
+ifeq ($(OS),Windows_NT)
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
+endif
+
 export GO111MODULE := off
 # end environment setup
-
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-
-_compilePackages := $(subst $(name),,$(subst -,/,$(foreach target,$(allPackages),./$(target))))
-testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
-lintOutput := $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
-coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
-
-
-compile $(buildDir): $(srcFiles)
-	$(gobin) build $(_compilePackages)
-
-# convenience targets for runing tests and coverage tasks on a
-# specific package.
-test-%: $(buildDir)/output.%.test
-	
-coverage-%: $(buildDir)/output.%.coverage
-	
-html-coverage-%: $(buildDir)/output.%.coverage.html
-	
-lint-%: $(buildDir)/output.%.lint
-	
-# end convienence targets
+.DEFAULT_GOAL: compile
 
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint
@@ -73,10 +50,42 @@ $(buildDir)/$(name): cmd/$(name)/$(name).go $(srcFiles)
 	$(gobin) build -o $@ $<
 # end cli targets
 
+# start output files
+testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
+lintOutput := $(foreach target,$(lintPackages),$(buildDir)/output.$(target).lint)
+coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
+coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+# end output files
+
+# start basic development targets
+compile: $(srcFiles)
+	$(gobin) build $(compilePackages)
+proto:
+	@mkdir -p remote/internal
+	protoc --go_out=plugins=grpc:remote/internal *.proto
+lint: $(lintOutput)
+test: $(testOutput)
+benchmark: $(buildDir)/run-benchmarks
+	./$<
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony += compile lint test coverage coverage-html proto benchmarks
+
+# start convenience targets for running tests and coverage tasks on a
+# specific package.
+test-%: $(buildDir)/output.%.test
+	
+coverage-%: $(buildDir)/output.%.coverage
+	
+html-coverage-%: $(buildDir)/output.%.coverage.html
+	
+lint-%: $(buildDir)/output.%.lint
+	
+# end convenience targets
+# end basic development targets
+
 # start test and coverage artifacts
-#    This varable includes everything that the tests actually need to
-#    run. (The "build" target is intentional and makes these targetsb
-#    rerun as expected.)
 testArgs := -v
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
@@ -93,7 +102,6 @@ endif
 ifneq (,$(SKIP_LONG))
 testArgs += -short
 endif
-# test execution and output handlers
 $(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 	@!( grep -s -q "^FAIL" $@ && grep -s -q "^WARNING: DATA RACE" $@)
@@ -103,54 +111,36 @@ $(buildDir)/output.%.coverage: .FORCE
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 $(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage .FORCE
 	$(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
 $(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-#  targets to process and generate coverage reports
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
-# user-facing targets for basic build and development operations
-proto:
-	@mkdir -p remote/internal
-	protoc --go_out=plugins=grpc:remote/internal *.proto
-lint:$(lintOutput)
-test:$(testOutput)
-benchmarks: $(buildDir)/run-benchmarks .FORCE
-	./$(buildDir)/run-benchmarks $(run-benchmark)
-coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
-phony += compile lint test coverage coverage-html docker-setup docker-cleanup
-.PHONY: $(phony) .FORCE
-.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
-# end front-ends
-#
-# Docker-related
-docker_image := $(DOCKER_IMAGE)
-ifeq ($(docker_image),)
-	docker_image := "ubuntu"
+# start Docker-related targets
+dockerImage := $(DOCKER_IMAGE)
+ifeq ($(dockerImage),)
+dockerImage := ubuntu
 endif
 
 docker-setup:
 ifneq (true,$(SKIP_DOCKER_TESTS))
-	docker pull $(docker_image)
+	docker pull $(dockerImage)
 endif
 
 docker-cleanup:
 ifneq (true,$(SKIP_DOCKER_TESTS))
 	docker rm -f $(shell docker ps -a -q)
-	docker rmi -f $(docker_image)
+	docker rmi -f $(dockerImage)
 endif
-# end Docker
+phony += docker-setup docker-cleanup
+# end Docker-related targets
 
-.FORCE:
-
-clean:
-	rm -rf $(buildDir)/$(name) $(lintDeps) $(buildDir)/run-benchmarks $(buildDir)/run-linter *.pb.go
-
-clean-results:
-	rm -rf $(buildDir)/output.*
-
+# start vendoring configuration
 vendor-clean:
 	rm -rf vendor/github.com/mongodb/amboy/vendor/github.com/google/uuid/
 	rm -rf vendor/github.com/mongodb/amboy/vendor/gopkg.in/yaml.v2/
@@ -240,3 +230,17 @@ vendor-clean:
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*testdata*" | xargs rm -rf
 	find vendor/ -type d -empty | xargs rm -rf
 	find vendor/ -type d -name '.git' | xargs rm -rf
+phony += vendor-clean
+# end vendoring configuration
+
+# start cleanup targets
+clean:
+	rm -rf $(buildDir)
+clean-results:
+	rm -rf $(buildDir)/output.*
+phony += clean clean-results
+# end cleanup targets
+
+# configure phony targets
+.FORCE:
+.PHONY: $(phony)


### PR DESCRIPTION
* Remove `GO_BIN_PATH`. CI tests now depend on `GOROOT` to tell them which Go version to use and which Go binary to use.
* Set the `GOLANGCI_LINT_CACHE`, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the `PATH` variable for the linter.
* Clean up and standardize the makefile.