### PR TITLE
docs: fix explanation of OverrideEnviron

### DIFF
--- a/options/create.go
+++ b/options/create.go
@@ -39,9 +39,10 @@ const (
 type Create struct {
 	Args        []string          `bson:"args" json:"args" yaml:"args"`
 	Environment map[string]string `bson:"env,omitempty" json:"env,omitempty" yaml:"env,omitempty"`
-	// OverrideEnviron sets the process environment to match the currently
-	// executing process's environment. This is ignored if Remote or Docker
-	// options are specified.
+	// OverrideEnviron overrides the default behavior so that the process
+	// environment does not inherit the currently executing process's
+	// environment. By default, the process will inherit the current process's
+	// environment. This is ignored if Remote or Docker options are specified.
 	OverrideEnviron bool `bson:"override_env,omitempty" json:"override_env,omitempty" yaml:"override_env,omitempty"`
 	// Synchronized specifies whether the process should be thread-safe or not.
 	// This is not guaranteed to be respected for managed processes.


### PR DESCRIPTION
If `OverrideEnviron` is set, [the child process will _not_ inherit the current process's environment](https://github.com/mongodb/jasper/blob/6d9ec4246500a4c9c7d4006d29f053c920e9dc18/options/create.go#L232) (this is what Go exec does by default), so the original doc was the opposite of the actual behavior. I updated the wording.