### PR TITLE
EVG-15505: replace deprecated maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - staticcheck
     - structcheck
@@ -23,6 +22,12 @@ linters:
 run:
   skip-dirs:
     - build
+
+linter-settings:
+  govet:
+    enable:
+      - fieldalignment
+
 issues:
   exclude-rules:
     - linters:

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ export GO111MODULE := off
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-.DEFAULT_GOAL: compile
+.DEFAULT_GOAL := compile
 
 # start lint setup targets
 lintDeps := $(buildDir)/run-linter $(buildDir)/golangci-lint


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15505

* Replace deprecated maligned with govet's fieldalignment.
* Fix the default make target.