### PR TITLE
EVG-15734: upgrade Docker to v20.10.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/containerd v1.5.7 // indirect
-	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
+	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/evergreen-ci/aviation v0.0.0-20211026175554-41a4410c650f
 	github.com/evergreen-ci/baobab v1.0.1-0.20211025210153-3206308845c1
@@ -28,6 +28,7 @@ require (
 	github.com/mongodb/anser v0.0.0-20211116195831-fdc43007b59f // indirect
 	github.com/mongodb/grip v0.0.0-20211101151816-abbea0c0d465
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/pierrec/lz4/v4 v4.1.9 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TT
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible h1:SiUATuP//KecDjpOK2tvZJgeScYAklvyjfK8JZlU6fo=
-github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.11+incompatible h1:OqzI/g/W54LczvhnccGqniFoQghHx3pklbLuhfXpqGo=
+github.com/docker/docker v20.10.11+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -632,6 +632,7 @@ github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQ
 github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
+github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -686,8 +687,9 @@ github.com/opencontainers/go-digest v1.0.0-rc1.0.20180430190053-c9281466c8b2/go.
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.0/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc8.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1347,6 +1349,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -46,8 +46,8 @@ type docker struct {
 	signal   syscall.Signal
 }
 
-// DockerOptions represent options for a Docker runtime executor.
-// within a Docker container.
+// DockerOptions represent options for a Docker runtime executor within a Docker
+// container.
 type DockerOptions struct {
 	// Client is the Docker client to use. This is required.
 	Client *client.Client
@@ -59,7 +59,7 @@ type DockerOptions struct {
 	// OS is the operating system that Docker is running in. If unspecified,
 	// this defaults to the runtime GOOS.
 	OS string
-	// OS is the CPU architecture of the machine that Docker is running in. If
+	// Arch is the CPU architecture of the machine that Docker is running in. If
 	// unspecified, this defaults to runtime GOARCH.
 	Arch string
 }

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -25,8 +27,9 @@ type docker struct {
 	stdout   io.Writer
 	stderr   io.Writer
 
-	image    string
-	platform string
+	image string
+	os    string
+	arch  string
 
 	client *client.Client
 	ctx    context.Context
@@ -43,22 +46,60 @@ type docker struct {
 	signal   syscall.Signal
 }
 
+// DockerOptions represent options for a Docker runtime executor.
+// within a Docker container.
+type DockerOptions struct {
+	// Client is the Docker client to use. This is required.
+	Client *client.Client
+	// Image is the name of the Docker image. This is required.
+	Image string
+	// Command is the arguments to the command to run in the Docker container.
+	// This is required.
+	Command []string
+	// OS is the operating system that Docker is running in. If unspecified,
+	// this defaults to the runtime GOOS.
+	OS string
+	// OS is the CPU architecture of the machine that Docker is running in. If
+	// unspecified, this defaults to runtime GOARCH.
+	Arch string
+}
+
+// Validate checks that the required Docker fields are populated. It sets
+// default values where possible.
+func (o *DockerOptions) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(o.Client == nil, "must specify a Docker client")
+	catcher.NewWhen(o.Image == "", "must specify a Docker image")
+	catcher.NewWhen(len(o.Command) == 0, "cannot specify an empty command to run in the container")
+	if o.OS == "" {
+		o.OS = runtime.GOOS
+	}
+	if o.Arch == "" {
+		o.Arch = runtime.GOARCH
+	}
+	return catcher.Resolve()
+}
+
 // NewDocker returns an Executor that creates a process within a Docker
 // container. Callers are expected to clean up resources by calling Close.
-func NewDocker(ctx context.Context, client *client.Client, platform, image string, args []string) Executor {
+func NewDocker(ctx context.Context, opts DockerOptions) (Executor, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid options")
+	}
 	return &docker{
 		ctx: ctx,
 		execOpts: types.ExecConfig{
-			Cmd: args,
+			Cmd: opts.Command,
 		},
-		platform: platform,
-		image:    image,
-		client:   client,
+		os:       opts.OS,
+		arch:     opts.Arch,
+		image:    opts.Image,
+		client:   opts.Client,
 		status:   Unstarted,
 		pid:      -1,
 		exitCode: -1,
 		signal:   syscall.Signal(-1),
-	}
+	}, nil
 }
 
 func (e *docker) Args() []string {
@@ -137,7 +178,10 @@ func (e *docker) setupContainer() error {
 		OpenStdin:    e.execOpts.AttachStdin,
 		AttachStdout: e.execOpts.AttachStdout,
 		AttachStderr: e.execOpts.AttachStderr,
-	}, &container.HostConfig{}, &network.NetworkingConfig{}, containerName)
+	}, &container.HostConfig{}, &network.NetworkingConfig{}, &specs.Platform{
+		OS:           e.os,
+		Architecture: e.arch,
+	}, containerName)
 	if err != nil {
 		return errors.Wrap(err, "problem creating container for process")
 	}
