### PR TITLE
EVG-19927: Upgrade go and Evergreen distros.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,22 +2,20 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
+    - unused
     - errcheck
     - gocognit
     - goconst
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosimple
     - govet
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
-    - varcheck
 
 run:
   skip-dirs:

--- a/benchmarks/harness.go
+++ b/benchmarks/harness.go
@@ -3,7 +3,6 @@ package benchmarks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -123,7 +122,7 @@ func getInMemoryLoggerBenchmark(makeProc makeProcess, timeout time.Duration) pop
 
 func getFileLoggerBenchmark(makeProc makeProcess, timeout time.Duration) poplar.Benchmark {
 	return func(ctx context.Context, r poplar.Recorder, _ int) error {
-		file, err := ioutil.TempFile("", "bench_out.txt")
+		file, err := os.CreateTemp("", "bench_out.txt")
 		if err != nil {
 			return err
 		}

--- a/cli/manager_test.go
+++ b/cli/manager_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/mongodb/jasper"
-	"github.com/mongodb/jasper/mock"
 	"github.com/mongodb/jasper/options"
 	"github.com/mongodb/jasper/testutil"
 	testoptions "github.com/mongodb/jasper/testutil/options"
@@ -31,7 +30,7 @@ func TestCLIManager(t *testing.T) {
 					assert.NotEmpty(t, resp.ID)
 				},
 				"CommandsWithInputFailWithInvalidInput": func(ctx context.Context, t *testing.T, c *cli.Context, jasperProcID string) {
-					input, err := json.Marshal(mock.Process{})
+					input, err := json.Marshal(map[string]string{"test": "test"})
 					require.NoError(t, err)
 					assert.Error(t, execCLICommandInputOutput(t, c, managerCreateProcess(), input, &InfoResponse{}))
 					assert.Error(t, execCLICommandInputOutput(t, c, managerCreateCommand(), input, &OutcomeResponse{}))
@@ -40,7 +39,7 @@ func TestCLIManager(t *testing.T) {
 					assert.Error(t, execCLICommandInputOutput(t, c, managerGroup(), input, &InfosResponse{}))
 				},
 				"CommandsWithoutInputPassWithInvalidInput": func(ctx context.Context, t *testing.T, c *cli.Context, jasperProcID string) {
-					input, err := json.Marshal(mock.Process{})
+					input, err := json.Marshal(map[string]string{"test": "test"})
 					require.NoError(t, err)
 					resp := &OutcomeResponse{}
 					assert.NoError(t, execCLICommandInputOutput(t, c, managerClear(), input, resp))

--- a/cli/manager_test.go
+++ b/cli/manager_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -136,7 +135,7 @@ func TestCLIManager(t *testing.T) {
 					assert.True(t, resp.Successful())
 				},
 				"WriteFileSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context, jasperProcID string) {
-					tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), "write_file")
+					tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), "write_file")
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, tmpFile.Close())
@@ -152,7 +151,7 @@ func TestCLIManager(t *testing.T) {
 
 					assert.True(t, resp.Successful())
 
-					data, err := ioutil.ReadFile(opts.Path)
+					data, err := os.ReadFile(opts.Path)
 					require.NoError(t, err)
 					assert.Equal(t, opts.Content, data)
 				},

--- a/cli/remote_test.go
+++ b/cli/remote_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestCLIRemote(t *testing.T) {
 					assert.True(t, resp.Successful())
 				},
 				"DownloadFileSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context) {
