### PR TITLE
DEVPROD-10457 set group leader

### DIFF
--- a/command.go
+++ b/command.go
@@ -406,6 +406,13 @@ func (c *Command) PostHook(h options.CommandPostHook) *Command { c.opts.PostHook
 // creation option. The PreHook is not run when using SetRunFunction.
 func (c *Command) PreHook(fn options.CommandPreHook) *Command { c.opts.PreHook = fn; return c }
 
+// SetGroupLeader marks the command as a group leader so when the process is started
+// the pgid is set to the process's pid. This is a noop for remote and non-unix commands.
+func (c *Command) SetGroupLeader() *Command {
+	c.opts.Process.GroupLeader = true
+	return c
+}
+
 func (c *Command) setupEnv() {
 	if c.opts.Process.Environment == nil {
 		c.opts.Process.Environment = map[string]string{}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -35,6 +35,9 @@ type Executor interface {
 	Wait() error
 	// Signal sends a signal to a running process.
 	Signal(syscall.Signal) error
+	// SetGroupLeader marks the local process as a group leader. This is a
+	// noop for remote executors and on non-unix systems.
+	SetGroupLeader()
 	// PID returns the local process ID of the process if it is running or
 	// complete. This is not guaranteed to return a valid value for remote
 	// executors and will return -1 if it could not be retrieved.

--- a/internal/executor/local_default.go
+++ b/internal/executor/local_default.go
@@ -1,0 +1,6 @@
+//go:build !unix
+
+package executor
+
+// SetGroupLeader is a noop on non-unix systems.
+func (e *local) SetGroupLeader() {}

--- a/internal/executor/local_unix.go
+++ b/internal/executor/local_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package executor
+
+import "syscall"
+
+// SetGroupLeader sets this process as a group leader.
+func (e *local) SetGroupLeader() {
+	e.cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/executor/ssh_binary.go
+++ b/internal/executor/ssh_binary.go
@@ -119,6 +119,9 @@ func (e *execSSHBinary) Signal(sig syscall.Signal) error {
 	return e.cmd.Process.Signal(sig)
 }
 
+// SetGroupLeader is a noop for SSH processes.
+func (e *execSSHBinary) SetGroupLeader() {}
+
 // PID returns the PID of the local SSH binary process.
 func (e *execSSHBinary) PID() int {
 	if e.cmd == nil || e.cmd.Process == nil {


### PR DESCRIPTION
[DEVPROD-10457](https://jira.mongodb.org/browse/DEVPROD-10457)

I will open an Evergreen PR shortly that will use this to make each process started by shell.exec and subprocess.exex a group leader.