@@ -315,7 +359,7 @@ func (e *docker) Signal(sig syscall.Signal) error {
 		return errors.New("cannot signal a non-running process")
 	}
 
-	dsig, err := syscallToDockerSignal(sig, e.platform)
+	dsig, err := syscallToDockerSignal(sig, e.os)
 	if err != nil {
 		return errors.Wrapf(err, "could not get Docker equivalent of signal '%d'", sig)
 	}

--- a/internal/executor/docker_signals.go
+++ b/internal/executor/docker_signals.go
@@ -6,13 +6,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// This file contains platform-dependent Docker signals taken from
+// This file contains OS-dependent Docker signals taken from
 // github.com/docker/docker/pkg/signal.
 
 // syscallToDockerSignal converts the syscall.Signal to the equivalent Docker
 // signal.
-func syscallToDockerSignal(sig syscall.Signal, platform string) (string, error) {
-	switch platform {
+func syscallToDockerSignal(sig syscall.Signal, os string) (string, error) {
+	switch os {
 	case "darwin":
 		if dsig, ok := syscallToDockerDarwin()[sig]; ok {
 			return dsig, nil
@@ -26,15 +26,15 @@ func syscallToDockerSignal(sig syscall.Signal, platform string) (string, error) 
 			return dsig, nil
 		}
 	default:
-		return "", errors.Errorf("unrecognized platform '%s'", platform)
+		return "", errors.Errorf("unrecognized OS '%s'", os)
 	}
-	return "", errors.Errorf("unrecognized Docker signal '%d' for platform '%s'", sig, platform)
+	return "", errors.Errorf("unrecognized Docker signal '%d' for OS '%s'", sig, os)
 }
 
 // dockerToSyscallSignal converts the Docker signal to the equivalent
 // syscall.Signal.
-func dockerToSyscallSignal(dsig string, platform string) (syscall.Signal, error) { //nolint: deadcode
-	switch platform {
+func dockerToSyscallSignal(dsig string, os string) (syscall.Signal, error) { //nolint: deadcode
+	switch os {
 	case "darwin":
 		if sig, ok := dockerToSyscallDarwin()[dsig]; ok {
 			return sig, nil
@@ -48,9 +48,9 @@ func dockerToSyscallSignal(dsig string, platform string) (syscall.Signal, error)
 			return sig, nil
 		}
 	default:
-		return syscall.Signal(-1), errors.Errorf("unrecognized platform '%s'", platform)
+		return syscall.Signal(-1), errors.Errorf("unrecognized os '%s'", os)
 	}
-	return syscall.Signal(-1), errors.Errorf("unrecognized signal '%s' for platform '%s'", dsig, platform)
+	return syscall.Signal(-1), errors.Errorf("unrecognized signal '%s' for os '%s'", dsig, os)
 }
 
 // These are constants taken from the signals in the syscall package for

--- a/internal/executor/docker_signals.go
+++ b/internal/executor/docker_signals.go
@@ -48,9 +48,9 @@ func dockerToSyscallSignal(dsig string, os string) (syscall.Signal, error) { //n
 			return sig, nil
 		}
 	default:
-		return syscall.Signal(-1), errors.Errorf("unrecognized os '%s'", os)
+		return syscall.Signal(-1), errors.Errorf("unrecognized OS '%s'", os)
 	}
-	return syscall.Signal(-1), errors.Errorf("unrecognized signal '%s' for os '%s'", dsig, os)
+	return syscall.Signal(-1), errors.Errorf("unrecognized signal '%s' for OS '%s'", dsig, os)
 }
 
 // These are constants taken from the signals in the syscall package for

--- a/internal/executor/docker_test.go
+++ b/internal/executor/docker_test.go
@@ -1,0 +1,98 @@
+package executor
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDocker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := client.NewClientWithOpts()
+	require.NoError(t, err)
+
+	t.Run("SucceedsWithAllOptions", func(t *testing.T) {
+		opts := DockerOptions{
+			Client:  client,
+			Image:   "image",
+			Command: []string{"echo", "foo"},
+			OS:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
+		}
+		exec, err := NewDocker(ctx, opts)
+		require.NoError(t, err)
+		assert.NotZero(t, exec)
+	})
+	t.Run("SucceedsWithMinimalOptions", func(t *testing.T) {
+		opts := DockerOptions{
+			Client:  client,
+			Image:   "image",
+			Command: []string{"echo", "foo"},
+		}
+		exec, err := NewDocker(ctx, opts)
+		require.NoError(t, err)
+		assert.NotZero(t, exec)
+	})
+	t.Run("FailsWithZeroOptions", func(t *testing.T) {
+		exec, err := NewDocker(ctx, DockerOptions{})
+		assert.Error(t, err)
+		assert.Zero(t, exec)
+	})
+}
+
+func TestDockerOptions(t *testing.T) {
+	client, err := client.NewClientWithOpts()
+	require.NoError(t, err)
+
+	getAllPopulatedOpts := func() DockerOptions {
+		return DockerOptions{
+			Client:  client,
+			Image:   "image",
+			Command: []string{"echo", "foo"},
+			OS:      runtime.GOOS,
+			Arch:    runtime.GOARCH,
+		}
+	}
+
+	t.Run("Validate", func(t *testing.T) {
+		t.Run("SucceedsWithAllOptions", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("SucceedsWithoutOS", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			opts.OS = ""
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("SucceedsWithoutArch", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			opts.Arch = ""
+			assert.NoError(t, opts.Validate())
+		})
+		t.Run("FailsWithZeroOptions", func(t *testing.T) {
+			opts := DockerOptions{}
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("FailsWithoutClient", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			opts.Client = nil
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("FailsWithoutImage", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			opts.Image = ""
+			assert.Error(t, opts.Validate())
+		})
+		t.Run("FailsWithoutCommand", func(t *testing.T) {
+			opts := getAllPopulatedOpts()
+			opts.Command = nil
+			assert.Error(t, opts.Validate())
+		})
+	})
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -35,7 +35,14 @@ func executorTypes() map[string]executorConstructor {
 			if image == "" {
 				image = testutil.DefaultDockerImage
 			}
-			return NewDocker(ctx, client, runtime.GOOS, image, args), nil
+			opts := DockerOptions{
+				Client:  client,
+				OS:      runtime.GOOS,
+				Arch:    runtime.GOARCH,
+				Image:   image,
+				Command: args,
+			}
+			return NewDocker(ctx, opts)
 		},
 	}
 }

--- a/options/create.go
+++ b/options/create.go
@@ -283,7 +283,14 @@ func (opts *Create) resolveExecutor(ctx context.Context) (executor.Executor, err
 		if err != nil {
 			return nil, errors.Wrap(err, "could not resolve Docker options")
 		}
-		return executor.NewDocker(ctx, client, opts.Docker.Platform, opts.Docker.Image, opts.Args), nil
+		opts := executor.DockerOptions{
+			Client:  client,
+			Image:   opts.Docker.Image,
+			Command: opts.Args,
+			OS:      opts.Docker.OS,
+			Arch:    opts.Docker.Arch,
+		}
+		return executor.NewDocker(ctx, opts)
 	}
 
 	return executor.NewLocal(ctx, opts.Args), nil

--- a/options/docker.go
+++ b/options/docker.go
@@ -34,10 +34,10 @@ func (opts *Docker) Validate() error {
 		if OSSupportsDocker(runtime.GOOS) {
 			opts.OS = runtime.GOOS
 		} else {
-			catcher.Errorf("cannot set default platform to current runtime platform '%s' because it is unsupported", opts.OS)
+			catcher.Errorf("cannot set default OS to current runtime OS '%s' because it is unsupported", opts.OS)
 		}
 	} else if !OSSupportsDocker(opts.OS) {
-		catcher.Errorf("unrecognized platform '%s'", opts.OS)
+		catcher.Errorf("unrecognized OS '%s'", opts.OS)
 	}
 	if opts.Arch == "" {
 		opts.Arch = runtime.GOARCH
@@ -53,8 +53,8 @@ func (opts *Docker) Copy() *Docker {
 
 // OSSupportsDocker returns whether or not the operating system is supported by
 // Docker.
-func OSSupportsDocker(platform string) bool {
-	switch platform {
+func OSSupportsDocker(os string) bool {
+	switch os {
 	case "darwin", "linux", "windows":
 		return true
 	default:

--- a/options/docker.go
+++ b/options/docker.go
@@ -16,9 +16,12 @@ type Docker struct {
 	Port       int    `bson:"port,omitempty" json:"port,omitempty" yaml:"port,omitempty"`
 	APIVersion string `bson:"api_version,omitempty" json:"api_version,omitempty" yaml:"api_version,omitempty"`
 	Image      string `bson:"image,omitempty" json:"image,omitempty" yaml:"image,omitempty"`
-	// Platform refers to the major operating system on which the Docker
-	// container runs.
-	Platform string `bson:"platform,omitempty" json:"platform,omitempty" yaml:"platform,omitempty"`
+	// OS refers to the major operating system on which the Docker container
+	// runs.
+	OS string `bson:"os,omitempty" json:"os,omitempty" yaml:"os,omitempty"`
+	// Arch is the CPU architecture of the machine on which the Docker container
+	// runs.
+	Arch string `bson:"arch,omitempty" json:"arch,omitempty" yaml:"arch,omitempty"`
 }
 
 // Validate checks whether all the required fields are set and sets defaults if
@@ -27,14 +30,17 @@ func (opts *Docker) Validate() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.NewWhen(opts.Port < 0, "port must be positive value")
 	catcher.NewWhen(opts.Image == "", "Docker image must be specified")
-	if opts.Platform == "" {
-		if PlatformSupportsDocker(runtime.GOOS) {
-			opts.Platform = runtime.GOOS
+	if opts.OS == "" {
+		if OSSupportsDocker(runtime.GOOS) {
+			opts.OS = runtime.GOOS
 		} else {
-			catcher.Errorf("failed to set default platform to current runtime platform '%s' because it is unsupported", opts.Platform)
+			catcher.Errorf("cannot set default platform to current runtime platform '%s' because it is unsupported", opts.OS)
 		}
-	} else if !PlatformSupportsDocker(opts.Platform) {
-		catcher.Errorf("unrecognized platform '%s'", opts.Platform)
+	} else if !OSSupportsDocker(opts.OS) {
+		catcher.Errorf("unrecognized platform '%s'", opts.OS)
+	}
+	if opts.Arch == "" {
+		opts.Arch = runtime.GOARCH
 	}
 	return catcher.Resolve()
 }
@@ -45,9 +51,9 @@ func (opts *Docker) Copy() *Docker {
 	return &optsCopy
 }
 
-// PlatformSupportsDocker returns whether or not the platform has support for
+// OSSupportsDocker returns whether or not the operating system is supported by
 // Docker.
-func PlatformSupportsDocker(platform string) bool {
+func OSSupportsDocker(platform string) bool {
 	switch platform {
 	case "darwin", "linux", "windows":
 		return true

--- a/options/docker.go
+++ b/options/docker.go
@@ -17,10 +17,10 @@ type Docker struct {
 	APIVersion string `bson:"api_version,omitempty" json:"api_version,omitempty" yaml:"api_version,omitempty"`
 	Image      string `bson:"image,omitempty" json:"image,omitempty" yaml:"image,omitempty"`
 	// OS refers to the major operating system on which the Docker container
-	// runs.
+	// runs. If unspecified, this defaults to the runtime GOOS.
 	OS string `bson:"os,omitempty" json:"os,omitempty" yaml:"os,omitempty"`
 	// Arch is the CPU architecture of the machine on which the Docker container
-	// runs.
+	// runs. If unspecified, this defaults to the runtime GOARCH.
 	Arch string `bson:"arch,omitempty" json:"arch,omitempty" yaml:"arch,omitempty"`
 }
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15734

* Bump Docker to the latest stable version. Since Docker isn't using Go modules, it's always risky to upgrade the Docker library without some caution because we can only have one version of Docker across all our repos.
* Add a field for CPU architecture. We already populate the OS, but Docker's `ContainerCreate` API call now requires you to specify the OS/arch, so we have to pass both of them as part of the options.
* Improve the way options are passed to the Docker executor a bit.