-					tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+					tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, tmpFile.Close())
@@ -53,7 +52,7 @@ func TestCLIRemote(t *testing.T) {
 					assert.NotZero(t, info.Size)
 				},
 				"DownloadMongoDBSucceeds": func(ctx context.Context, t *testing.T, c *cli.Context) {
-					tmpDir, err := ioutil.TempDir(testutil.BuildDirectory(), "out")
+					tmpDir, err := os.MkdirTemp(testutil.BuildDirectory(), "out")
 					require.NoError(t, err)
 					defer func() {
 						assert.NoError(t, os.RemoveAll(tmpDir))

--- a/cli/remote_unix_test.go
+++ b/cli/remote_unix_test.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+//go:build linux || darwin
 
 package cli
 

--- a/cli/service.go
+++ b/cli/service.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -198,7 +197,7 @@ func makeLogger(c *cli.Context) *options.LoggerConfig {
 	}
 	if info.Token == "" {
 		if tokenFilePath := c.String(splunkTokenFilePathFlagName); tokenFilePath != "" {
-			token, err := ioutil.ReadFile(tokenFilePath)
+			token, err := os.ReadFile(tokenFilePath)
 			if err != nil {
 				grip.Error(errors.Wrapf(err, "could not read Splunk token file from path '%s'", tokenFilePath))
 				return nil
@@ -332,7 +331,7 @@ func makeUserEnvironment(user string, vars []string) map[string]string { //nolin
 	// Content and format of /etc/passwd is documented here:
 	// https://linux.die.net/man/5/passwd
 	file := "/etc/passwd"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		grip.Debug(message.WrapErrorf(err, "reading file '%s' to populate environment variables", file))
 		return env

--- a/cli/ssh_client_test.go
+++ b/cli/ssh_client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -20,13 +20,13 @@ import (
 
 func TestNewSSHClient(t *testing.T) {
 	for testName, testCase := range map[string]func(t *testing.T, remoteOpts options.Remote, clientOpts ClientOptions){
-		"NewSSHClientFailsWithEmptyRemoteOptions": func(t *testing.T, remoteOpts options.Remote, clientOpts ClientOptions) {
-			remoteOpts = options.Remote{}
+		"NewSSHClientFailsWithEmptyRemoteOptions": func(t *testing.T, _ options.Remote, clientOpts ClientOptions) {
+			remoteOpts := options.Remote{}
 			_, err := NewSSHClient(clientOpts, remoteOpts)
 			assert.Error(t, err)
 		},
-		"NewSSHClientFailsWithEmptyClientOptions": func(t *testing.T, remoteOpts options.Remote, clientOpts ClientOptions) {
-			clientOpts = ClientOptions{}
+		"NewSSHClientFailsWithEmptyClientOptions": func(t *testing.T, remoteOpts options.Remote, _ ClientOptions) {
+			clientOpts := ClientOptions{}
 			_, err := NewSSHClient(clientOpts, remoteOpts)
 			assert.Error(t, err)
 		},
@@ -537,7 +537,7 @@ func TestSSHClient(t *testing.T) {
 func makeCreateFunc(t *testing.T, client *sshClient, expectedClientSubcommand []string, inputChecker interface{}, expectedResponse interface{}) func(*options.Create) mock.Process {
 	return func(opts *options.Create) mock.Process {
 		if opts.StandardInputBytes != nil && inputChecker != nil {
-			input, err := ioutil.ReadAll(bytes.NewBuffer(opts.StandardInputBytes))
+			input, err := io.ReadAll(bytes.NewBuffer(opts.StandardInputBytes))
 			require.NoError(t, err)
 			require.NoError(t, json.Unmarshal(input, inputChecker))
 		}

--- a/cli/util.go
+++ b/cli/util.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -54,53 +53,6 @@ func requireStringFlag(name string) cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		if c.String(name) == "" {
 			return errors.Errorf("must specify string for flag '%s'", name)
-		}
-		return nil
-	}
-}
-
-func requireOneFlag(names ...string) cli.BeforeFunc { //nolint:unused
-	return func(c *cli.Context) error {
-		var count int
-		for _, name := range names {
-			if c.IsSet(name) {
-				count++
-			}
-		}
-		if count != 1 {
-			return errors.Errorf("must specify exactly one flag from the following: %s", names)
-		}
-		return nil
-	}
-}
-
-// requireRelativePath verifies that the path flag relPathFlagName is set to a
-// path relative to the directory path set for dirFlagName.
-//
-//nolint:unused
-func requireRelativePath(relPathFlagName, pathFlagName string) cli.BeforeFunc {
-	return func(c *cli.Context) error {
-		relPath := util.ConsistentFilepath(c.String(relPathFlagName))
-		path := util.ConsistentFilepath(c.String(pathFlagName))
-		if filepath.IsAbs(relPath) {
-			if strings.HasPrefix(relPath, path) {
-				relPath = strings.TrimPrefix(relPath, path)
-				return errors.Wrapf(c.Set(relPathFlagName, relPath), "setting flag '%s' to relative path", relPathFlagName)
-			}
-			return errors.Errorf("path '%s' must be relative to the path '%s'", relPath, path)
-		}
-		return nil
-	}
-}
-
-// requireStringSliceFlag verifies that the flag name is set to a non-empty
-// string slice.
-//
-//nolint:unused
-func requireStringSliceFlag(name string) cli.BeforeFunc {
-	return func(c *cli.Context) error {
-		if len(c.StringSlice(name)) == 0 {
-			return errors.Errorf("must specify at least one string for flag '%s'", name)
 		}
 		return nil
 	}

--- a/cli/util.go
+++ b/cli/util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -60,7 +59,7 @@ func requireStringFlag(name string) cli.BeforeFunc {
 	}
 }
 
-func requireOneFlag(names ...string) cli.BeforeFunc { //nolint: deadcode
+func requireOneFlag(names ...string) cli.BeforeFunc { //nolint:unused
 	return func(c *cli.Context) error {
 		var count int
 		for _, name := range names {
@@ -77,7 +76,8 @@ func requireOneFlag(names ...string) cli.BeforeFunc { //nolint: deadcode
 
 // requireRelativePath verifies that the path flag relPathFlagName is set to a
 // path relative to the directory path set for dirFlagName.
-//nolint: deadcode
+//
+//nolint:unused
 func requireRelativePath(relPathFlagName, pathFlagName string) cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		relPath := util.ConsistentFilepath(c.String(relPathFlagName))
@@ -95,7 +95,8 @@ func requireRelativePath(relPathFlagName, pathFlagName string) cli.BeforeFunc {
 
 // requireStringSliceFlag verifies that the flag name is set to a non-empty
 // string slice.
-//nolint: deadcode
+//
+//nolint:unused
 func requireStringSliceFlag(name string) cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		if len(c.StringSlice(name)) == 0 {
@@ -123,7 +124,7 @@ func validatePort(flagName string) func(*cli.Context) error {
 
 // readInput reads JSON from the input and decodes it to the output.
 func readInput(input io.Reader, output interface{}) error {
-	bytes, err := ioutil.ReadAll(input)
+	bytes, err := io.ReadAll(input)
 	if err != nil {
 		return errors.Wrap(err, "reading from input")
 	}

--- a/cli/util_for_test.go
+++ b/cli/util_for_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -59,7 +59,7 @@ func withMockStdin(t *testing.T, input string, operation func(*os.File) error) e
 	defer func() {
 		os.Stdin = stdin
 	}()
-	tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), "mock_stdin.txt")
+	tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), "mock_stdin.txt")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, tmpFile.Close())
@@ -80,7 +80,7 @@ func withMockStdout(t *testing.T, operation func(*os.File) error) error {
 	defer func() {
 		os.Stdout = stdout
 	}()
-	tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), "mock_stdout.txt")
+	tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), "mock_stdout.txt")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, tmpFile.Close())
@@ -108,7 +108,7 @@ func execCLICommandOutput(t *testing.T, c *cli.Context, cmd cli.Command, output 
 		if _, err := stdout.Seek(0, 0); err != nil {
 			return err
 		}
-		resp, err := ioutil.ReadAll(stdout)
+		resp, err := io.ReadAll(stdout)
 		if err != nil {
 			return err
 		}

--- a/cli/util_test.go
+++ b/cli/util_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -80,7 +80,7 @@ func TestWriteOutputInvalidInput(t *testing.T) {
 func TestWriteOutputInvalidOutput(t *testing.T) {
 	input := bytes.NewBufferString(`{"foo":"bar"}`)
 
-	output, err := ioutil.TempFile(testutil.BuildDirectory(), "write_output.txt")
+	output, err := os.CreateTemp(testutil.BuildDirectory(), "write_output.txt")
 	require.NoError(t, err)
 	defer os.RemoveAll(output.Name())
 	require.NoError(t, output.Close())
@@ -132,7 +132,7 @@ func TestCLICommon(t *testing.T) {
 						return withMockStdout(t, func(*os.File) error {
 							input := &mockInput{}
 							require.NoError(t, doPassthroughInputOutput(c, input, mockRequest("")))
-							output, err := ioutil.ReadAll(stdin)
+							output, err := io.ReadAll(stdin)
 							require.NoError(t, err)
 							assert.Len(t, output, 0)
 							return nil
@@ -163,7 +163,7 @@ func TestCLICommon(t *testing.T) {
 							expectedOutput := `{"value":"bar"}`
 							_, err := stdout.Seek(0, 0)
 							require.NoError(t, err)
-							output, err := ioutil.ReadAll(stdout)
+							output, err := io.ReadAll(stdout)
 							require.NoError(t, err)
 							assert.Equal(t, testutil.RemoveWhitespace(expectedOutput), testutil.RemoveWhitespace(string(output)))
 							return nil
@@ -175,7 +175,7 @@ func TestCLICommon(t *testing.T) {
 					return withMockStdin(t, input, func(stdin *os.File) error {
 						return withMockStdout(t, func(*os.File) error {
 							require.NoError(t, doPassthroughOutput(c, mockRequest("")))
-							output, err := ioutil.ReadAll(stdin)
+							output, err := io.ReadAll(stdin)
 							require.NoError(t, err)
 							assert.Len(t, output, len(input))
 							return nil
@@ -191,7 +191,7 @@ func TestCLICommon(t *testing.T) {
 						expectedOutput := `{"value": "bar"}`
 						_, err := stdout.Seek(0, 0)
 						require.NoError(t, err)
-						output, err := ioutil.ReadAll(stdout)
+						output, err := io.ReadAll(stdout)
 						require.NoError(t, err)
 						assert.Equal(t, testutil.RemoveWhitespace(expectedOutput), testutil.RemoveWhitespace(string(output)))
 						return nil

--- a/download_test.go
+++ b/download_test.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -55,7 +54,7 @@ func TestSetupDownloadMongoDBReleasesWithInvalidArtifactsFeed(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.TestTimeout)
 	defer cancel()
 
-	dir, err := ioutil.TempDir(testutil.BuildDirectory(), "out")
+	dir, err := os.MkdirTemp(testutil.BuildDirectory(), "out")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -70,7 +69,7 @@ func TestSetupDownloadMongoDBReleasesWithInvalidArtifactsFeed(t *testing.T) {
 }
 
 func TestCreateValidDownloadJobs(t *testing.T) {
-	dir, err := ioutil.TempDir(testutil.BuildDirectory(), "out")
+	dir, err := os.MkdirTemp(testutil.BuildDirectory(), "out")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -118,11 +117,11 @@ func TestProcessDownloadJobs(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testutil.LongTestTimeout)
 	defer cancel()
 
-	downloadDir, err := ioutil.TempDir(testutil.BuildDirectory(), "download_test")
+	downloadDir, err := os.MkdirTemp(testutil.BuildDirectory(), "download_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(downloadDir)
 
-	fileServerDir, err := ioutil.TempDir(testutil.BuildDirectory(), "download_test_server")
+	fileServerDir, err := os.MkdirTemp(testutil.BuildDirectory(), "download_test_server")
 	require.NoError(t, err)
 	defer os.RemoveAll(fileServerDir)
 
@@ -219,7 +218,7 @@ func TestDownloadAndExtract(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			file, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+			file, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 			require.NoError(t, err)
 			defer os.Remove(file.Name())
 
@@ -227,7 +226,7 @@ func TestDownloadAndExtract(t *testing.T) {
 			require.NoError(t, err)
 			defer os.Remove(archiveFileName)
 
-			extractDir, err := ioutil.TempDir(testutil.BuildDirectory(), "out")
+			extractDir, err := os.MkdirTemp(testutil.BuildDirectory(), "out")
 			require.NoError(t, err)
 			defer os.RemoveAll(extractDir)
 
@@ -251,7 +250,7 @@ func TestDownloadAndExtract(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotZero(t, fileInfo.Size())
 
-			fileInfos, err := ioutil.ReadDir(extractDir)
+			fileInfos, err := os.ReadDir(extractDir)
 			require.NoError(t, err)
 			assert.Equal(t, 1, len(fileInfos))
 		})
@@ -259,7 +258,7 @@ func TestDownloadAndExtract(t *testing.T) {
 }
 
 func TestDownloadAndExtractFailsWithUnarchivedFile(t *testing.T) {
-	file, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+	file, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 	require.NoError(t, err)
 	defer os.Remove(file.Name())
 

--- a/event_unix.go
+++ b/event_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux freebsd
+//go:build darwin || linux || freebsd
 
 package jasper
 

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -167,25 +167,12 @@ task_groups:
 #           Buildvariants             #
 #######################################
 buildvariants:
-  - name: race-detector
-    display_name: Race Detector (Arch Linux)
-    expansions:
-      GOROOT: /opt/golang/go1.16
-      RACE_DETECTOR: true
-      SKIP_DOCKER_TESTS: true
-    run_on:
-      - archlinux-new-small
-      - archlinux-new-large
-    tasks:
-      - name: test_group
-
   - name: lint-linux
-    display_name: Lint (Arch Linux)
+    display_name: Lint (Ubuntu 22.04)
     expansions:
-      GOROOT: /opt/golang/go1.16
+      GOROOT: /opt/golang/go1.20
     run_on:
-      - archlinux-new-small
-      - archlinux-new-large
+      - ubuntu2204-small
     tasks: 
       - name: lint_group
       - name: verify-mod-tidy
@@ -193,41 +180,37 @@ buildvariants:
   - name: lint-windows
     display_name: Lint (Windows)
     expansions:
-      GOROOT: C:/golang/go1.16
+      GOROOT: C:/golang/go1.20
     run_on:
-      - windows-64-vs2019-small
-      - windows-64-vs2019-large
+      - windows-vsCurrent-small
     tasks:
       - lint_group
 
   - name: ubuntu
-    display_name: Ubuntu 18.04
+    display_name: Ubuntu 22.04
     expansions:
-      GOROOT: /opt/golang/go1.16
+      GOROOT: /opt/golang/go1.20
+      RACE_DETECTOR: true
       DOCKER_IMAGE: ubuntu
     run_on:
-      - ubuntu1804-small
-      - ubuntu1804-large
+      - ubuntu2204-small
     tasks:
       - name: test_group
 
   - name: macos
     display_name: macOS
     expansions:
-      GOROOT: /opt/golang/go1.16
+      GOROOT: /opt/golang/go1.20
     run_on:
-      - macos-1014
+      - macos-1100-arm64
     tasks:
       - name: test_group
 
   - name: windows
     display_name: Windows
     run_on:
-      - windows-64-vs2019-small
-      - windows-64-vs2019-large
-      - windows-64-vs2017-small
-      - windows-64-vs2017-large
+      - windows-vsCurrent-small
     expansions:
-      GOROOT: C:/golang/go1.16
+      GOROOT: C:/golang/go1.20
     tasks:
       - name: test_group

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -168,7 +168,7 @@ task_groups:
 #######################################
 buildvariants:
   - name: lint-linux
-    display_name: Lint (Ubuntu 22.04)
+    display_name: Lint
     expansions:
       GOROOT: /opt/golang/go1.20
     run_on:

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,11 @@
 module github.com/mongodb/jasper
 
-go 1.16
+go 1.20
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/Microsoft/go-winio v0.4.17 // indirect
-	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/cheynewallace/tabby v1.1.1
 	github.com/containerd/cgroups v1.0.4
-	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.22+incompatible
-	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/evergreen-ci/aviation v0.0.0-20220405151811-ff4a78a4297c
 	github.com/evergreen-ci/baobab v1.0.1-0.20220107150152-03b522479f52
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
@@ -25,24 +19,99 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/mholt/archiver/v3 v3.5.1
-	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
 	github.com/mongodb/amboy v0.0.0-20220408184825-b2a14e2c511d
 	github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21
-	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
-	github.com/pierrec/lz4/v4 v4.1.9 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/square/certstrap v1.2.0 // indirect
 	github.com/stretchr/testify v1.8.1
-	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/urfave/cli v1.22.10
 	go.mongodb.org/mongo-driver v1.11.1
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
-	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Microsoft/go-winio v0.4.17 // indirect
+	github.com/PuerkitoBio/rehttp v1.1.0 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/andybalholm/brotli v1.0.3 // indirect
+	github.com/andygrunwald/go-jira v1.14.0 // indirect
+	github.com/aws/aws-sdk-go v1.43.30 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079 // indirect
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dghubble/oauth1 v0.7.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
+	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 // indirect
+	github.com/evergreen-ci/pail v0.0.0-20220405154537-920afff49d92 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fuyufjh/splunk-hec-go v0.3.4-0.20210909061418-feecd03924b7 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/godbus/dbus/v5 v5.0.4 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/klauspost/pgzip v1.2.5 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mattn/go-xmpp v0.0.0-20211029151415-912ba614897a // indirect
+	github.com/moby/term v0.0.0-20200312100748-672ec06f55cd // indirect
+	github.com/mongodb/anser v0.0.0-20220408164649-99dd61768f4a // indirect
+	github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809 // indirect
+	github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/nwaples/rardecode v1.1.2 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 // indirect
+	github.com/phyber/negroni-gzip v1.0.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/rs/cors v1.8.2 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/shirou/gopsutil/v3 v3.22.3 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/square/certstrap v1.2.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.10 // indirect
+	github.com/tklauser/numcpus v0.4.0 // indirect
+	github.com/trivago/tgo v1.0.7 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/urfave/negroni v1.0.0 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.1 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	golang.org/x/oauth2 v0.0.0-20211028175245-ba495a64dcb5 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/text v0.4.0 // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	gonum.org/v1/gonum v0.11.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20211101144312-62acf1d99145 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -79,7 +79,6 @@ github.com/cheynewallace/tabby v1.1.1/go.mod h1:Pba/6cUL8uYqvOc9RkyvFbHGrQ9wShyr
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -87,7 +86,6 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/cgroups v1.0.4 h1:jN/mbWBEaz+T1pi5OFtnkQ+8qnmEbAr1Oo1FRm5B0dA=
 github.com/containerd/cgroups v1.0.4/go.mod h1:nLNQtsF7Sl2HxNebu77i1R0oDlhiTG+kO4JTrUzo6IA=
@@ -126,7 +124,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evergreen-ci/aviation v0.0.0-20211026175554-41a4410c650f/go.mod h1:aKaSPhULP3hvwaX/sF5k5bQLtnOhndnRdnwNTqR3/cA=
 github.com/evergreen-ci/aviation v0.0.0-20220405151811-ff4a78a4297c h1:o9S56cFdIhqv47Ckj9jJS1nVXZu5TIcZyUwkOChYRrk=
@@ -168,7 +165,6 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fuyufjh/splunk-hec-go v0.3.3/go.mod h1:DSeNMkIDw6WdmEnc4CBxC1+Hk12JEQcsaymRG/g/Qns=
@@ -274,7 +270,6 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
@@ -402,7 +397,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 h1:i1egM7gz4bPxLCIwBJOkpk6TqHpjTnL4dE1xdN/4dcs=
@@ -444,7 +438,6 @@ github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 h1:OkMGxebDj
 github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06/go.mod h1:+ePHsJ1keEjQtpvf9HHw0f4ZeJ0TLRsxhunSI2hYJSs=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/shirou/gopsutil v3.21.9+incompatible h1:LTLpUnfX81MkHeCtSrwNKZwuW5Id6kCa7/P43NdcNn4=
 github.com/shirou/gopsutil v3.21.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil/v3 v3.22.3 h1:UebRzEomgMpv61e3hgD1tGooqX5trFbdU/ehphbHd00=
 github.com/shirou/gopsutil/v3 v3.22.3/go.mod h1:D01hZJ4pVHPpCTZ3m3T2+wDF2YAGfd+H4ifUguaQzHM=
@@ -517,9 +510,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPRg=
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
@@ -533,7 +524,6 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -596,9 +586,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -653,9 +641,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -708,7 +695,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
@@ -784,9 +770,7 @@ golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210114065538-d78b04bdf963/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.9/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -910,7 +894,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +42,7 @@ func downloadMongoDB(t *testing.T) (string, string) {
 	arch := "x86_64"
 	release := "4.0-stable"
 
-	dir, err := ioutil.TempDir("", "mongodb")
+	dir, err := os.MkdirTemp("", "mongodb")
 	require.NoError(t, err)
 
 	opts := bond.BuildOptions{
@@ -80,7 +79,7 @@ func setupMongods(numProcs int, mongodPath string) ([]options.Create, []string, 
 		procName := "mongod"
 		port := testutil.GetPortNumber()
 
-		dbPath, err := ioutil.TempDir(testutil.BuildDirectory(), procName)
+		dbPath, err := os.MkdirTemp(testutil.BuildDirectory(), procName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/executor/docker.go
+++ b/internal/executor/docker.go
@@ -3,7 +3,6 @@ package executor
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"sync"
 	"syscall"
@@ -255,10 +254,10 @@ func (e *docker) runIOStream(stream types.HijackedResponse) {
 			stdout := e.stdout
 			stderr := e.stderr
 			if stdout == nil {
-				stdout = ioutil.Discard
+				stdout = io.Discard
 			}
 			if stderr == nil {
-				stderr = ioutil.Discard
+				stderr = io.Discard
 			}
 			if _, err := stdcopy.StdCopy(stdout, stderr, stream.Reader); err != nil {
 				grip.Error(errors.Wrap(err, "streaming output from process"))

--- a/internal/executor/docker_signals.go
+++ b/internal/executor/docker_signals.go
@@ -31,28 +31,6 @@ func syscallToDockerSignal(sig syscall.Signal, os string) (string, error) {
 	return "", errors.Errorf("unrecognized Docker signal '%d' for OS '%s'", sig, os)
 }
 
-// dockerToSyscallSignal converts the Docker signal to the equivalent
-// syscall.Signal.
-func dockerToSyscallSignal(dsig string, os string) (syscall.Signal, error) { //nolint: deadcode
-	switch os {
-	case "darwin":
-		if sig, ok := dockerToSyscallDarwin()[dsig]; ok {
-			return sig, nil
-		}
-	case "linux":
-		if sig, ok := dockerToSyscallLinux()[dsig]; ok {
-			return sig, nil
-		}
-	case "windows":
-		if sig, ok := dockerToSyscallWindows()[dsig]; ok {
-			return sig, nil
-		}
-	default:
-		return syscall.Signal(-1), errors.Errorf("unrecognized OS '%s'", os)
-	}
-	return syscall.Signal(-1), errors.Errorf("unrecognized signal '%s' for OS '%s'", dsig, os)
-}
-
 // These are constants taken from the signals in the syscall package for
 // GOOS="linux".
 const (
@@ -96,76 +74,6 @@ const (
 	sigrtmin = 34
 	sigrtmax = 64
 )
-
-func dockerToSyscallLinux() map[string]syscall.Signal {
-	return map[string]syscall.Signal{
-		"ABRT":     linuxSIGABRT,
-		"ALRM":     linuxSIGALRM,
-		"BUS":      linuxSIGBUS,
-		"CHLD":     linuxSIGCHLD,
-		"CLD":      linuxSIGCLD,
-		"CONT":     linuxSIGCONT,
-		"FPE":      linuxSIGFPE,
-		"HUP":      linuxSIGHUP,
-		"ILL":      linuxSIGILL,
-		"INT":      linuxSIGINT,
-		"IO":       linuxSIGIO,
-		"IOT":      linuxSIGIOT,
-		"KILL":     linuxSIGKILL,
-		"PIPE":     linuxSIGPIPE,
-		"POLL":     linuxSIGPOLL,
-		"PROF":     linuxSIGPROF,
-		"PWR":      linuxSIGPWR,
-		"QUIT":     linuxSIGQUIT,
-		"SEGV":     linuxSIGSEGV,
-		"STKFLT":   linuxSIGSTKFLT,
-		"STOP":     linuxSIGSTOP,
-		"SYS":      linuxSIGSYS,
-		"TERM":     linuxSIGTERM,
-		"TRAP":     linuxSIGTRAP,
-		"TSTP":     linuxSIGTSTP,
-		"TTIN":     linuxSIGTTIN,
-		"TTOU":     linuxSIGTTOU,
-		"URG":      linuxSIGURG,
-		"USR1":     linuxSIGUSR1,
-		"USR2":     linuxSIGUSR2,
-		"VTALRM":   linuxSIGVTALRM,
-		"WINCH":    linuxSIGWINCH,
-		"XCPU":     linuxSIGXCPU,
-		"XFSZ":     linuxSIGXFSZ,
-		"RTMIN":    sigrtmin,
-		"RTMIN+1":  sigrtmin + 1,
-		"RTMIN+2":  sigrtmin + 2,
-		"RTMIN+3":  sigrtmin + 3,
-		"RTMIN+4":  sigrtmin + 4,
-		"RTMIN+5":  sigrtmin + 5,
-		"RTMIN+6":  sigrtmin + 6,
-		"RTMIN+7":  sigrtmin + 7,
-		"RTMIN+8":  sigrtmin + 8,
-		"RTMIN+9":  sigrtmin + 9,
-		"RTMIN+10": sigrtmin + 10,
-		"RTMIN+11": sigrtmin + 11,
-		"RTMIN+12": sigrtmin + 12,
-		"RTMIN+13": sigrtmin + 13,
-		"RTMIN+14": sigrtmin + 14,
-		"RTMIN+15": sigrtmin + 15,
-		"RTMAX-14": sigrtmax - 14,
-		"RTMAX-13": sigrtmax - 13,
-		"RTMAX-12": sigrtmax - 12,
-		"RTMAX-11": sigrtmax - 11,
-		"RTMAX-10": sigrtmax - 10,
-		"RTMAX-9":  sigrtmax - 9,
-		"RTMAX-8":  sigrtmax - 8,
-		"RTMAX-7":  sigrtmax - 7,
-		"RTMAX-6":  sigrtmax - 6,
-		"RTMAX-5":  sigrtmax - 5,
-		"RTMAX-4":  sigrtmax - 4,
-		"RTMAX-3":  sigrtmax - 3,
-		"RTMAX-2":  sigrtmax - 2,
-		"RTMAX-1":  sigrtmax - 1,
-		"RTMAX":    sigrtmax,
-	}
-}
 
 func syscallToDockerLinux() map[syscall.Signal]string {
 	return map[syscall.Signal]string{
@@ -274,43 +182,6 @@ const (
 	darwinSIGXFSZ   = syscall.Signal(0x19)
 )
 
-func dockerToSyscallDarwin() map[string]syscall.Signal {
-	return map[string]syscall.Signal{
-		"ABRT":   darwinSIGABRT,
-		"ALRM":   darwinSIGALRM,
-		"BUG":    darwinSIGBUS, // This one is spelled as "BUG" for Darwin even though it's "BUG" on Linux.
-		"CHLD":   darwinSIGCHLD,
-		"CONT":   darwinSIGCONT,
-		"EMT":    darwinSIGEMT,
-		"FPE":    darwinSIGFPE,
-		"HUP":    darwinSIGHUP,
-		"ILL":    darwinSIGILL,
-		"INFO":   darwinSIGINFO,
-		"INT":    darwinSIGINT,
-		"IO":     darwinSIGIO,
-		"IOT":    darwinSIGIOT,
-		"KILL":   darwinSIGKILL,
-		"PIPE":   darwinSIGPIPE,
-		"PROF":   darwinSIGPROF,
-		"QUIT":   darwinSIGQUIT,
-		"SEGV":   darwinSIGSEGV,
-		"STOP":   darwinSIGSTOP,
-		"SYS":    darwinSIGSYS,
-		"TERM":   darwinSIGTERM,
-		"TRAP":   darwinSIGTRAP,
-		"TSTP":   darwinSIGTSTP,
-		"TTIN":   darwinSIGTTIN,
-		"TTOU":   darwinSIGTTOU,
-		"URG":    darwinSIGURG,
-		"USR1":   darwinSIGUSR1,
-		"USR2":   darwinSIGUSR2,
-		"VTALRM": darwinSIGVTALRM,
-		"WINCH":  darwinSIGWINCH,
-		"XCPU":   darwinSIGXCPU,
-		"XFSZ":   darwinSIGXFSZ,
-	}
-}
-
 func syscallToDockerDarwin() map[syscall.Signal]string {
 	return map[syscall.Signal]string{
 		darwinSIGABRT: "ABRT",
@@ -354,13 +225,6 @@ const (
 	windowsSIGTERM = syscall.Signal(0x9)
 	windowsSIGKILL = syscall.Signal(0xf)
 )
-
-func dockerToSyscallWindows() map[string]syscall.Signal {
-	return map[string]syscall.Signal{
-		"KILL": windowsSIGKILL,
-		"TERM": windowsSIGTERM,
-	}
-}
 
 func syscallToDockerWindows() map[syscall.Signal]string {
 	return map[syscall.Signal]string{

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -56,6 +56,9 @@ func executorTypes() map[string]executorConstructor {
 				Command: args,
 			}
 			executor, err := NewDocker(ctx, opts)
+			if err != nil {
+				return nil, err
+			}
 			dockerExecutor := executor.(*docker)
 			return dockerWrapper{
 				dockerExecutor,

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ $(shell mkdir -p $(buildDir))
 
 # start lint setup targets
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(buildDir) v1.51.2 >/dev/null 2>&1
 $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@$(gobin) build -o $@ $<
 # end lint setup targets

--- a/manager_test.go
+++ b/manager_test.go
@@ -144,7 +144,8 @@ func TestManagerImplementations(t *testing.T) {
 
 					proc, err := newBlockingProcess(ctx, opts)
 					require.NoError(t, err)
-					assert.NotEmpty(t, proc)
+					// Must use NotNil here since NotEmpty can data race on the proc object
+					assert.NotNil(t, proc)
 					err = mngr.Register(ctx, proc)
 					require.NoError(t, err)
 					err = mngr.Register(ctx, proc)

--- a/manager_windows_test.go
+++ b/manager_windows_test.go
@@ -1,4 +1,4 @@
-// +build windows
+//go:build windows
 
 package jasper
 

--- a/mock/process.go
+++ b/mock/process.go
@@ -19,8 +19,8 @@ type Process struct {
 	WaitExitCode                int
 
 	ProcInfo         jasper.ProcessInfo
-	Triggers         jasper.ProcessTriggerSequence `json:"-"`
-	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"`
+	Triggers         jasper.ProcessTriggerSequence `json:"-"` // omitted since ProcessTrigger is an unserializable function
+	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"` // omitted since SignalTrigger is an unserializable function
 	SignalTriggerIDs []jasper.SignalTriggerID
 	Signals          []syscall.Signal
 	Tags             []string

--- a/mock/process.go
+++ b/mock/process.go
@@ -19,8 +19,8 @@ type Process struct {
 	WaitExitCode                int
 
 	ProcInfo         jasper.ProcessInfo
-	Triggers         jasper.ProcessTriggerSequence `json:"-"` // omitted since ProcessTrigger is a function, and functions aren't JSON serializable
-	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"` // omitted since SignalTrigger is a function, and functions aren't JSON serializable
+	Triggers         jasper.ProcessTriggerSequence
+	SignalTriggers   jasper.SignalTriggerSequence
 	SignalTriggerIDs []jasper.SignalTriggerID
 	Signals          []syscall.Signal
 	Tags             []string

--- a/mock/process.go
+++ b/mock/process.go
@@ -19,8 +19,8 @@ type Process struct {
 	WaitExitCode                int
 
 	ProcInfo         jasper.ProcessInfo
-	Triggers         jasper.ProcessTriggerSequence
-	SignalTriggers   jasper.SignalTriggerSequence
+	Triggers         jasper.ProcessTriggerSequence `json:"-"`
+	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"`
 	SignalTriggerIDs []jasper.SignalTriggerID
 	Signals          []syscall.Signal
 	Tags             []string

--- a/mock/process.go
+++ b/mock/process.go
@@ -19,8 +19,8 @@ type Process struct {
 	WaitExitCode                int
 
 	ProcInfo         jasper.ProcessInfo
-	Triggers         jasper.ProcessTriggerSequence `json:"-"` // omitted since ProcessTrigger is an unserializable function
-	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"` // omitted since SignalTrigger is an unserializable function
+	Triggers         jasper.ProcessTriggerSequence `json:"-"` // omitted since ProcessTrigger is a function, and functions aren't JSON serializable
+	SignalTriggers   jasper.SignalTriggerSequence  `json:"-"` // omitted since SignalTrigger is a function, and functions aren't JSON serializable
 	SignalTriggerIDs []jasper.SignalTriggerID
 	Signals          []syscall.Signal
 	Tags             []string

--- a/oom_tracker.go
+++ b/oom_tracker.go
@@ -1,11 +1,7 @@
 package jasper
 
 import (
-	"bufio"
 	"context"
-	"os/exec"
-
-	"github.com/pkg/errors"
 )
 
 type oomTrackerImpl struct {
@@ -27,65 +23,3 @@ type OOMTracker interface {
 // for the current platform.
 func NewOOMTracker() OOMTracker                     { return &oomTrackerImpl{} }
 func (o *oomTrackerImpl) Report() ([]string, []int) { return o.Lines, o.PIDs }
-
-func isSudo(ctx context.Context) (bool, error) {
-	if err := exec.CommandContext(ctx, "sudo", "-n", "date").Run(); err != nil {
-		switch err.(type) {
-		case *exec.ExitError:
-			return false, nil
-		default:
-			return false, errors.Wrap(err, "executing sudo permissions check")
-		}
-	}
-
-	return true, nil
-}
-
-type logAnalyzer struct {
-	cmdArgs        []string
-	lineHasOOMKill func(string) bool
-	extractPID     func(string) (int, bool)
-}
-
-func (a *logAnalyzer) analyzeKernelLog(ctx context.Context) ([]string, []int, error) {
-	sudo, err := isSudo(ctx)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "checking sudo")
-	}
-
-	var cmd *exec.Cmd
-	if sudo {
-		cmd = exec.CommandContext(ctx, "sudo", a.cmdArgs...)
-	} else {
-		cmd = exec.CommandContext(ctx, a.cmdArgs[0], a.cmdArgs[1:]...)
-	}
-	logPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "creating standard output pipe for log command")
-	}
-	scanner := bufio.NewScanner(logPipe)
-	if err := cmd.Start(); err != nil {
-		return nil, nil, errors.Wrap(err, "starting log command")
-	}
-
-	lines := []string{}
-	pids := []int{}
-	for scanner.Scan() {
-		line := scanner.Text()
-		if a.lineHasOOMKill(line) {
-			lines = append(lines, line)
-			if pid, hasPID := a.extractPID(line); hasPID {
-				pids = append(pids, pid)
-			}
-		}
-	}
-
-	errs := make(chan error, 1)
-	select {
-	case <-ctx.Done():
-		return nil, nil, errors.New("request cancelled")
-	case errs <- cmd.Wait():
-		err = <-errs
-		return lines, pids, errors.Wrap(err, "waiting for log command")
-	}
-}

--- a/oom_tracker_default.go
+++ b/oom_tracker_default.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin
+//go:build !linux && !darwin
 
 package jasper
 

--- a/oom_tracker_helpers.go
+++ b/oom_tracker_helpers.go
@@ -1,0 +1,73 @@
+//go:build darwin || linux
+
+package jasper
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+func isSudo(ctx context.Context) (bool, error) {
+	if err := exec.CommandContext(ctx, "sudo", "-n", "date").Run(); err != nil {
+		switch err.(type) {
+		case *exec.ExitError:
+			return false, nil
+		default:
+			return false, errors.Wrap(err, "executing sudo permissions check")
+		}
+	}
+
+	return true, nil
+}
+
+type logAnalyzer struct {
+	cmdArgs        []string
+	lineHasOOMKill func(string) bool
+	extractPID     func(string) (int, bool)
+}
+
+func (a *logAnalyzer) analyzeKernelLog(ctx context.Context) ([]string, []int, error) {
+	sudo, err := isSudo(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "checking sudo")
+	}
+
+	var cmd *exec.Cmd
+	if sudo {
+		cmd = exec.CommandContext(ctx, "sudo", a.cmdArgs...)
+	} else {
+		cmd = exec.CommandContext(ctx, a.cmdArgs[0], a.cmdArgs[1:]...)
+	}
+	logPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating standard output pipe for log command")
+	}
+	scanner := bufio.NewScanner(logPipe)
+	if err := cmd.Start(); err != nil {
+		return nil, nil, errors.Wrap(err, "starting log command")
+	}
+
+	lines := []string{}
+	pids := []int{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if a.lineHasOOMKill(line) {
+			lines = append(lines, line)
+			if pid, hasPID := a.extractPID(line); hasPID {
+				pids = append(pids, pid)
+			}
+		}
+	}
+
+	errs := make(chan error, 1)
+	select {
+	case <-ctx.Done():
+		return nil, nil, errors.New("request cancelled")
+	case errs <- cmd.Wait():
+		err = <-errs
+		return lines, pids, errors.Wrap(err, "waiting for log command")
+	}
+}

--- a/options/create_test.go
+++ b/options/create_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"testing"
@@ -98,7 +98,7 @@ func TestCreate(t *testing.T) {
 
 			require.NoError(t, opts.Validate())
 
-			out, err := ioutil.ReadAll(opts.StandardInput)
+			out, err := io.ReadAll(opts.StandardInput)
 			require.NoError(t, err)
 			assert.EqualValues(t, stdinBytesStr, out)
 		},
@@ -111,7 +111,7 @@ func TestCreate(t *testing.T) {
 
 			require.NoError(t, opts.Validate())
 
-			out, err := ioutil.ReadAll(opts.StandardInput)
+			out, err := io.ReadAll(opts.StandardInput)
 			require.NoError(t, err)
 			assert.EqualValues(t, stdinBytesStr, out)
 		},
@@ -323,7 +323,7 @@ func TestFileLogging(t *testing.T) {
 	errorSize := int64(len(catErrorMessage) + 1)
 
 	// Ensure good file exists and has data
-	goodFile, err := ioutil.TempFile("", "this_file_exists")
+	goodFile, err := os.CreateTemp("", "this_file_exists")
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, goodFile.Close())
@@ -416,7 +416,7 @@ func TestFileLogging(t *testing.T) {
 
 			files := []*os.File{}
 			for i := 0; i < testParams.numLogs; i++ {
-				file, err := ioutil.TempFile("", "out.txt")
+				file, err := os.CreateTemp("", "out.txt")
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, file.Close())

--- a/options/output.go
+++ b/options/output.go
@@ -2,7 +2,6 @@ package options
 
 import (
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/mongodb/grip"
@@ -36,7 +35,7 @@ func (o Output) outputIsNull() bool {
 		return true
 	}
 
-	if o.Output == ioutil.Discard {
+	if o.Output == io.Discard {
 		return true
 	}
 
@@ -56,7 +55,7 @@ func (o Output) errorIsNull() bool {
 		return true
 	}
 
-	if o.Error == ioutil.Discard {
+	if o.Error == io.Discard {
 		return true
 	}
 
@@ -112,7 +111,7 @@ func (o *Output) GetOutput() (io.Writer, error) {
 	}
 
 	if o.outputIsNull() && !o.outputLogging() {
-		return ioutil.Discard, nil
+		return io.Discard, nil
 	}
 
 	if o.outputMulti != nil {
@@ -125,7 +124,7 @@ func (o *Output) GetOutput() (io.Writer, error) {
 		for i := range o.Loggers {
 			sender, err := o.Loggers[i].Resolve()
 			if err != nil {
-				return ioutil.Discard, err
+				return io.Discard, err
 			}
 			outLoggers = append(outLoggers, sender)
 		}
@@ -137,7 +136,7 @@ func (o *Output) GetOutput() (io.Writer, error) {
 			var err error
 			outMulti, err = send.NewMultiSender(DefaultLogName, send.LevelInfo{Default: level.Info, Threshold: level.Trace}, outLoggers)
 			if err != nil {
-				return ioutil.Discard, err
+				return io.Discard, err
 			}
 		}
 		o.outputSender = send.NewWriterSender(outMulti)
@@ -162,7 +161,7 @@ func (o *Output) GetError() (io.Writer, error) {
 	}
 
 	if o.errorIsNull() && !o.errorLogging() {
-		return ioutil.Discard, nil
+		return io.Discard, nil
 	}
 
 	if o.errorMulti != nil {
@@ -175,14 +174,14 @@ func (o *Output) GetError() (io.Writer, error) {
 		for i := range o.Loggers {
 			sender, err := o.Loggers[i].Resolve()
 			if err != nil {
-				return ioutil.Discard, err
+				return io.Discard, err
 			}
 			errSenders = append(errSenders, sender)
 		}
 
 		errMulti, err := send.NewMultiSender(DefaultLogName, send.LevelInfo{Default: level.Error, Threshold: level.Trace}, errSenders)
 		if err != nil {
-			return ioutil.Discard, err
+			return io.Discard, err
 		}
 		// This will not close the Loggers' underlying senders.
 		o.errorSender = send.NewWriterSender(errMulti)

--- a/options/output_test.go
+++ b/options/output_test.go
@@ -2,7 +2,7 @@ package options
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -57,7 +57,7 @@ func TestOutputOptions(t *testing.T) {
 		},
 		"DiscardIsNilForOutput": func(t *testing.T, opts Output) {
 			opts.Error = stderr
-			opts.Output = ioutil.Discard
+			opts.Output = io.Discard
 
 			assert.True(t, opts.outputIsNull())
 			assert.False(t, opts.errorIsNull())
@@ -68,7 +68,7 @@ func TestOutputOptions(t *testing.T) {
 			assert.False(t, opts.errorIsNull())
 		},
 		"DiscardIsNilForError": func(t *testing.T, opts Output) {
-			opts.Error = ioutil.Discard
+			opts.Error = io.Discard
 			opts.Output = stdout
 			assert.True(t, opts.errorIsNull())
 			assert.False(t, opts.outputIsNull())
@@ -81,7 +81,7 @@ func TestOutputOptions(t *testing.T) {
 		"OutputGetterNilIsIoDiscard": func(t *testing.T, opts Output) {
 			out, err := opts.GetOutput()
 			assert.NoError(t, err)
-			assert.Equal(t, ioutil.Discard, out)
+			assert.Equal(t, io.Discard, out)
 		},
 		"OutputGetterWhenPopulatedIsCorrect": func(t *testing.T, opts Output) {
 			opts.Output = stdout
@@ -92,7 +92,7 @@ func TestOutputOptions(t *testing.T) {
 		"ErrorGetterNilIsIoDiscard": func(t *testing.T, opts Output) {
 			outErr, err := opts.GetError()
 			assert.NoError(t, err)
-			assert.Equal(t, ioutil.Discard, outErr)
+			assert.Equal(t, io.Discard, outErr)
 		},
 		"ErrorGetterWhenPopulatedIsCorrect": func(t *testing.T, opts Output) {
 			opts.Error = stderr

--- a/options/remote.go
+++ b/options/remote.go
@@ -2,7 +2,7 @@ package options
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/mongodb/grip"
@@ -108,7 +108,7 @@ func (opts *RemoteConfig) publicKeyAuth() (ssh.AuthMethod, error) {
 	var key []byte
 	if opts.KeyFile != "" {
 		var err error
-		key, err = ioutil.ReadFile(opts.KeyFile)
+		key, err = os.ReadFile(opts.KeyFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "reading key file")
 		}

--- a/options/util_test.go
+++ b/options/util_test.go
@@ -2,7 +2,7 @@ package options
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -131,7 +131,7 @@ func TestWriteFileOptions(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, opts.Reader, reader)
 
-					content, err := ioutil.ReadAll(reader)
+					content, err := io.ReadAll(reader)
 					require.NoError(t, err)
 					assert.Equal(t, expected, content)
 				},
@@ -143,7 +143,7 @@ func TestWriteFileOptions(t *testing.T) {
 					assert.Equal(t, reader, opts.Reader)
 					assert.Empty(t, opts.Content)
 
-					content, err := ioutil.ReadAll(reader)
+					content, err := io.ReadAll(reader)
 					require.NoError(t, err)
 					assert.Equal(t, expected, content)
 				},
@@ -211,7 +211,7 @@ func TestWriteFileOptions(t *testing.T) {
 
 					require.NoError(t, opts.DoWrite())
 
-					fileContent, err := ioutil.ReadFile(opts.Path)
+					fileContent, err := os.ReadFile(opts.Path)
 					require.NoError(t, err)
 					assert.Equal(t, content, fileContent)
 				},
@@ -220,7 +220,7 @@ func TestWriteFileOptions(t *testing.T) {
 
 					require.NoError(t, opts.DoWrite())
 
-					fileContent, err := ioutil.ReadFile(opts.Path)
+					fileContent, err := os.ReadFile(opts.Path)
 					require.NoError(t, err)
 					assert.Equal(t, content, fileContent)
 				},
@@ -237,7 +237,7 @@ func TestWriteFileOptions(t *testing.T) {
 
 					require.NoError(t, opts.DoWrite())
 
-					fileContent, err := ioutil.ReadFile(opts.Path)
+					fileContent, err := os.ReadFile(opts.Path)
 					require.NoError(t, err)
 					assert.Equal(t, initialContent, fileContent[:len(initialContent)])
 					assert.Equal(t, content, fileContent[len(fileContent)-len(content):])
@@ -254,7 +254,7 @@ func TestWriteFileOptions(t *testing.T) {
 
 					require.NoError(t, opts.DoWrite())
 
-					fileContent, err := ioutil.ReadFile(opts.Path)
+					fileContent, err := os.ReadFile(opts.Path)
 					require.NoError(t, err)
 					assert.Equal(t, content, fileContent)
 				},

--- a/process_blocking.go
+++ b/process_blocking.go
@@ -136,9 +136,10 @@ func (p *blockingProcess) reactor(ctx context.Context, deadline time.Time, exec 
 			func() {
 				p.mu.RLock()
 				defer p.mu.RUnlock()
-				p.info.EndAt = finishTime
 
 				info = p.info
+
+				info.EndAt = finishTime
 				info.Complete = true
 				info.IsRunning = false
 

--- a/process_test.go
+++ b/process_test.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -190,7 +189,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "ProcessLogDefault",
 						Case: func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
-							file, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+							file, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 							require.NoError(t, err)
 							defer func() {
 								assert.NoError(t, file.Close())
@@ -217,7 +216,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "ProcessWritesToLogFile",
 						Case: func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
-							file, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+							file, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 							require.NoError(t, err)
 							defer func() {
 								assert.NoError(t, file.Close())
@@ -271,7 +270,7 @@ func TestProcessImplementations(t *testing.T) {
 					{
 						Name: "ProcessWritesToBufferedLog",
 						Case: func(ctx context.Context, t *testing.T, opts *options.Create, makep ProcessConstructor) {
-							file, err := ioutil.TempFile(testutil.BuildDirectory(), "out.txt")
+							file, err := os.CreateTemp(testutil.BuildDirectory(), "out.txt")
 							require.NoError(t, err)
 							defer func() {
 								assert.NoError(t, file.Close())

--- a/remote/rest_client.go
+++ b/remote/rest_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -84,7 +83,7 @@ func handleError(resp *http.Response) error {
 		return errors.Wrapf(err, "HTTP status code %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return wrapError(errors.Wrap(err, "reading response body"))
 	}

--- a/remote/rest_service_test.go
+++ b/remote/rest_service_test.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -35,7 +35,7 @@ func TestRESTService(t *testing.T) {
 	httpClient := utility.GetHTTPClient()
 	defer utility.PutHTTPClient(httpClient)
 
-	tempDir, err := ioutil.TempDir(testutil.BuildDirectory(), filepath.Base(t.Name()))
+	tempDir, err := os.MkdirTemp(testutil.BuildDirectory(), filepath.Base(t.Name()))
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, os.RemoveAll(tempDir)) }()
 
@@ -229,7 +229,7 @@ func TestRESTService(t *testing.T) {
 			body, err := makeBody(map[string]int{"tags": 42})
 			require.NoError(t, err)
 
-			req, err := http.NewRequest(http.MethodPost, "", ioutil.NopCloser(body))
+			req, err := http.NewRequest(http.MethodPost, "", io.NopCloser(body))
 			require.NoError(t, err)
 			rw := httptest.NewRecorder()
 			srv.createProcess(rw, req)
@@ -417,7 +417,7 @@ func TestRESTService(t *testing.T) {
 			assert.Error(t, err)
 		},
 		"DownloadMongoDBPassesWithValidOptions": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			dir, err := ioutil.TempDir(tempDir, "mongodb")
+			dir, err := os.MkdirTemp(tempDir, "mongodb")
 			require.NoError(t, err)
 			defer os.RemoveAll(dir)
 			absDir, err := filepath.Abs(dir)
@@ -430,7 +430,7 @@ func TestRESTService(t *testing.T) {
 			assert.NoError(t, err)
 		},
 		"CreateWithMultipleLoggers": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			file, err := ioutil.TempFile(tempDir, "out.txt")
+			file, err := os.CreateTemp(tempDir, "out.txt")
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, file.Close())
@@ -467,7 +467,7 @@ func TestRESTService(t *testing.T) {
 
 		},
 		"WriteFileSucceeds": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			tmpFile, err := ioutil.TempFile(tempDir, filepath.Base(t.Name()))
+			tmpFile, err := os.CreateTemp(tempDir, filepath.Base(t.Name()))
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, tmpFile.Close())
@@ -477,13 +477,13 @@ func TestRESTService(t *testing.T) {
 			opts := options.WriteFile{Path: tmpFile.Name(), Content: []byte("foo")}
 			require.NoError(t, client.WriteFile(ctx, opts))
 
-			content, err := ioutil.ReadFile(tmpFile.Name())
+			content, err := os.ReadFile(tmpFile.Name())
 			require.NoError(t, err)
 
 			assert.Equal(t, opts.Content, content)
 		},
 		"WriteFileAcceptsContentFromReader": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			tmpFile, err := ioutil.TempFile(tempDir, filepath.Base(t.Name()))
+			tmpFile, err := os.CreateTemp(tempDir, filepath.Base(t.Name()))
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, tmpFile.Close())
@@ -494,13 +494,13 @@ func TestRESTService(t *testing.T) {
 			opts := options.WriteFile{Path: tmpFile.Name(), Reader: bytes.NewBuffer(buf)}
 			require.NoError(t, client.WriteFile(ctx, opts))
 
-			content, err := ioutil.ReadFile(tmpFile.Name())
+			content, err := os.ReadFile(tmpFile.Name())
 			require.NoError(t, err)
 
 			assert.Equal(t, buf, content)
 		},
 		"WriteFileSucceedsWithLargeContentReader": func(ctx context.Context, t *testing.T, srv *Service, client *restClient) {
-			tmpFile, err := ioutil.TempFile(tempDir, filepath.Base(t.Name()))
+			tmpFile, err := os.CreateTemp(tempDir, filepath.Base(t.Name()))
 			require.NoError(t, err)
 			defer func() {
 				assert.NoError(t, tmpFile.Close())
@@ -512,7 +512,7 @@ func TestRESTService(t *testing.T) {
 			opts := options.WriteFile{Path: tmpFile.Name(), Reader: bytes.NewBuffer(buf)}
 			require.NoError(t, client.WriteFile(ctx, opts))
 
-			content, err := ioutil.ReadFile(tmpFile.Name())
+			content, err := os.ReadFile(tmpFile.Name())
 			require.NoError(t, err)
 
 			assert.Equal(t, buf, content)

--- a/remote/rpc_util_test.go
+++ b/remote/rpc_util_test.go
@@ -3,8 +3,8 @@ package remote
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/evergreen-ci/certdepot"
@@ -54,17 +54,17 @@ func makeTLSRPCServiceAndClient(ctx context.Context, mngr jasper.Manager) (Manag
 	clientKeyFile := filepath.Join("testdata", "client.key")
 
 	// Make CA credentials
-	caCert, err := ioutil.ReadFile(caCertFile)
+	caCert, err := os.ReadFile(caCertFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cert file")
 	}
 
 	// Make server credentials
-	serverCert, err := ioutil.ReadFile(serverCertFile)
+	serverCert, err := os.ReadFile(serverCertFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cert file")
 	}
-	serverKey, err := ioutil.ReadFile(serverKeyFile)
+	serverKey, err := os.ReadFile(serverKeyFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading key file")
 	}
@@ -80,11 +80,11 @@ func makeTLSRPCServiceAndClient(ctx context.Context, mngr jasper.Manager) (Manag
 		return nil, errors.Wrap(err, "starting RPC service")
 	}
 
-	clientCert, err := ioutil.ReadFile(clientCertFile)
+	clientCert, err := os.ReadFile(clientCertFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading cert file")
 	}
-	clientKey, err := ioutil.ReadFile(clientKeyFile)
+	clientKey, err := os.ReadFile(clientKeyFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading key file")
 	}

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux freebsd
+//go:build darwin || linux || freebsd
 
 package jasper
 

--- a/subprocess_unix.go
+++ b/subprocess_unix.go
@@ -1,3 +1,3 @@
-// +build linux
+//go:build linux
 
 package jasper

--- a/testcase.go
+++ b/testcase.go
@@ -3,7 +3,6 @@ package jasper
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -763,7 +762,7 @@ func ManagerTests() []ManagerTestCase {
 		{
 			Name: "WriteFileSucceeds",
 			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
-				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
+				tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, os.RemoveAll(tmpFile.Name()))
@@ -773,7 +772,7 @@ func ManagerTests() []ManagerTestCase {
 				opts := options.WriteFile{Path: tmpFile.Name(), Content: []byte("foo")}
 				require.NoError(t, mngr.WriteFile(ctx, opts))
 
-				content, err := ioutil.ReadFile(tmpFile.Name())
+				content, err := os.ReadFile(tmpFile.Name())
 				require.NoError(t, err)
 
 				assert.Equal(t, opts.Content, content)
@@ -782,7 +781,7 @@ func ManagerTests() []ManagerTestCase {
 		{
 			Name: "WriteFileAcceptsContentFromReader",
 			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
-				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
+				tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, os.RemoveAll(tmpFile.Name()))
@@ -793,7 +792,7 @@ func ManagerTests() []ManagerTestCase {
 				opts := options.WriteFile{Path: tmpFile.Name(), Reader: bytes.NewBuffer(buf)}
 				require.NoError(t, mngr.WriteFile(ctx, opts))
 
-				content, err := ioutil.ReadFile(tmpFile.Name())
+				content, err := os.ReadFile(tmpFile.Name())
 				require.NoError(t, err)
 
 				assert.Equal(t, buf, content)
@@ -802,7 +801,7 @@ func ManagerTests() []ManagerTestCase {
 		{
 			Name: "WriteFileSucceedsWithLargeContent",
 			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
-				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
+				tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, os.RemoveAll(tmpFile.Name()))
@@ -813,7 +812,7 @@ func ManagerTests() []ManagerTestCase {
 				opts := options.WriteFile{Path: tmpFile.Name(), Content: bytes.Repeat([]byte("foo"), mb)}
 				require.NoError(t, mngr.WriteFile(ctx, opts))
 
-				content, err := ioutil.ReadFile(tmpFile.Name())
+				content, err := os.ReadFile(tmpFile.Name())
 				require.NoError(t, err)
 
 				assert.Equal(t, opts.Content, content)
@@ -822,7 +821,7 @@ func ManagerTests() []ManagerTestCase {
 		{
 			Name: "WriteFileSucceedsWithLargeContentFromReader",
 			Case: func(ctx context.Context, t *testing.T, mngr Manager, modifyOpts testoptions.ModifyOpts) {
-				tmpFile, err := ioutil.TempFile(testutil.BuildDirectory(), filepath.Base(t.Name()))
+				tmpFile, err := os.CreateTemp(testutil.BuildDirectory(), filepath.Base(t.Name()))
 				require.NoError(t, err)
 				defer func() {
 					assert.NoError(t, tmpFile.Close())
@@ -834,7 +833,7 @@ func ManagerTests() []ManagerTestCase {
 				opts := options.WriteFile{Path: tmpFile.Name(), Reader: bytes.NewBuffer(buf)}
 				require.NoError(t, mngr.WriteFile(ctx, opts))
 
-				content, err := ioutil.ReadFile(tmpFile.Name())
+				content, err := os.ReadFile(tmpFile.Name())
 				require.NoError(t, err)
 
 				assert.Equal(t, buf, content)

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -45,7 +44,7 @@ func tryAddFileToArchive(dir, fileName, fileContents string) (bool, error) {
 		return false, nil
 	}
 
-	tmpFile, err := ioutil.TempFile(dir, "tmp.txt")
+	tmpFile, err := os.CreateTemp(dir, "tmp.txt")
 	if err != nil {
 		return false, err
 	}

--- a/tracker_linux_test.go
+++ b/tracker_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package jasper
 

--- a/tracker_windows_test.go
+++ b/tracker_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package jasper
 

--- a/triggers_unix.go
+++ b/triggers_unix.go
@@ -1,4 +1,4 @@
-// +build darwin linux freebsd
+//go:build darwin || linux || freebsd
 
 package jasper
 


### PR DESCRIPTION
This upgrades to go 1.20, and makes sure we use newer versions of our Evergreen distros.